### PR TITLE
Compile Rust core targets in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,27 @@ jobs:
       - name: Check typing
         run: uv run ty check
 
+  rust-core-compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up the Python environment
+        uses: ./.github/actions/setup-python-env
+
+      - name: Check Rust core library
+        run: cargo check -p mcp-compressor-core
+
+      - name: Compile Rust core unit-test targets without running intentional TODO tests
+        run: cargo test -p mcp-compressor-core --lib --no-run
+
+      - name: Compile Rust core integration contracts without running intentional TODO tests
+        run: cargo test -p mcp-compressor-core --tests --no-run
+
   check-docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- add a compile-only Rust core CI job
- run cargo check for the Rust core crate
- compile Rust unit-test and integration-contract targets with --no-run so intentional TODO tests are not executed yet

## Validation
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core --lib --no-run
- cargo test -p mcp-compressor-core --tests --no-run

## Notes
This is intentionally not full Rust test execution yet. The Rust core currently has TDD/contract tests that compile but intentionally fail at todo!() runtime boundaries until implementation work catches up.