### PR TITLE
feat(typescript): add lightweight sub-path exports for config, errors…

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -283,3 +283,23 @@ Published as `@atlassian/mcp-compressor` via Atlassian Artifactory → npmJS.
 ```bash
 npm install @atlassian/mcp-compressor
 ```
+
+### Sub-path exports
+
+`@atlassian/mcp-compressor` ships a small set of sub-path exports for consumers that only need the lightweight pieces. Importing from these sub-paths avoids loading `fastmcp`, the MCP SDK, and the rest of the runtime, which can add hundreds of ms of cold-import cost.
+
+| Sub-path | Contents | When to use |
+|---|---|---|
+| `@atlassian/mcp-compressor` | Full runtime (`CompressorRuntime`, `CompressorServer`, `BackendClient`, `FastMCP`, ...) | Building / hosting a compressor proxy. |
+| `@atlassian/mcp-compressor/bash` | The just-bash transform helpers | Bash-tool transformation. |
+| `@atlassian/mcp-compressor/config` | `interpolateString`, `interpolateRecord`, `parseServerConfigJson` | Pure config parsing / `${ENV}` interpolation in tooling. |
+| `@atlassian/mcp-compressor/errors` | `InvalidConfigurationError` and friends | Error type checks without the runtime. |
+| `@atlassian/mcp-compressor/types` | `BackendConfig`, `CompressionLevel`, `CommonProxyOptions`, ... | Type-only consumers. |
+
+```ts
+// heavy: pulls fastmcp + MCP SDK
+import { CompressorRuntime } from "@atlassian/mcp-compressor";
+
+// light: ~zero runtime deps
+import { interpolateString } from "@atlassian/mcp-compressor/config";
+```

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -26,6 +26,18 @@
     "./bash": {
       "import": "./dist/bash_commands.js",
       "types": "./dist/bash_commands.d.ts"
+    },
+    "./config": {
+      "import": "./dist/config.js",
+      "types": "./dist/config.d.ts"
+    },
+    "./errors": {
+      "import": "./dist/errors.js",
+      "types": "./dist/errors.d.ts"
+    },
+    "./types": {
+      "import": "./dist/types.js",
+      "types": "./dist/types.d.ts"
     }
   },
   "bin": {

--- a/typescript/tests/subpath_exports.test.ts
+++ b/typescript/tests/subpath_exports.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { readFileSync } from "node:fs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, "..");
+const srcRoot = resolve(pkgRoot, "src");
+
+/**
+ * The published `exports` map declares which sub-path entrypoints third-party consumers may import. These tests pin
+ * the surface so we don't accidentally drop or rename one in a future refactor — and assert that the lightweight
+ * entries (`./config`, `./errors`, `./types`) stay free of the heavy `fastmcp` runtime, which is the whole point of
+ * having them as separate sub-paths.
+ */
+
+const pkgJson = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8")) as {
+  exports: Record<string, { import: string; types: string }>;
+};
+
+test("package.json exports declares the lightweight sub-paths", () => {
+  expect(Object.keys(pkgJson.exports).sort()).toEqual([
+    ".",
+    "./bash",
+    "./config",
+    "./errors",
+    "./types",
+  ]);
+});
+
+test("each lightweight sub-path resolves to its own source file", () => {
+  for (const sub of ["./config", "./errors", "./types"] as const) {
+    const entry = pkgJson.exports[sub];
+    expect(entry, `missing exports entry for ${sub}`).toBeDefined();
+    expect(entry?.import).toMatch(/^\.\/dist\//);
+    expect(entry?.types).toMatch(/^\.\/dist\//);
+  }
+});
+
+/**
+ * Walk the static (non-type-only) import graph rooted at the given source file and collect the set of bare-package
+ * specifiers reachable from it. We only need to detect whether the heavy runtime entries (fastmcp, the modelcontext
+ * SDK, etc.) appear — so a single-pass regex scanner is enough; we don't need a real ESM parser.
+ */
+function collectRuntimeImports(entryFile: string): Set<string> {
+  const seen = new Set<string>();
+  const externalSpecifiers = new Set<string>();
+  const stack = [entryFile];
+  while (stack.length > 0) {
+    const file = stack.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    let body: string;
+    try {
+      body = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    const importRegex = /^[ \t]*import(?!\s+type\b)(?:[^"';]*?from)?\s*["']([^"']+)["']/gm;
+    for (const match of body.matchAll(importRegex)) {
+      const spec = match[1]!;
+      if (spec.startsWith(".")) {
+        const next = resolve(dirname(file), spec.replace(/\.js$/, ".ts"));
+        stack.push(next);
+        continue;
+      }
+      if (spec.startsWith("node:")) continue;
+      externalSpecifiers.add(spec);
+    }
+  }
+  return externalSpecifiers;
+}
+
+test.each([
+  ["./config", resolve(srcRoot, "config.ts")],
+  ["./errors", resolve(srcRoot, "errors.ts")],
+  ["./types", resolve(srcRoot, "types.ts")],
+])("sub-path %s does not pull fastmcp into the runtime graph", (subpath, srcFile) => {
+  const externals = collectRuntimeImports(srcFile);
+  // The heavy graph we explicitly want these sub-paths to avoid. If a refactor adds any of these as a runtime
+  // dependency of config/errors/types, the test fails — and the fix is to either move the import behind a more
+  // narrowly-scoped sub-path, or to revisit whether the lightweight contract still holds.
+  const heavyForbidden = ["fastmcp", "@modelcontextprotocol/sdk", "@toon-format/toon", "commander"];
+  for (const forbidden of heavyForbidden) {
+    expect(externals, `${subpath} (${srcFile}) imported '${forbidden}'`).not.toContain(forbidden);
+  }
+});


### PR DESCRIPTION
Add ./config, ./errors, and ./types as published sub-path exports so consumers that only need the pure-string interpolation helpers, error classes, or type definitions can avoid eagerly loading fastmcp, the modelcontext SDK, and the rest of the runtime. The dist files for these modules already have ~zero runtime dependencies; this change just makes them addressable from outside the package.

Also adds tests/subpath_exports.test.ts which pins the exports surface and walks the static import graph rooted at each lightweight entry to fail loudly if a future refactor pulls in fastmcp / @modelcontextprotocol/sdk / @toon-format/toon / commander.

Motivation: importing the main barrel currently drags in ~110 files from undici (transitively via fastmcp) even when the consumer only needs interpolateString, costing hundreds of ms of cold-import time in CLI tools that load agent definitions on every invocation.