### PR TITLE
Bump TypeScript MCP Compressor to 0.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-compressor"
-version = "0.0.0"
+version = "0.10.1"
 description = "An MCP server wrapper for reducing tokens consumed by MCP tools."
 authors = [{ name = "Tim Esler", email = "tesler@atlassian.com" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-compressor"
-version = "0.10.1"
+version = "0.0.0"
 description = "An MCP server wrapper for reducing tokens consumed by MCP tools."
 authors = [{ name = "Tim Esler", email = "tesler@atlassian.com" }]
 readme = "README.md"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlassian/mcp-compressor",
-  "version": "0.0.0",
+  "version": "0.10.1",
   "description": "TypeScript MCP server wrapper for reducing tokens consumed by MCP tools.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/atlassian-labs/mcp-compressor",


### PR DESCRIPTION
## Summary
- Bump TypeScript package version to 0.10.1
- Keep Python package version at the source placeholder 0.0.0

## Verification
- Verified pyproject.toml remains 0.0.0
- Verified typescript/package.json reports 0.10.1
- Ran `uv lock --locked` successfully