### PR TITLE
Fix handling of inputs for tools with no arguments

### DIFF
--- a/mcp_compressor/cli_bridge.py
+++ b/mcp_compressor/cli_bridge.py
@@ -25,9 +25,9 @@ from .cli_tools import format_tool_help, format_top_level_help, parse_argv_to_to
 if TYPE_CHECKING:
     from fastmcp import FastMCP
 
-# Type alias for the direct backend call callable — receives tool_name + arguments,
+# Type alias for the direct backend call callable — receives tool_name + arguments + quiet flag,
 # returns a ToolResult (not a CallToolResult)
-InvokeFn = Callable[[str, dict[str, Any] | None], Coroutine[Any, Any, Any]]
+InvokeFn = Callable[[str, dict[str, Any] | None, bool], Coroutine[Any, Any, Any]]
 # Type alias for the lazy tool fetch callable
 GetToolsFn = Callable[[], Coroutine[Any, Any, dict[str, Tool]]]
 
@@ -143,6 +143,11 @@ class CliBridge:
 
         tool = self._tools[tool_name]
 
+        # Extract --quiet before passing argv to the tool-schema-driven parser,
+        # since quiet is a universal flag not present in any individual tool schema.
+        quiet = "--quiet" in rest
+        rest = [arg for arg in rest if arg != "--quiet"]
+
         try:
             tool_input = parse_argv_to_tool_input(rest, tool)
         except ValueError as exc:
@@ -158,9 +163,9 @@ class CliBridge:
                 # stateful backends like chrome-devtools-mcp fail with
                 # "No active context found".
                 async with Context(fastmcp=self._fastmcp):
-                    result = await self._invoke_fn(tool_name, tool_input)
+                    result = await self._invoke_fn(tool_name, tool_input, quiet)
             else:
-                result = await self._invoke_fn(tool_name, tool_input)
+                result = await self._invoke_fn(tool_name, tool_input, quiet)
         except Exception as exc:
             return PlainTextResponse(f"error: {exc}\n", status_code=400)
 

--- a/mcp_compressor/cli_tools.py
+++ b/mcp_compressor/cli_tools.py
@@ -127,11 +127,14 @@ def format_tool_help(cli_name: str, tool: Tool) -> str:
                 schema_json = json.dumps(schema_display, separators=(",", ":"))
                 options_list.append(f"    Values must be a JSON string with the following schema: {schema_json}")
 
+    # --quiet is a universal flag available on every subcommand (not in the tool schema)
+    options_list.append("  --quiet                    (optional) Truncate large output to a short preview")
+
     return TOOL_HELP_TEMPLATE.format(
         cli_name=cli_name,
         subcommand=subcommand,
         description=description or "(no description)",
-        options="\n".join(options_list) if options_list else "  (no options)",
+        options="\n".join(options_list),
     )
 
 

--- a/mcp_compressor/tools.py
+++ b/mcp_compressor/tools.py
@@ -58,18 +58,24 @@ class InvokeToolCompatibilityMiddleware(Middleware):
     ) -> ToolResult:
         tool_name = context.message.name
         tool_args = context.message.arguments or {}
