### PR TITLE
Implement Rust tool proxy runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +520,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -708,10 +767,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "mcp-compressor-core"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "axum",
  "predicates",
  "rand 0.8.6",
  "rmcp",
@@ -727,6 +793,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1082,6 +1154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1244,29 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1395,6 +1496,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1433,6 +1535,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -10,6 +10,7 @@ thiserror  = "1"
 rand       = "0.8"
 tokio      = { version = "1", features = ["sync"] }
 rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
+axum       = "0.8"
 
 [dev-dependencies]
 # async test runtime and macros (#[tokio::test])

--- a/crates/mcp-compressor-core/src/proxy/server.rs
+++ b/crates/mcp-compressor-core/src/proxy/server.rs
@@ -2,10 +2,18 @@
 //!
 //! Binds to `127.0.0.1:<port>` (random free port by default), generates a
 //! `SessionToken` at startup, and routes `/health` and `/exec` requests.
-//!
-//! This module intentionally exposes the API that integration tests and client
-//! generators should target. Method bodies remain `todo!()` until the Phase 1
-//! proxy implementation is built.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::net::TcpListener;
 
 use crate::proxy::auth::SessionToken;
 use crate::server::compressed::CompressedServer;
@@ -20,10 +28,99 @@ pub struct RunningToolProxy {
     token: SessionToken,
 }
 
