### PR TITLE
Implement Rust compression core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 serde      = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 thiserror  = "1"
 rand       = "0.8"
 tokio      = { version = "1", features = ["sync"] }

--- a/crates/mcp-compressor-core/src/compression/engine.rs
+++ b/crates/mcp-compressor-core/src/compression/engine.rs
@@ -38,12 +38,20 @@ impl Tool {
         description: impl Into<Option<String>>,
         input_schema: serde_json::Value,
     ) -> Self {
-        Self { name: name.into(), description: description.into(), input_schema }
+        Self {
+            name: name.into(),
+            description: description.into(),
+            input_schema,
+        }
     }
 
     /// Return the ordered list of parameter names from `input_schema.properties`.
     pub fn param_names(&self) -> Vec<String> {
-        todo!()
+        self.input_schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+            .map(|properties| properties.keys().cloned().collect())
+            .unwrap_or_default()
     }
 }
 
@@ -58,7 +66,7 @@ pub struct CompressionEngine {
 
 impl CompressionEngine {
     pub fn new(level: CompressionLevel) -> Self {
-        todo!()
+        Self { level }
     }
 
     /// Format the listing of *all* tools at the engine's compression level.
@@ -67,21 +75,29 @@ impl CompressionEngine {
     /// a `list_tools` MCP tool instead.
     /// Otherwise joins individual [`format_tool`] results with `"\n"`.
     pub fn format_listing(&self, tools: &[Tool]) -> String {
-        todo!()
+        if self.level == CompressionLevel::Max {
+            return String::new();
+        }
+
+        tools
+            .iter()
+            .map(|tool| self.format_tool(tool))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Format a *single* tool at the engine's compression level.
     ///
     /// See module-level doc for the format rules.
     pub fn format_tool(&self, tool: &Tool) -> String {
-        todo!()
+        format_tool_at_level(tool, &self.level)
     }
 
     /// Look up a tool by name in the provided slice.
     ///
     /// Returns `None` when the name is not found.
     pub fn get_schema<'a>(&self, tools: &'a [Tool], name: &str) -> Option<&'a Tool> {
-        todo!()
+        tools.iter().find(|tool| tool.name == name)
     }
 
     /// Build the full schema response string for a tool.
@@ -100,8 +116,38 @@ impl CompressionEngine {
     /// }
     /// ```
     pub fn format_schema_response(tool: &Tool) -> String {
-        todo!()
+        let tool_description = format_tool_at_level(tool, &CompressionLevel::Low);
+        let schema = serde_json::to_string_pretty(&tool.input_schema)
+            .unwrap_or_else(|_| tool.input_schema.to_string());
+        format!("{tool_description}\n\n{schema}")
     }
+}
+
+fn format_tool_at_level(tool: &Tool, level: &CompressionLevel) -> String {
+    match level {
+        CompressionLevel::Max => format!("<tool>{}</tool>", tool.name),
+        CompressionLevel::High => format!("<tool>{}({})</tool>", tool.name, format_args(tool)),
+        CompressionLevel::Medium => format_with_description(tool, first_sentence_description(tool)),
+        CompressionLevel::Low => format_with_description(tool, tool.description.as_deref()),
+    }
+}
+
+fn format_with_description(tool: &Tool, description: Option<&str>) -> String {
+    let signature = format!("{}({})", tool.name, format_args(tool));
+    match description.map(str::trim).filter(|description| !description.is_empty()) {
+        Some(description) => format!("<tool>{signature}: {description}</tool>"),
+        None => format!("<tool>{signature}</tool>"),
+    }
+}
+
+fn format_args(tool: &Tool) -> String {
+    tool.param_names().join(", ")
+}
+
+fn first_sentence_description(tool: &Tool) -> Option<&str> {
+    let description = tool.description.as_deref()?;
+    let first_line = description.lines().next().unwrap_or_default();
+    Some(first_line.split('.').next().unwrap_or_default().trim())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/mcp-compressor-core/src/compression/levels.rs
+++ b/crates/mcp-compressor-core/src/compression/levels.rs
@@ -29,7 +29,13 @@ pub enum CompressionLevel {
 
 impl fmt::Display for CompressionLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+        let value = match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Max => "max",
+        };
+        f.write_str(value)
     }
 }
 
@@ -37,7 +43,13 @@ impl FromStr for CompressionLevel {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        todo!()
+        match s.trim().to_ascii_lowercase().as_str() {
+            "low" => Ok(Self::Low),
+            "medium" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "max" => Ok(Self::Max),
+            _ => Err(Error::UnknownCompressionLevel(s.to_string())),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- implement CompressionLevel Display and FromStr behavior
- implement pure CompressionEngine formatting for low/medium/high/max
- implement schema lookup, full schema response formatting, and parameter extraction
- enable serde_json preserve_order so JSON Schema property order is retained for parameter listings

## Validation
- cargo test -p mcp-compressor-core compression:: -- --nocapture
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core --lib --no-run
- cargo test -p mcp-compressor-core --tests --no-run

## Notes
This PR intentionally stays in the pure compression layer and does not touch rmcp/runtime integration. Runtime contract tests remain compile-only until those TODOs are implemented.