### PR TITLE
Add Rust core e2e contract test scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,48 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -15,10 +53,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -43,10 +200,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -68,6 +328,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -94,10 +355,225 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -112,10 +588,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -136,6 +640,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,11 +655,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "mcp-compressor-core"
 version = "0.1.0"
 dependencies = [
- "rand",
+ "rand 0.8.6",
+ "rmcp",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -160,16 +671,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -200,6 +764,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,7 +800,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -232,7 +821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -242,6 +831,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "rand 0.10.1",
+ "reqwest",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -255,6 +950,38 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -294,6 +1021,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +1045,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +1116,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -336,7 +1157,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -351,13 +1181,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -372,6 +1229,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +1345,44 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -408,6 +1409,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +1486,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,16 +1511,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
@@ -551,6 +1734,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +1776,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -9,6 +9,7 @@ serde_json = "1"
 thiserror  = "1"
 rand       = "0.8"
 tokio      = { version = "1", features = ["sync"] }
+rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
 
 [dev-dependencies]
 # async test runtime and macros (#[tokio::test])

--- a/crates/mcp-compressor-core/src/proxy/mod.rs
+++ b/crates/mcp-compressor-core/src/proxy/mod.rs
@@ -2,3 +2,5 @@ pub mod auth;
 pub mod registry;
 pub mod router;
 pub mod server;
+
+pub use server::{RunningToolProxy, ToolProxyServer};

--- a/crates/mcp-compressor-core/src/proxy/server.rs
+++ b/crates/mcp-compressor-core/src/proxy/server.rs
@@ -2,5 +2,48 @@
 //!
 //! Binds to `127.0.0.1:<port>` (random free port by default), generates a
 //! `SessionToken` at startup, and routes `/health` and `/exec` requests.
+//!
+//! This module intentionally exposes the API that integration tests and client
+//! generators should target. Method bodies remain `todo!()` until the Phase 1
+//! proxy implementation is built.
 
-// Stub — implementation added in Phase 1 build.
+use crate::proxy::auth::SessionToken;
+use crate::server::compressed::CompressedServer;
+use crate::Error;
+
+#[derive(Debug)]
+pub struct ToolProxyServer;
+
+#[derive(Debug, Clone)]
+pub struct RunningToolProxy {
+    bridge_url: String,
+    token: SessionToken,
+}
+
+impl ToolProxyServer {
+    pub async fn start(_server: CompressedServer) -> Result<RunningToolProxy, Error> {
+        todo!()
+    }
+}
+
+impl RunningToolProxy {
+    pub fn bridge_url(&self) -> &str {
+        &self.bridge_url
+    }
+
+    pub fn token(&self) -> &SessionToken {
+        &self.token
+    }
+
+    pub fn token_value(&self) -> &str {
+        self.token.value()
+    }
+
+    pub fn health_url(&self) -> String {
+        format!("{}/health", self.bridge_url)
+    }
+
+    pub fn exec_url(&self) -> String {
+        format!("{}/exec", self.bridge_url)
+    }
+}

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -46,6 +46,28 @@ impl BackendServerConfig {
     }
 }
 
+/// Frontend tool-surface mode exposed by the proxy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProxyTransformMode {
+    /// Normal compressed MCP mode: get_tool_schema/invoke_tool/(list_tools at max).
+    CompressedTools,
+    /// CLI mode: expose one help tool per configured server and route generated clients through /exec.
+    Cli,
+    /// Just Bash mode: expose one bash tool plus per-server help tools.
+    JustBash,
+}
+
+/// How upstream backend servers are supplied to the runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendConfigSource {
+    /// Direct command/argv input, e.g. `python alpha_server.py`.
+    Command,
+    /// JSON MCP config input with one `mcpServers` entry.
+    SingleServerJsonConfig,
+    /// JSON MCP config input with multiple `mcpServers` entries.
+    MultiServerJsonConfig,
+}
+
 /// Compression/runtime options shared by single-server and multi-server modes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompressedServerConfig {
@@ -54,6 +76,8 @@ pub struct CompressedServerConfig {
     pub include_tools: Vec<String>,
     pub exclude_tools: Vec<String>,
     pub toonify: bool,
+    pub transform_mode: ProxyTransformMode,
+    pub config_source: BackendConfigSource,
 }
 
 impl Default for CompressedServerConfig {
@@ -64,6 +88,8 @@ impl Default for CompressedServerConfig {
             include_tools: Vec::new(),
             exclude_tools: Vec::new(),
             toonify: false,
+            transform_mode: ProxyTransformMode::CompressedTools,
+            config_source: BackendConfigSource::Command,
         }
     }
 }