+#[derive(Clone)]
+struct ProxyState {
+    server: Arc<CompressedServer>,
+    token: SessionToken,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExecRequest {
+    tool: String,
+    #[serde(default)]
+    input: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct WrapperInvokeInput {
+    tool_name: String,
+    #[serde(default)]
+    tool_input: Value,
+}
+
 impl ToolProxyServer {
-    pub async fn start(_server: CompressedServer) -> Result<RunningToolProxy, Error> {
-        todo!()
+    pub async fn start(server: CompressedServer) -> Result<RunningToolProxy, Error> {
+        let token = SessionToken::generate();
+        let state = ProxyState {
+            server: Arc::new(server),
+            token: token.clone(),
+        };
+
+        let app = Router::new()
+            .route("/health", get(health))
+            .route("/exec", post(exec))
+            .with_state(state);
+
+        let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move {
+            if let Err(error) = axum::serve(listener, app).await {
+                eprintln!("mcp-compressor proxy server error: {error}");
+            }
+        });
+
+        Ok(RunningToolProxy {
+            bridge_url: format!("http://{addr}"),
+            token,
+        })
     }
+}
+
+async fn health() -> Response {
+    close_response(StatusCode::OK, "ok")
+}
+
+async fn exec(
+    State(state): State<ProxyState>,
+    headers: HeaderMap,
+    Json(request): Json<ExecRequest>,
+) -> Response {
+    if !authorized(&state.token, &headers) {
+        return close_response(StatusCode::UNAUTHORIZED, "unauthorized");
+    }
+
+    match dispatch_exec(&state.server, request).await {
+        Ok(result) => close_response(StatusCode::OK, result),
+        Err(error) => close_response(StatusCode::BAD_REQUEST, error.to_string()),
+    }
+}
+
+fn close_response(status: StatusCode, body: impl Into<String>) -> Response {
+    let mut response = (status, body.into()).into_response();
+    response
+        .headers_mut()
+        .insert(header::CONNECTION, header::HeaderValue::from_static("close"));
+    response
+}
+
+async fn dispatch_exec(server: &CompressedServer, request: ExecRequest) -> Result<String, Error> {
+    if request.tool.ends_with("_invoke_tool") || request.tool == "invoke_tool" {
+        let wrapper_input: WrapperInvokeInput = serde_json::from_value(request.input)?;
+        server
+            .invoke_tool(&request.tool, &wrapper_input.tool_name, wrapper_input.tool_input)
+            .await
+    } else {
+        server
+            .invoke_single_backend_tool(&request.tool, request.input)
+            .await
+    }
+}
+
+fn authorized(token: &SessionToken, headers: &HeaderMap) -> bool {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|header| token.verify(header))
 }
 
 impl RunningToolProxy {

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -263,20 +263,7 @@ impl CompressedServer {
         tool_input: Value,
     ) -> Result<String, Error> {
         let backend = self.backend_for_wrapper(_wrapper_tool_name)?;
-        let arguments = match tool_input {
-            Value::Object(map) => Some(map),
-            _ => None,
-        };
-        let mut params = CallToolRequestParams::new(backend_tool_name.to_string());
-        if let Some(arguments) = arguments {
-            params = params.with_arguments(arguments);
-        }
-        let result = backend
-            .client
-            .call_tool(params)
-            .await
-            .map_err(|error| Error::Config(error.to_string()))?;
-        Ok(call_tool_result_to_string(result))
+        self.invoke_backend(backend, backend_tool_name, tool_input).await
     }
 
     /// List frontend resources, including pass-through backend resources and
@@ -320,6 +307,45 @@ impl CompressedServer {
             .iter()
             .flat_map(|backend| backend.prompts.clone())
             .collect())
+    }
+
+    /// Invoke a backend tool directly when the runtime has exactly one backend.
+    ///
+    /// This is used by generated proxy clients, which call `/exec` with the
+    /// backend tool name directly rather than the MCP wrapper tool name.
+    pub async fn invoke_single_backend_tool(
+        &self,
+        backend_tool_name: &str,
+        tool_input: Value,
+    ) -> Result<String, Error> {
+        let backend = self
+            .backends
+            .first()
+            .filter(|_| self.backends.len() == 1)
+            .ok_or_else(|| Error::ToolNotFound(backend_tool_name.to_string()))?;
+        self.invoke_backend(backend, backend_tool_name, tool_input).await
+    }
+
+    async fn invoke_backend(
+        &self,
+        backend: &ConnectedBackend,
+        backend_tool_name: &str,
+        tool_input: Value,
+    ) -> Result<String, Error> {
+        let arguments = match tool_input {
+            Value::Object(map) => Some(map),
+            _ => None,
+        };
+        let mut params = CallToolRequestParams::new(backend_tool_name.to_string());
+        if let Some(arguments) = arguments {
+            params = params.with_arguments(arguments);
+        }
+        let result = backend
+            .client
+            .call_tool(params)
+            .await
+            .map_err(|error| Error::Config(error.to_string()))?;
+        Ok(call_tool_result_to_string(result))
     }
 
     fn wrapper_prefix(&self, backend: &ConnectedBackend) -> String {

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -36,7 +36,7 @@ async fn running_proxy_config(output_dir: &std::path::Path) -> GeneratorConfig {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_cli_script_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let config = running_proxy_config(tempdir.path()).await;
@@ -62,7 +62,7 @@ async fn generated_cli_script_invokes_real_proxy_and_backend() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_python_module_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let config = running_proxy_config(tempdir.path()).await;
@@ -86,7 +86,7 @@ async fn generated_python_module_invokes_real_proxy_and_backend() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_typescript_module_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let config = running_proxy_config(tempdir.path()).await;

--- a/crates/mcp-compressor-core/tests/proxy_http.rs
+++ b/crates/mcp-compressor-core/tests/proxy_http.rs
@@ -57,7 +57,7 @@ fn send_raw_http(method: &str, url: &str, auth: Option<&str>, body: Option<&str>
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn proxy_health_is_public_and_exec_requires_bearer_token() {
     let compressed = CompressedServer::connect_stdio(
         common::max_config(Some("alpha")),
@@ -82,7 +82,7 @@ async fn proxy_health_is_public_and_exec_requires_bearer_token() {
     assert_eq!(wrong_auth.status, 401);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn proxy_exec_dispatches_to_real_backend_with_session_token() {
     let compressed = CompressedServer::connect_stdio(
         common::max_config(Some("alpha")),


### PR DESCRIPTION
## Summary
- add axum-backed loopback HTTP proxy runtime
- implement ToolProxyServer::start with per-session bearer token and random localhost port
- add public /health and authenticated /exec routes
- support wrapper-style /exec payloads and generated-client direct tool payloads
- add CompressedServer::invoke_single_backend_tool for generated clients
- update proxy/generated-client e2e tests to use multi-threaded Tokio runtimes so blocking clients do not starve the proxy task

## Validation
- cargo test -p mcp-compressor-core --test proxy_http -- --nocapture
- cargo test -p mcp-compressor-core --test generated_clients -- --nocapture
- cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture
- cargo test -p mcp-compressor-core --test multi_server -- --nocapture
- cargo test -p mcp-compressor-core --test config_sources -- --nocapture
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core --lib --no-run
- cargo test -p mcp-compressor-core --tests --no-run

## Notes
This unlocks real generated shell/Python/TypeScript client execution through the Rust proxy against the fixture MCP server. Direct Rust CLI runtime and transform-mode-specific behavior remain follow-up work.