-        if (
-            tool_name in self._compressed_tools.invoke_tool_names
-            and tool_args
-            and ("tool_input" not in tool_args or tool_args["tool_input"] is None)
-        ):
-            flat_input = {k: v for k, v in tool_args.items() if k not in {"tool_name", "quiet"}}
-            if flat_input and "tool_name" in tool_args:
-                return await self._compressed_tools.invoke_tool(
-                    tool_name=tool_args["tool_name"],
-                    tool_input=flat_input,
-                    quiet=tool_args.get("quiet", False),
-                )
+        if tool_name in self._compressed_tools.invoke_tool_names and "tool_name" in tool_args:
+            tool_input_raw = tool_args.get("tool_input")
+            if isinstance(tool_input_raw, dict):
+                # Structured call: {tool_name: "foo", tool_input: {...}}
+                # tool_input may be an empty dict for zero-argument tools — that is valid.
+                tool_input = tool_input_raw
+            else:
+                # tool_input is None or absent: check for flattened args
+                # e.g. {tool_name: "add", "a": 5, "b": 3} (no tool_input wrapper)
+                # Exclude meta-keys so they don't leak into the backend tool args.
+                flat_input = {k: v for k, v in tool_args.items() if k not in {"tool_name", "quiet", "tool_input"}}
+                tool_input = flat_input  # may be empty dict for zero-argument tools
+
+            return await self._compressed_tools.invoke_tool(
+                tool_name=tool_args["tool_name"],
+                tool_input=tool_input,
+                quiet=tool_args.get("quiet", False),
+            )
 
         result = await call_next(context)
         if self._compressed_tools.should_toonify_tool(tool_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-compressor"
-version = "0.2.3"
+version = "0.2.4"
 description = "An MCP server wrapper for reducing tokens consumed by MCP tools."
 authors = [{ name = "Tim Esler", email = "tesler@atlassian.com" }]
 readme = "README.md"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -402,10 +402,13 @@ def mock_invoke_fn(add_tool: Tool):
     from fastmcp.tools.tool import ToolResult
     from mcp.types import TextContent
 
-    async def invoke(tool_name: str, tool_input: dict | None) -> ToolResult:
+    async def invoke(tool_name: str, tool_input: dict | None, quiet: bool = False) -> ToolResult:
         if tool_name == "add":
             val = (tool_input or {}).get("a", 0) + (tool_input or {}).get("b", 0)
-            return ToolResult(content=[TextContent(type="text", text=str(val))])
+            text = str(val)
+            if quiet:
+                text = f"[quiet] {text}"
+            return ToolResult(content=[TextContent(type="text", text=text)])
         return ToolResult(content=[TextContent(type="text", text="ok")])
 
     return invoke
@@ -480,3 +483,46 @@ async def test_bridge_missing_required_arg(bridge: CliBridge) -> None:
     response = client.post("/exec", json={"argv": ["add", "--a", "5"]})
     assert response.status_code == 400
     assert "Missing required" in response.text
+
+
+async def test_bridge_quiet_flag_is_passed_to_invoke_fn(bridge: CliBridge) -> None:
+    """Test that --quiet is extracted from argv and passed to the invoke function."""
+    from starlette.testclient import TestClient
+
+    client = TestClient(bridge.app)
+    response = client.post("/exec", json={"argv": ["add", "--a", "5", "--b", "3", "--quiet"]})
+    assert response.status_code == 200
+    # The mock_invoke_fn prefixes output with "[quiet]" when quiet=True
+    assert "[quiet] 8" in response.text
+
+
+async def test_bridge_without_quiet_flag_passes_false_to_invoke_fn(bridge: CliBridge) -> None:
+    """Test that quiet=False is passed when --quiet is not in argv."""
+    from starlette.testclient import TestClient
+
+    client = TestClient(bridge.app)
+    response = client.post("/exec", json={"argv": ["add", "--a", "5", "--b", "3"]})
+    assert response.status_code == 200
+    assert response.text.strip() == "8"
+    assert "[quiet]" not in response.text
+
+
+async def test_bridge_quiet_flag_not_passed_to_tool_input(bridge: CliBridge) -> None:
+    """Test that --quiet is stripped from argv before parse_argv_to_tool_input, so it doesn't
+    cause 'Unknown option' errors for tools that don't declare a 'quiet' parameter."""
+    from starlette.testclient import TestClient
+
+    client = TestClient(bridge.app)
+    # If --quiet leaked into tool input parsing it would raise "Unknown option: --quiet"
+    response = client.post("/exec", json={"argv": ["add", "--quiet", "--a", "5", "--b", "3"]})
+    assert response.status_code == 200
+    assert "[quiet] 8" in response.text
+
+
+async def test_format_tool_help_includes_quiet_flag(add_tool: Tool) -> None:
+    """Test that --quiet appears in per-subcommand help output."""
+    from mcp_compressor.cli_tools import format_tool_help
+
+    help_text = format_tool_help("mycli", add_tool)
+    assert "--quiet" in help_text
+    assert "Truncate large output" in help_text

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -361,3 +361,25 @@ async def test_on_call_tool_extracts_flat_args_as_tool_input(proxy_mcp_client) -
     )
     assert result.content
     assert result.content[0].text == "8"
+
+
+@pytest.mark.parametrize(
+    "tool_args",
+    [
+        {"tool_name": "empty_tool", "tool_input": {}},
+        {"tool_name": "empty_tool", "tool_input": None},
+        {"tool_name": "empty_tool"},
+    ],
+    ids=["empty_dict_tool_input", "null_tool_input", "no_tool_input_key"],
+)
+async def test_on_call_tool_handles_zero_arg_tool(proxy_mcp_client, tool_args: dict) -> None:
+    """Test that invoke_tool correctly handles zero-argument tools.
+
+    This is a regression test for a bug where zero-arg tools caused a Pydantic
+    'Unexpected keyword argument' validation error. The root cause was:
+    - tool_input={} is falsy, so it fell through to the flat-args path
+    - The flat-args filter didn't exclude 'tool_input' itself, so it leaked
+      into the backend call as an unexpected kwarg (additionalProperties=false)
+    """
+    result = await proxy_mcp_client.call_tool("test_server_invoke_tool", tool_args)
+    assert result.content is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "mcp-compressor"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
**fix: handle empty and null tool_input for zero-argument MCP tools in InvokeToolCompatibilityMiddleware**

`InvokeToolCompatibilityMiddleware.on_call_tool` failed to correctly route calls to zero-argument MCP tools (e.g. `get_atlassian_site_urls`), producing a Pydantic `Unexpected keyword argument` validation error.

**Root cause:** Two bugs combined:
1. `not tool_args` guard and the inner `if flat_input and "tool_name" in tool_args` condition both failed for zero-arg tools — when `tool_input={}` (falsy) or `tool_input=None` with no other args, neither path routed the call through `self._compressed_tools.invoke_tool`, so it fell through to `call_next` which attempted to call the backend tool directly with `tool_input` as a kwarg
2. The flat-args filter only excluded `"tool_name"` and `"quiet"`, so `"tool_input": None` leaked into the backend call as an unexpected kwarg — rejected by tools with `"additionalProperties": false`

**Fix:** Simplify the routing condition to `"tool_name" in tool_args` (if `tool_name` is present, this is always an `invoke_tool` dispatch). Use `isinstance(tool_input, dict)` to distinguish structured calls (including empty dicts) from the flat-args calling convention, and explicitly exclude `"tool_input"` from the flat-args extraction.

**Tests:** Added 3 parametrized regression tests covering `tool_input={}`, `tool_input=None`, and no `tool_input` key for a zero-argument tool (`empty_tool`).