@@ -101,6 +127,14 @@ impl CompressedServer {
     pub async fn connect_multi_stdio(
         _config: CompressedServerConfig,
         _backends: Vec<BackendServerConfig>,
+    ) -> Result<Self, Error> {
+        todo!()
+    }
+
+    /// Connect using a JSON MCP config document containing one or more `mcpServers` entries.
+    pub async fn connect_mcp_config_json(
+        _config: CompressedServerConfig,
+        _mcp_config_json: &str,
     ) -> Result<Self, Error> {
         todo!()
     }

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -1,4 +1,157 @@
 //! `CompressedServer` — the top-level object that owns the backend client,
 //! tool cache, and compression engine, and exposes them via a frontend MCP server.
+//!
+//! This file intentionally exposes the runtime API that integration tests and
+//! language bindings should target. Method bodies remain `todo!()` until the
+//! Phase 1 runtime is implemented.
 
-// Stub — full implementation added in Phase 1 build.
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use serde_json::Value;
+
+use crate::compression::engine::Tool;
+use crate::compression::CompressionLevel;
+use crate::Error;
+
+/// Configuration for one upstream MCP server process reached over stdio.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendServerConfig {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+}
+
+impl BackendServerConfig {
+    pub fn new(
+        name: impl Into<String>,
+        command: impl Into<String>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            command: command.into(),
+            args: args.into_iter().map(Into::into).collect(),
+            env: HashMap::new(),
+        }
+    }
+
+    pub fn with_env(
+        mut self,
+        env: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.env = env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+}
+
+/// Compression/runtime options shared by single-server and multi-server modes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompressedServerConfig {
+    pub level: CompressionLevel,
+    pub server_name: Option<String>,
+    pub include_tools: Vec<String>,
+    pub exclude_tools: Vec<String>,
+    pub toonify: bool,
+}
+
+impl Default for CompressedServerConfig {
+    fn default() -> Self {
+        Self {
+            level: CompressionLevel::default(),
+            server_name: None,
+            include_tools: Vec::new(),
+            exclude_tools: Vec::new(),
+            toonify: false,
+        }
+    }
+}
+
+/// Handle for a frontend MCP server running over streamable HTTP.
+#[derive(Debug, Clone)]
+pub struct RunningCompressedServer {
+    addr: SocketAddr,
+}
+
+impl RunningCompressedServer {
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+}
+
+/// Connected compressor runtime.
+#[derive(Debug)]
+pub struct CompressedServer;
+
+impl CompressedServer {
+    /// Connect to one upstream stdio MCP server.
+    pub async fn connect_stdio(
+        _config: CompressedServerConfig,
+        _backend: BackendServerConfig,
+    ) -> Result<Self, Error> {
+        todo!()
+    }
+
+    /// Connect to multiple upstream stdio MCP servers.
+    pub async fn connect_multi_stdio(
+        _config: CompressedServerConfig,
+        _backends: Vec<BackendServerConfig>,
+    ) -> Result<Self, Error> {
+        todo!()
+    }
+
+    /// Start the frontend MCP server over streamable HTTP.
+    pub async fn run_http(&self, _addr: SocketAddr) -> Result<RunningCompressedServer, Error> {
+        todo!()
+    }
+
+    /// Return the frontend MCP tools exposed to callers.
+    pub async fn list_frontend_tools(&self) -> Result<Vec<Tool>, Error> {
+        todo!()
+    }
+
+    /// Return the full backend schema for a tool via the compressed wrapper API.
+    pub async fn get_tool_schema(
+        &self,
+        _wrapper_tool_name: &str,
+        _backend_tool_name: &str,
+    ) -> Result<String, Error> {
+        todo!()
+    }
+
+    /// List backend tools via the max-compression `list_tools` wrapper.
+    pub async fn list_backend_tools(&self, _wrapper_tool_name: &str) -> Result<String, Error> {
+        todo!()
+    }
+
+    /// Invoke a backend tool via the compressed wrapper API.
+    pub async fn invoke_tool(
+        &self,
+        _wrapper_tool_name: &str,
+        _backend_tool_name: &str,
+        _tool_input: Value,
+    ) -> Result<String, Error> {
+        todo!()
+    }
+
+    /// List frontend resources, including pass-through backend resources and
+    /// compressor-owned uncompressed-tool-list resources.
+    pub async fn list_resources(&self) -> Result<Vec<String>, Error> {
+        todo!()
+    }
+
+    /// Read a frontend resource by URI.
+    pub async fn read_resource(&self, _uri: &str) -> Result<String, Error> {
+        todo!()
+    }
+
+    /// List frontend prompts passed through from backend servers.
+    pub async fn list_prompts(&self) -> Result<Vec<String>, Error> {
+        todo!()
+    }
+}

--- a/crates/mcp-compressor-core/src/server/mod.rs
+++ b/crates/mcp-compressor-core/src/server/mod.rs
@@ -3,6 +3,7 @@ pub mod registration;
 pub mod tool_cache;
 
 pub use compressed::{
-    BackendServerConfig, CompressedServer, CompressedServerConfig, RunningCompressedServer,
+    BackendConfigSource, BackendServerConfig, CompressedServer, CompressedServerConfig,
+    ProxyTransformMode, RunningCompressedServer,
 };
 pub use tool_cache::ToolCache;

--- a/crates/mcp-compressor-core/src/server/mod.rs
+++ b/crates/mcp-compressor-core/src/server/mod.rs
@@ -2,4 +2,7 @@ pub mod compressed;
 pub mod registration;
 pub mod tool_cache;
 
+pub use compressed::{
+    BackendServerConfig, CompressedServer, CompressedServerConfig, RunningCompressedServer,
+};
 pub use tool_cache::ToolCache;

--- a/crates/mcp-compressor-core/tests/common/mod.rs
+++ b/crates/mcp-compressor-core/tests/common/mod.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use mcp_compressor_core::compression::CompressionLevel;
+use mcp_compressor_core::server::{BackendServerConfig, CompressedServerConfig};
+
+pub fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+pub fn python_command() -> String {
+    std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+}
+
+pub fn backend(name: &str, fixture: &str) -> BackendServerConfig {
+    BackendServerConfig::new(
+        name,
+        python_command(),
+        [fixture_path(fixture).to_string_lossy().into_owned()],
+    )
+}
+
+pub fn max_config(server_name: impl Into<Option<&'static str>>) -> CompressedServerConfig {
+    CompressedServerConfig {
+        level: CompressionLevel::Max,
+        server_name: server_name.into().map(str::to_string),
+        include_tools: Vec::new(),
+        exclude_tools: Vec::new(),
+        toonify: false,
+    }
+}

