### PR TITLE
Add Rust core CLI executable contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +21,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "async-trait"
@@ -51,6 +81,17 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -161,6 +202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +251,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -655,6 +711,8 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "mcp-compressor-core"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
+ "predicates",
  "rand 0.8.6",
  "rmcp",
  "serde",
@@ -692,6 +750,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
@@ -742,6 +806,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -858,6 +952,35 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1152,6 +1275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1502,15 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -16,3 +16,6 @@ rmcp       = { version = "1.6.0", features = ["client", "server", "transport-chi
 tokio    = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 # temporary directories for client_gen file-generation tests
 tempfile = "3"
+# binary e2e contract tests
+assert_cmd = "2"
+predicates = "3"

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -1,0 +1,72 @@
+//! CLI entrypoint for the standalone Rust mcp-compressor core binary.
+//!
+//! This binary is intentionally present before the runtime implementation so
+//! executable-level e2e contracts can compile and describe the intended CLI
+//! surface. Runtime behavior remains TODO until the Rust core server/proxy is
+//! implemented.
+
+use std::process::ExitCode;
+
+const HELP: &str = "mcp-compressor-core\n\nUSAGE:\n    mcp-compressor-core [OPTIONS] [-- <COMMAND>...]\n\nOPTIONS:\n    --help                      Print help\n    --compression <LEVEL>       low | medium | high | max\n    --config <PATH>             MCP config JSON file\n    --server-name <NAME>        Frontend server name/prefix\n    --transport <TYPE>          stdio | streamable-http\n    --transform-mode <MODE>     compressed-tools | cli | just-bash\n    --cli-mode                  Alias for --transform-mode cli\n    --just-bash                 Alias for --transform-mode just-bash\n";
+
+fn main() -> ExitCode {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        println!("{HELP}");
+        return ExitCode::SUCCESS;
+    }
+
+    if let Err(message) = validate_args(&args) {
+        eprintln!("error: {message}\n\n{HELP}");
+        return ExitCode::from(2);
+    }
+
+    todo!("standalone Rust CLI runtime is not implemented yet")
+}
+
+fn validate_args(args: &[String]) -> Result<(), String> {
+    let mut passthrough = false;
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if passthrough {
+            index += 1;
+            continue;
+        }
+
+        match arg.as_str() {
+            "--" => {
+                passthrough = true;
+                index += 1;
+            }
+            "--compression" => {
+                let level = args
+                    .get(index + 1)
+                    .ok_or_else(|| "--compression requires a value".to_string())?;
+                match level.as_str() {
+                    "low" | "medium" | "high" | "max" => {}
+                    _ => return Err(format!("unknown compression level: {level}")),
+                }
+                index += 2;
+            }
+            "--config" | "--server-name" | "--transport" | "--transform-mode" => {
+                if args.get(index + 1).is_none() {
+                    return Err(format!("{arg} requires a value"));
+                }
+                index += 2;
+            }
+            "--cli-mode" | "--just-bash" => {
+                index += 1;
+            }
+            option if option.starts_with('-') => return Err(format!("unknown option: {option}")),
+            _ => {
+                passthrough = true;
+                index += 1;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -1,0 +1,146 @@
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn core_cmd() -> Command {
+    Command::cargo_bin("mcp-compressor-core").unwrap()
+}
+
+#[test]
+fn rust_cli_help_describes_supported_modes() {
+    let mut cmd = core_cmd();
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--compression <LEVEL>"))
+        .stdout(predicate::str::contains("--config <PATH>"))
+        .stdout(predicate::str::contains("--transform-mode <MODE>"))
+        .stdout(predicate::str::contains("--cli-mode"))
+        .stdout(predicate::str::contains("--just-bash"));
+}
+
+#[test]
+fn rust_cli_invalid_compression_level_exits_nonzero() {
+    let mut cmd = core_cmd();
+    cmd.args(["--compression", "verbose"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("unknown compression level: verbose"));
+}
+
+#[test]
+fn rust_cli_contract_single_server_direct_command_all_compression_levels() {
+    for level in ["low", "medium", "high", "max"] {
+        let mut cmd = core_cmd();
+        cmd.args([
+            "--compression",
+            level,
+            "--server-name",
+            "alpha",
+            "--",
+            &common::python_command(),
+            common::fixture_path("alpha_server.py").to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("alpha_get_tool_schema"))
+        .stdout(predicate::str::contains("alpha_invoke_tool"));
+    }
+}
+
+#[test]
+fn rust_cli_contract_single_server_json_config() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config_path = tempdir.path().join("mcp.json");
+    std::fs::write(
+        &config_path,
+        common::mcp_config_json(&[("alpha", "alpha_server.py")]),
+    )
+    .unwrap();
+
+    let mut cmd = core_cmd();
+    cmd.args([
+        "--compression",
+        "max",
+        "--config",
+        config_path.to_str().unwrap(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("get_tool_schema"))
+    .stdout(predicate::str::contains("invoke_tool"))
+    .stdout(predicate::str::contains("list_tools"));
+}
+
+#[test]
+fn rust_cli_contract_multi_server_json_config() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config_path = tempdir.path().join("mcp.json");
+    std::fs::write(
+        &config_path,
+        common::mcp_config_json(&[
+            ("alpha", "alpha_server.py"),
+            ("beta", "beta_server.py"),
+        ]),
+    )
+    .unwrap();
+
+    let mut cmd = core_cmd();
+    cmd.args([
+        "--compression",
+        "max",
+        "--server-name",
+        "suite",
+        "--config",
+        config_path.to_str().unwrap(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("suite_alpha_invoke_tool"))
+    .stdout(predicate::str::contains("suite_beta_invoke_tool"));
+}
+
+#[test]
+fn rust_cli_contract_cli_transform_mode() {
+    let mut cmd = core_cmd();
+    cmd.args([
+        "--transform-mode",
+        "cli",
+        "--server-name",
+        "alpha",
+        "--",
+        &common::python_command(),
+        common::fixture_path("alpha_server.py").to_str().unwrap(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("alpha_help"));
+}
+
+#[test]
+fn rust_cli_contract_just_bash_transform_mode_multi_server() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config_path = tempdir.path().join("mcp.json");
+    std::fs::write(
+        &config_path,
+        common::mcp_config_json(&[
+            ("alpha", "alpha_server.py"),
+            ("beta", "beta_server.py"),
+        ]),
+    )
+    .unwrap();
+
+    let mut cmd = core_cmd();
+    cmd.args([
+        "--just-bash",
+        "--config",
+        config_path.to_str().unwrap(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("bash_tool"))
+    .stdout(predicate::str::contains("alpha_help"))
+    .stdout(predicate::str::contains("beta_help"));
+}

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -6,7 +6,7 @@
 
 ## Goals
 
-Move core behavior into a shared Rust library, while keeping thin, idiomatic wrappers for Python and TypeScript.
+Move core behavior into a shared Rust library and first-class Rust CLI binary, while keeping thin, idiomatic wrappers for Python and TypeScript.
 
 For both language packages, preserve support for:
 
@@ -120,8 +120,9 @@ Build the full Rust implementation as a standalone crate with no dependency on t
 
 - `CompressedServer` — MCP client connection, `ToolCache`, `CompressionEngine`, stdio and streamable HTTP transports
 - `ToolProxyServer` — generic HTTP proxy with bearer token auth and `POST /exec` dispatch
+- First-class Rust CLI binary — directly usable without Python/TypeScript wrappers for normal compression mode, CLI mode, Just Bash mode, config-file input, and direct command input
 - All client generators: `CliGenerator`, `PythonGenerator`, `TypeScriptGenerator`
-- Self-contained Rust test suite covering compression, proxy, and auth behaviour
+- Self-contained Rust test suite covering compression, proxy, auth behaviour, and CLI executable e2e behaviour
 
 ### Phase 2 — Language bindings (independent build)
 
@@ -608,6 +609,7 @@ Because each bridge entry now carries its own token, generated artifacts from di
 crates/mcp-compressor-core/
 └── src/
     ├── lib.rs                   # public re-exports; crate feature flags
+    ├── main.rs                  # Rust CLI binary entrypoint
     ├── compression/
     │   ├── mod.rs
     │   ├── engine.rs            # tool listing compression for low|medium|high|max
@@ -671,6 +673,32 @@ mcp_compressor/
 
 `CliBridge` and `cli_script.py` are superseded by `proxy/server.py` and `client_gen/cli.py` respectively.
 The public CLI flags (`--cli-mode`, `--cli-port`) and all existing behaviour are preserved.
+
+#### Rust CLI binary
+
+The Rust core crate should also ship a directly usable CLI executable. This binary is not just a development harness; it is a supported entrypoint for users who want the Rust implementation without the Python or TypeScript wrappers.
+
+The Rust CLI should support the same high-level modes as the wrappers:
+
+- normal compressed MCP server mode
+- CLI mode / generated-client proxy mode
+- Just Bash mode
+- single-server direct command input, e.g. `mcp-compressor-core -- uvx mcp-server-fetch`
+- single-server and multi-server MCP config JSON input
+- stdio and streamable HTTP frontend transports where applicable
+
+The Rust CLI e2e test suite should invoke the compiled binary with real fixture MCP servers and assert observable behavior, including:
+
+- `--help` and invalid-argument output
+- all compression levels
+- all proxy transform modes
+- single-server direct command config
+- single-server JSON config
+- multi-server JSON config
+- expected wrapper tool names and tool invocation output
+- resources/prompts passthrough once the runtime supports them
+
+These tests are distinct from library-level Rust integration tests. Library tests prove the Rust API works; CLI e2e tests prove the packaged executable, argument parsing, process lifecycle, stdout/stderr behavior, and exit codes work.
 
 #### TypeScript package (`typescript/`)
 


### PR DESCRIPTION
## Summary
- update the Rust core design to require a first-class standalone Rust CLI binary
- add a minimal CLI binary placeholder exposing help/argument validation and TODO runtime boundary
- add CLI executable e2e contract tests for help, invalid args, compression levels, transform modes, and single/multi-server config paths

## Validation
- cargo test -p mcp-compressor-core --tests --no-run
- cargo test -p mcp-compressor-core --test cli_binary rust_cli_help_describes_supported_modes
- cargo test -p mcp-compressor-core --test cli_binary rust_cli_invalid_compression_level_exits_nonzero
- cargo check -p mcp-compressor-core

## Notes
Most CLI e2e contracts intentionally remain runtime contracts: they compile now and will fail at the CLI TODO boundary until the Rust runtime is implemented. The help and invalid-argument smoke tests pass now to validate the binary plumbing.