--- a/crates/mcp-compressor-core/tests/common/mod.rs
+++ b/crates/mcp-compressor-core/tests/common/mod.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
 use mcp_compressor_core::compression::CompressionLevel;
-use mcp_compressor_core::server::{BackendServerConfig, CompressedServerConfig};
+use mcp_compressor_core::server::{
+    BackendConfigSource, BackendServerConfig, CompressedServerConfig, ProxyTransformMode,
+};
 
 pub fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -22,12 +24,44 @@ pub fn backend(name: &str, fixture: &str) -> BackendServerConfig {
     )
 }
 
-pub fn max_config(server_name: impl Into<Option<&'static str>>) -> CompressedServerConfig {
+pub fn config(
+    level: CompressionLevel,
+    server_name: impl Into<Option<&'static str>>,
+    transform_mode: ProxyTransformMode,
+    config_source: BackendConfigSource,
+) -> CompressedServerConfig {
     CompressedServerConfig {
-        level: CompressionLevel::Max,
+        level,
         server_name: server_name.into().map(str::to_string),
         include_tools: Vec::new(),
         exclude_tools: Vec::new(),
         toonify: false,
+        transform_mode,
+        config_source,
     }
+}
+
+pub fn max_config(server_name: impl Into<Option<&'static str>>) -> CompressedServerConfig {
+    config(
+        CompressionLevel::Max,
+        server_name,
+        ProxyTransformMode::CompressedTools,
+        BackendConfigSource::Command,
+    )
+}
+
+pub fn mcp_config_json(backends: &[(&str, &str)]) -> String {
+    let servers = backends
+        .iter()
+        .map(|(name, fixture)| {
+            let path = fixture_path(fixture).to_string_lossy().into_owned();
+            format!(
+                r#""{name}":{{"command":"{}","args":["{}"]}}"#,
+                python_command(),
+                path
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(r#"{{"mcpServers":{{{servers}}}}}"#)
 }

--- a/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
+++ b/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
@@ -49,7 +49,7 @@ async fn single_stdio_backend_schema_listing_invocation_resources_and_prompts_wo
     let listed = server.list_backend_tools("alpha_list_tools").await.unwrap();
     assert!(listed.contains("echo"));
     assert!(listed.contains("add"));
-    assert!(listed.contains("object"));
+    assert!(listed.contains("structured_data"));
 
     let echo = server
         .invoke_tool("alpha_invoke_tool", "echo", json!({ "message": "hello" }))

--- a/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
+++ b/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
@@ -1,0 +1,83 @@
+mod common;
+
+use mcp_compressor_core::server::CompressedServer;
+use serde_json::json;
+
+#[tokio::test]
+async fn single_stdio_backend_exposes_only_compressed_wrapper_tools() {
+    let server = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let names: Vec<String> = server
+        .list_frontend_tools()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
+
+    assert_eq!(
+        names,
+        [
+            "alpha_get_tool_schema",
+            "alpha_invoke_tool",
+            "alpha_list_tools"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn single_stdio_backend_schema_listing_invocation_resources_and_prompts_work() {
+    let server = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let schema = server
+        .get_tool_schema("alpha_get_tool_schema", "echo")
+        .await
+        .unwrap();
+    assert!(schema.contains("echo"));
+    assert!(schema.contains("message"));
+
+    let listed = server.list_backend_tools("alpha_list_tools").await.unwrap();
+    assert!(listed.contains("echo"));
+    assert!(listed.contains("add"));
+    assert!(listed.contains("object"));
+
+    let echo = server
+        .invoke_tool("alpha_invoke_tool", "echo", json!({ "message": "hello" }))
+        .await
+        .unwrap();
+    assert_eq!(echo, "alpha:hello");
+
+    let add = server
+        .invoke_tool("alpha_invoke_tool", "add", json!({ "a": 2, "b": 5 }))
+        .await
+        .unwrap();
+    assert_eq!(add, "7");
+
+    let resources = server.list_resources().await.unwrap();
+    assert!(resources
+        .iter()
+        .any(|uri| uri == "fixture://alpha-resource"));
+    assert!(resources
+        .iter()
+        .any(|uri| uri == "compressor://alpha/uncompressed-tools"));
+    assert_eq!(
+        server
+            .read_resource("fixture://alpha-resource")
+            .await
+            .unwrap(),
+        "alpha resource"
+    );
+
+    let prompts = server.list_prompts().await.unwrap();
+    assert!(prompts.iter().any(|name| name == "alpha_prompt"));
+}

--- a/crates/mcp-compressor-core/tests/compression_levels.rs
+++ b/crates/mcp-compressor-core/tests/compression_levels.rs
@@ -1,0 +1,102 @@
+mod common;
+
+use mcp_compressor_core::compression::CompressionLevel;
+use mcp_compressor_core::server::{BackendConfigSource, CompressedServer, ProxyTransformMode};
+
+#[tokio::test]
+async fn low_medium_and_high_expose_only_schema_and_invoke_wrappers() {
+    for level in [CompressionLevel::Low, CompressionLevel::Medium, CompressionLevel::High] {
+        let server = CompressedServer::connect_stdio(
+            common::config(
+                level.clone(),
+                Some("alpha"),
+                ProxyTransformMode::CompressedTools,
+                BackendConfigSource::Command,
+            ),
+            common::backend("alpha", "alpha_server.py"),
+        )
+        .await
+        .unwrap();
+
+        let names: Vec<String> = server
+            .list_frontend_tools()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+
+        assert_eq!(
+            names,
+            ["alpha_get_tool_schema", "alpha_invoke_tool"],
+            "unexpected wrapper tools for {level:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn max_exposes_schema_invoke_and_list_wrappers() {
+    let server = CompressedServer::connect_stdio(
+        common::config(
+            CompressionLevel::Max,
+            Some("alpha"),
+            ProxyTransformMode::CompressedTools,
+            BackendConfigSource::Command,
+        ),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let names: Vec<String> = server
+        .list_frontend_tools()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
+
+    assert_eq!(
+        names,
+        ["alpha_get_tool_schema", "alpha_invoke_tool", "alpha_list_tools"]
+    );
+}
+
+#[tokio::test]
+async fn all_compression_levels_can_fetch_schema_and_invoke_backend_tools() {
+    for level in [
+        CompressionLevel::Low,
+        CompressionLevel::Medium,
+        CompressionLevel::High,
+        CompressionLevel::Max,
+    ] {
+        let server = CompressedServer::connect_stdio(
+            common::config(
+                level.clone(),
+                Some("alpha"),
+                ProxyTransformMode::CompressedTools,
+                BackendConfigSource::Command,
+            ),
+            common::backend("alpha", "alpha_server.py"),
+        )
+        .await
+        .unwrap();
+
+        let schema = server
+            .get_tool_schema("alpha_get_tool_schema", "echo")
+            .await
+            .unwrap();
+        assert!(schema.contains("echo"), "schema missing tool name for {level:?}");
+        assert!(schema.contains("message"), "schema missing input field for {level:?}");
+
+        let result = server
+            .invoke_tool(
+                "alpha_invoke_tool",
+                "echo",
+                serde_json::json!({ "message": "hello" }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result, "alpha:hello", "invoke failed for {level:?}");
+    }
+}

--- a/crates/mcp-compressor-core/tests/config_sources.rs
+++ b/crates/mcp-compressor-core/tests/config_sources.rs
@@ -1,0 +1,126 @@
+mod common;
+
+use mcp_compressor_core::compression::CompressionLevel;
+use mcp_compressor_core::server::{BackendConfigSource, CompressedServer, ProxyTransformMode};
+use serde_json::json;
+
+#[tokio::test]
+async fn single_server_direct_command_config_connects_and_invokes() {
+    let server = CompressedServer::connect_stdio(
+        common::config(
+            CompressionLevel::Max,
+            Some("alpha"),
+            ProxyTransformMode::CompressedTools,
+            BackendConfigSource::Command,
+        ),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let result = server
+        .invoke_tool("alpha_invoke_tool", "add", json!({ "a": 2, "b": 5 }))
+        .await
+        .unwrap();
+    assert_eq!(result, "7");
+}
+
+#[tokio::test]
+async fn single_server_json_mcp_config_connects_and_invokes() {
+    let config_json = common::mcp_config_json(&[("alpha", "alpha_server.py")]);
+    let server = CompressedServer::connect_mcp_config_json(
+        common::config(
+            CompressionLevel::Max,
+            None,
+            ProxyTransformMode::CompressedTools,
+            BackendConfigSource::SingleServerJsonConfig,
+        ),
+        &config_json,
+    )
+    .await
+    .unwrap();
+
+    let names: Vec<String> = server
+        .list_frontend_tools()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
+    assert_eq!(names, ["get_tool_schema", "invoke_tool", "list_tools"]);
+
+    let result = server
+        .invoke_tool("invoke_tool", "add", json!({ "a": 2, "b": 5 }))
+        .await
+        .unwrap();
+    assert_eq!(result, "7");
+}
+
+#[tokio::test]
+async fn multi_server_direct_command_config_connects_and_routes() {
+    let server = CompressedServer::connect_multi_stdio(
+        common::config(
+            CompressionLevel::Max,
+            Some("suite"),
+            ProxyTransformMode::CompressedTools,
+            BackendConfigSource::Command,
+        ),
+        vec![
+            common::backend("alpha", "alpha_server.py"),
+            common::backend("beta", "beta_server.py"),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let alpha = server
+        .invoke_tool("suite_alpha_invoke_tool", "add", json!({ "a": 3, "b": 7 }))
+        .await
+        .unwrap();
+    let beta = server
+        .invoke_tool("suite_beta_invoke_tool", "multiply", json!({ "a": 4, "b": 5 }))
+        .await
+        .unwrap();
+    assert_eq!(alpha, "10");
+    assert_eq!(beta, "20");
+}
+
+#[tokio::test]
+async fn multi_server_json_mcp_config_connects_and_routes() {
+    let config_json = common::mcp_config_json(&[
+        ("alpha", "alpha_server.py"),
+        ("beta", "beta_server.py"),
+    ]);
+    let server = CompressedServer::connect_mcp_config_json(
+        common::config(
+            CompressionLevel::Max,
+            Some("suite"),
+            ProxyTransformMode::CompressedTools,
+            BackendConfigSource::MultiServerJsonConfig,
+        ),
+        &config_json,
+    )
+    .await
+    .unwrap();
+
+    let names: Vec<String> = server
+        .list_frontend_tools()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
+    assert!(names.iter().any(|name| name == "suite_alpha_invoke_tool"));
+    assert!(names.iter().any(|name| name == "suite_beta_invoke_tool"));
+
+    let alpha = server
+        .invoke_tool("suite_alpha_invoke_tool", "add", json!({ "a": 3, "b": 7 }))
+        .await
+        .unwrap();
+    let beta = server
+        .invoke_tool("suite_beta_invoke_tool", "multiply", json!({ "a": 4, "b": 5 }))
+        .await
+        .unwrap();
+    assert_eq!(alpha, "10");
+    assert_eq!(beta, "20");
+}

--- a/crates/mcp-compressor-core/tests/fixtures/alpha_server.py
+++ b/crates/mcp-compressor-core/tests/fixtures/alpha_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+from typing import Any
 
 from fastmcp import FastMCP
 
@@ -20,7 +21,7 @@ def add(a: int, b: int) -> int:
 
 
 @mcp.tool
-def object() -> dict[str, object]:  # noqa: A001
+def structured_data() -> dict[str, Any]:
     """Return structured alpha data."""
     return {"server": "alpha", "values": [1, 2], "nested": {"ok": True}}
 

--- a/crates/mcp-compressor-core/tests/fixtures/alpha_server.py
+++ b/crates/mcp-compressor-core/tests/fixtures/alpha_server.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import contextlib
+
+from fastmcp import FastMCP
+
+mcp = FastMCP("Rust Core Alpha Fixture")
+
+
+@mcp.tool
+def echo(message: str) -> str:
+    """Echo a message from alpha."""
+    return f"alpha:{message}"
+
+
+@mcp.tool
+def add(a: int, b: int) -> int:
+    """Add two integers on alpha."""
+    return a + b
+
+
+@mcp.tool
+def object() -> dict[str, object]:  # noqa: A001
+    """Return structured alpha data."""
+    return {"server": "alpha", "values": [1, 2], "nested": {"ok": True}}
+
+
+@mcp.resource("fixture://alpha-resource")
+def alpha_resource() -> str:
+    """Return a static alpha resource."""
+    return "alpha resource"
+
+
+@mcp.prompt
+def alpha_prompt() -> str:
+    """Return a static alpha prompt."""
+    return "alpha prompt"
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        mcp.run(show_banner=False)

--- a/crates/mcp-compressor-core/tests/fixtures/beta_server.py
+++ b/crates/mcp-compressor-core/tests/fixtures/beta_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+from typing import Any
 
 from fastmcp import FastMCP
 
@@ -20,7 +21,7 @@ def multiply(a: int, b: int) -> int:
 
 
 @mcp.tool
-def object() -> dict[str, object]:  # noqa: A001
+def structured_data() -> dict[str, Any]:
     """Return structured beta data."""
     return {"server": "beta", "values": [3, 4], "nested": {"ok": True}}
 

--- a/crates/mcp-compressor-core/tests/fixtures/beta_server.py
+++ b/crates/mcp-compressor-core/tests/fixtures/beta_server.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import contextlib
+
+from fastmcp import FastMCP
+
+mcp = FastMCP("Rust Core Beta Fixture")
+
+
+@mcp.tool
+def echo(message: str) -> str:
+    """Echo a message from beta."""
+    return f"beta:{message}"
+
+
+@mcp.tool
+def multiply(a: int, b: int) -> int:
+    """Multiply two integers on beta."""
+    return a * b
+
+
+@mcp.tool
+def object() -> dict[str, object]:  # noqa: A001
+    """Return structured beta data."""
+    return {"server": "beta", "values": [3, 4], "nested": {"ok": True}}
+
+
+@mcp.resource("fixture://beta-resource")
+def beta_resource() -> str:
+    """Return a static beta resource."""
+    return "beta resource"
+
+
+@mcp.prompt
+def beta_prompt() -> str:
+    """Return a static beta prompt."""
+    return "beta prompt"
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        mcp.run(show_banner=False)

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -1,0 +1,114 @@
+mod common;
+
+use std::process::Command;
+
+use mcp_compressor_core::client_gen::cli::CliGenerator;
+use mcp_compressor_core::client_gen::python::PythonGenerator;
+use mcp_compressor_core::client_gen::typescript::TypeScriptGenerator;
+use mcp_compressor_core::client_gen::{ClientGenerator, GeneratorConfig};
+use mcp_compressor_core::proxy::ToolProxyServer;
+use mcp_compressor_core::server::CompressedServer;
+
+async fn running_proxy_config(output_dir: &std::path::Path) -> GeneratorConfig {
+    let compressed = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+    let proxy = ToolProxyServer::start(compressed).await.unwrap();
+
+    GeneratorConfig {
+        cli_name: "alpha".to_string(),
+        bridge_url: proxy.bridge_url().to_string(),
+        token: proxy.token_value().to_string(),
+        tools: vec![mcp_compressor_core::compression::engine::Tool::new(
+            "echo",
+            Some("Echo a message from alpha.".to_string()),
+            serde_json::json!({
+                "type": "object",
+                "properties": { "message": { "type": "string" } },
+                "required": ["message"]
+            }),
+        )],
+        session_pid: std::process::id(),
+        output_dir: output_dir.to_path_buf(),
+    }
+}
+
+#[tokio::test]
+async fn generated_cli_script_invokes_real_proxy_and_backend() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = running_proxy_config(tempdir.path()).await;
+    let paths = CliGenerator.generate(&config).unwrap();
+    let script = paths
+        .iter()
+        .find(|path| path.file_name().unwrap() == "alpha")
+        .unwrap();
+
+    let output = Command::new(script)
+        .args(["echo", "--message", "hello"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "alpha:hello"
+    );
+}
+
+#[tokio::test]
+async fn generated_python_module_invokes_real_proxy_and_backend() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = running_proxy_config(tempdir.path()).await;
+    PythonGenerator.generate(&config).unwrap();
+
+    let code = "import alpha; print(alpha.echo('hello'))";
+    let output = Command::new(common::python_command())
+        .env("PYTHONPATH", tempdir.path())
+        .args(["-c", code])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "alpha:hello"
+    );
+}
+
+#[tokio::test]
+async fn generated_typescript_module_invokes_real_proxy_and_backend() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = running_proxy_config(tempdir.path()).await;
+    TypeScriptGenerator.generate(&config).unwrap();
+
+    let module_path = tempdir.path().join("alpha.ts");
+    let output = Command::new("bun")
+        .arg("--eval")
+        .arg(format!(
+            "import {{ echo }} from '{}'; console.log(await echo('hello'));",
+            module_path.display()
+        ))
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "alpha:hello"
+    );
+}

--- a/crates/mcp-compressor-core/tests/multi_server.rs
+++ b/crates/mcp-compressor-core/tests/multi_server.rs
@@ -1,0 +1,77 @@
+mod common;
+
+use mcp_compressor_core::server::CompressedServer;
+use serde_json::json;
+
+#[tokio::test]
+async fn multi_stdio_backends_are_prefixed_and_routed_independently() {
+    let server = CompressedServer::connect_multi_stdio(
+        common::max_config(Some("suite")),
+        vec![
+            common::backend("alpha", "alpha_server.py"),
+            common::backend("beta", "beta_server.py"),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let names: Vec<String> = server
+        .list_frontend_tools()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
+
+    for expected in [
+        "suite_alpha_get_tool_schema",
+        "suite_alpha_invoke_tool",
+        "suite_alpha_list_tools",
+        "suite_beta_get_tool_schema",
+        "suite_beta_invoke_tool",
+        "suite_beta_list_tools",
+    ] {
+        assert!(
+            names.iter().any(|name| name == expected),
+            "missing frontend tool {expected}"
+        );
+    }
+
+    let alpha_tools = server
+        .list_backend_tools("suite_alpha_list_tools")
+        .await
+        .unwrap();
+    let beta_tools = server
+        .list_backend_tools("suite_beta_list_tools")
+        .await
+        .unwrap();
+    assert!(alpha_tools.contains("add"));
+    assert!(beta_tools.contains("multiply"));
+
+    let alpha = server
+        .invoke_tool("suite_alpha_invoke_tool", "add", json!({ "a": 3, "b": 7 }))
+        .await
+        .unwrap();
+    let beta = server
+        .invoke_tool(
+            "suite_beta_invoke_tool",
+            "multiply",
+            json!({ "a": 4, "b": 5 }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(alpha, "10");
+    assert_eq!(beta, "20");
+
+    let resources = server.list_resources().await.unwrap();
+    assert!(resources
+        .iter()
+        .any(|uri| uri == "fixture://alpha-resource"));
+    assert!(resources.iter().any(|uri| uri == "fixture://beta-resource"));
+    assert!(resources
+        .iter()
+        .any(|uri| uri == "compressor://suite_alpha/uncompressed-tools"));
+    assert!(resources
+        .iter()
+        .any(|uri| uri == "compressor://suite_beta/uncompressed-tools"));
+}

--- a/crates/mcp-compressor-core/tests/proxy_http.rs
+++ b/crates/mcp-compressor-core/tests/proxy_http.rs
@@ -1,0 +1,109 @@
+mod common;
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+use mcp_compressor_core::proxy::ToolProxyServer;
+use mcp_compressor_core::server::CompressedServer;
+use serde_json::json;
+
+struct HttpResponse {
+    status: u16,
+    body: String,
+}
+
+fn split_http_url(url: &str) -> (&str, &str) {
+    let rest = url
+        .strip_prefix("http://")
+        .expect("fixture proxy URL should be plain HTTP");
+    rest.split_once('/')
+        .map_or((rest, "/"), |(host, path)| (host, path))
+}
+
+fn send_raw_http(method: &str, url: &str, auth: Option<&str>, body: Option<&str>) -> HttpResponse {
+    let (host, path) = split_http_url(url);
+    let path = format!("/{path}");
+    let body = body.unwrap_or("");
+
+    let mut request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\nContent-Length: {}\r\n",
+        body.len()
+    );
+    if let Some(token) = auth {
+        request.push_str(&format!("Authorization: Bearer {token}\r\n"));
+    }
+    if !body.is_empty() {
+        request.push_str("Content-Type: application/json\r\n");
+    }
+    request.push_str("\r\n");
+    request.push_str(body);
+
+    let mut stream = TcpStream::connect(host).unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+
+    let mut raw = String::new();
+    stream.read_to_string(&mut raw).unwrap();
+    let (head, body) = raw.split_once("\r\n\r\n").unwrap_or((&raw, ""));
+    let status = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse::<u16>().ok())
+        .expect("HTTP response should contain a numeric status code");
+
+    HttpResponse {
+        status,
+        body: body.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn proxy_health_is_public_and_exec_requires_bearer_token() {
+    let compressed = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+    let proxy = ToolProxyServer::start(compressed).await.unwrap();
+
+    let health = send_raw_http("GET", &proxy.health_url(), None, None);
+    assert!((200..300).contains(&health.status));
+
+    let body = json!({
+        "tool": "alpha_invoke_tool",
+        "input": { "tool_name": "echo", "tool_input": { "message": "hello" } }
+    })
+    .to_string();
+    let missing_auth = send_raw_http("POST", &proxy.exec_url(), None, Some(&body));
+    assert_eq!(missing_auth.status, 401);
+
+    let wrong_auth = send_raw_http("POST", &proxy.exec_url(), Some("wrong-token"), Some(&body));
+    assert_eq!(wrong_auth.status, 401);
+}
+
+#[tokio::test]
+async fn proxy_exec_dispatches_to_real_backend_with_session_token() {
+    let compressed = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+    let proxy = ToolProxyServer::start(compressed).await.unwrap();
+
+    let body = json!({
+        "tool": "alpha_invoke_tool",
+        "input": { "tool_name": "echo", "tool_input": { "message": "hello" } }
+    })
+    .to_string();
+    let response = send_raw_http(
+        "POST",
+        &proxy.exec_url(),
+        Some(proxy.token_value()),
+        Some(&body),
+    );
+
+    assert!((200..300).contains(&response.status));
+    assert_eq!(response.body.trim(), "alpha:hello");
+}

--- a/crates/mcp-compressor-core/tests/transform_modes.rs
+++ b/crates/mcp-compressor-core/tests/transform_modes.rs
@@ -1,0 +1,90 @@
+mod common;
+
+use mcp_compressor_core::compression::CompressionLevel;
+use mcp_compressor_core::server::{BackendConfigSource, CompressedServer, ProxyTransformMode};
+use serde_json::json;
+
+#[tokio::test]
+async fn compressed_tools_mode_exposes_wrappers_for_single_server() {
+    let server = CompressedServer::connect_stdio(
+        common::config(
+            CompressionLevel::Max,
+            Some("alpha"),
+            ProxyTransformMode::CompressedTools,
+            BackendConfigSource::Command,
+        ),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let names: Vec<String> = server
+        .list_frontend_tools()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
+    assert_eq!(
+        names,
+        ["alpha_get_tool_schema", "alpha_invoke_tool", "alpha_list_tools"]
+    );
+}
+
+#[tokio::test]
+async fn cli_mode_exposes_help_tool_and_keeps_exec_routing_available() {
+    let server = CompressedServer::connect_stdio(
+        common::config(
+            CompressionLevel::Low,
+            Some("alpha"),
+            ProxyTransformMode::Cli,
+            BackendConfigSource::Command,
+        ),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let tools = server.list_frontend_tools().await.unwrap();
+    let names: Vec<String> = tools.iter().map(|tool| tool.name.clone()).collect();
+    assert_eq!(names, ["alpha_help"]);
+    assert!(tools[0].description.as_deref().unwrap_or_default().contains("echo"));
+
+    let result = server
+        .invoke_tool("alpha_invoke_tool", "echo", json!({ "message": "hello" }))
+        .await
+        .unwrap();
+    assert_eq!(result, "alpha:hello");
+}
+
+#[tokio::test]
+async fn just_bash_mode_exposes_bash_tool_and_per_server_help_tools() {
+    let server = CompressedServer::connect_multi_stdio(
+        common::config(
+            CompressionLevel::Low,
+            None,
+            ProxyTransformMode::JustBash,
+            BackendConfigSource::Command,
+        ),
+        vec![
+            common::backend("alpha", "alpha_server.py"),
+            common::backend("beta", "beta_server.py"),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let tools = server.list_frontend_tools().await.unwrap();
+    let names: Vec<String> = tools.iter().map(|tool| tool.name.clone()).collect();
+    assert_eq!(names, ["bash_tool", "alpha_help", "beta_help"]);
+
+    let bash_description = tools
+        .iter()
+        .find(|tool| tool.name == "bash_tool")
+        .and_then(|tool| tool.description.as_deref())
+        .unwrap_or_default();
+    assert!(bash_description.contains("just-bash"));
+    assert!(bash_description.contains("alpha"));
+    assert!(bash_description.contains("beta"));
+    assert!(bash_description.contains("TOON"));
+}

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -147,6 +147,8 @@ Replace the existing implementations once the Rust-backed packages are productio
   Maintain parity fixtures and run language-level golden tests against shared scenarios.
 - **Operational complexity from native artifacts**
   Publish prebuilt wheels and Node binaries for major targets; keep a pure-language fallback path temporarily during migration.
+- **Future V8 isolate / WASM portability**
+  Use `napi-rs` for the initial TypeScript binding, but keep the public TS APIs and generated TS clients free of avoidable Node-native assumptions so a later `wasm32`/V8-isolate target remains feasible.
 
 ## Open Questions
 
@@ -557,6 +559,29 @@ export async function getConfluencePage(pageId: string, spaceKey?: string): Prom
 ```
 
 An accompanying `<cli_name>.d.ts` declaration file is generated for projects that consume the module without bundling.
+
+#### Future V8 isolate / WASM compatibility guidance
+
+The initial TypeScript package can use `napi-rs` and ship as a native Node.js module. However, a future deployment target may need to run the TypeScript library inside a V8 isolate or another environment where native Node addons are unavailable. We do not need to implement the WASM path initially, but the design should avoid choices that make it unnecessarily hard later.
+
+Guidance for TypeScript-facing APIs and generated TypeScript artifacts:
+
+- Prefer Web-standard APIs where possible: `fetch`, `Request`, `Response`, `Headers`, `URL`, `TextEncoder`, `TextDecoder`, `AbortSignal`, `ReadableStream`.
+- Avoid exposing Node-native types in public APIs: `Buffer`, `fs` paths, `net.Socket`, `http.ClientRequest`, `stream.Readable`, `EventEmitter`, and Node-specific timer/process handles.
+- Keep filesystem, process spawning, environment-variable access, and local TCP listener startup behind narrow runtime adapters. These are fine for the Node/napi implementation, but should not leak into the stable TS API shape.
+- Keep generated TypeScript client modules dependency-light and ESM-first. They should call the local proxy through `fetch` rather than `node:http`, `axios`, or other Node-only clients.
+- Keep data crossing the Rust/TS boundary JSON-serializable: strings, numbers, booleans, arrays, objects, and byte data represented explicitly rather than as `Buffer`.
+- Avoid global mutable Node process state in generated clients. Multi-session bridge selection should be representable as explicit configuration, not only as `process.env` or process-global registries.
+- Separate runtime capability detection from core behavior. The Node package may provide adapters for spawning MCP servers and starting loopback proxies; a future isolate/WASM package may require callers to inject transport/proxy capabilities instead.
+- Keep Rust core logic that is pure or protocol-level separate from OS-bound code. That makes it easier to compile compression, schema, CLI mapping, and generated-client logic to `wasm32` later while leaving stdio/process/local-network transports as host-provided adapters.
+
+Non-goals for the initial `napi-rs` implementation:
+
+- shipping a WASM package
+- supporting MCP stdio child-process spawning inside isolates
+- supporting local TCP proxy startup inside isolates
+
+The main requirement today is API discipline: Node-native behavior is allowed internally for the Node binding, but public TypeScript surfaces should remain portable enough that a future WASM/V8-isolate implementation can reuse the same high-level API.
 
 ---
 

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -148,7 +148,7 @@ Replace the existing implementations once the Rust-backed packages are productio
 - **Operational complexity from native artifacts**
   Publish prebuilt wheels and Node binaries for major targets; keep a pure-language fallback path temporarily during migration.
 - **Future V8 isolate / WASM portability**
-  Use `napi-rs` for the initial TypeScript binding, but keep the public TS APIs and generated TS clients free of avoidable Node-native assumptions so a later `wasm32`/V8-isolate target remains feasible.
+  `napi-rs` v3 provides an official WebAssembly path, but current support is centered on `wasm32-wasip1-threads` and still depends on host capabilities such as WASI, threads/Atomics, networking, and process adapters. Use `napi-rs` for the initial TypeScript binding, but keep public TS APIs and generated TS clients free of avoidable Node-native assumptions so a later WASM/V8-isolate target remains feasible.
 
 ## Open Questions
 
@@ -562,7 +562,7 @@ An accompanying `<cli_name>.d.ts` declaration file is generated for projects tha
 
 #### Future V8 isolate / WASM compatibility guidance
 
-The initial TypeScript package can use `napi-rs` and ship as a native Node.js module. However, a future deployment target may need to run the TypeScript library inside a V8 isolate or another environment where native Node addons are unavailable. We do not need to implement the WASM path initially, but the design should avoid choices that make it unnecessarily hard later.
+The initial TypeScript package can use `napi-rs` and ship as a native Node.js module. Current `napi-rs` v3 releases also provide an official WebAssembly path, with the practical default centered on `wasm32-wasip1-threads`. That is encouraging for future browser/StackBlitz/Node-WASM fallback scenarios, but it does not automatically guarantee compatibility with every V8-isolate host. Isolate viability will still depend on the host's support for WASI, threads/Atomics, networking/fetch, timers, and any process-spawning or local-listener capabilities we require. We do not need to implement the WASM path initially, but the design should avoid choices that make it unnecessarily hard later.
 
 Guidance for TypeScript-facing APIs and generated TypeScript artifacts:
 
@@ -573,11 +573,11 @@ Guidance for TypeScript-facing APIs and generated TypeScript artifacts:
 - Keep data crossing the Rust/TS boundary JSON-serializable: strings, numbers, booleans, arrays, objects, and byte data represented explicitly rather than as `Buffer`.
 - Avoid global mutable Node process state in generated clients. Multi-session bridge selection should be representable as explicit configuration, not only as `process.env` or process-global registries.
 - Separate runtime capability detection from core behavior. The Node package may provide adapters for spawning MCP servers and starting loopback proxies; a future isolate/WASM package may require callers to inject transport/proxy capabilities instead.
-- Keep Rust core logic that is pure or protocol-level separate from OS-bound code. That makes it easier to compile compression, schema, CLI mapping, and generated-client logic to `wasm32` later while leaving stdio/process/local-network transports as host-provided adapters.
+- Keep Rust core logic that is pure or protocol-level separate from OS-bound code. That makes it easier to compile compression, schema, CLI mapping, and generated-client logic to a WASM target later while leaving stdio/process/local-network transports as host-provided adapters.
 
 Non-goals for the initial `napi-rs` implementation:
 
-- shipping a WASM package
+- shipping a WASM package or selecting a final WASM target/trampoline strategy
 - supporting MCP stdio child-process spawning inside isolates
 - supporting local TCP proxy startup inside isolates
 


### PR DESCRIPTION
## Summary
- add real alpha/beta MCP fixture servers for Rust core integration contracts
- add Rust integration contract tests for single-server stdio compression, multi-server routing, proxy HTTP auth/dispatch, and generated clients
- add explicit placeholder runtime APIs for CompressedServer and ToolProxyServer so future implementation work has concrete e2e targets
- add the official Rust MCP SDK crate (rmcp) with client/server/stdio/http transport features

## Validation
- manually smoke-tested fixture servers with FastMCP Client:
  - alpha echo returned alpha:hello
  - beta multiply returned 12
  - resources and prompts were listed
- cargo test -p mcp-compressor-core --tests --no-run
- cargo test -p mcp-compressor-core --test compressed_server_stdio single_stdio_backend_exposes_only_compressed_wrapper_tools -- --nocapture
  - intentionally fails at CompressedServer::connect_stdio todo!(), confirming the contract reaches the runtime TODO boundary
- uv run ruff check crates/mcp-compressor-core/tests/fixtures/alpha_server.py crates/mcp-compressor-core/tests/fixtures/beta_server.py

## Notes
These are intentionally contract/TDD tests. They compile now, but runtime e2e tests are expected to fail until the Rust core runtime TODOs are implemented.