### PR TITLE
Serve Rust normal stdio MCP mode

### DIFF
--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -9,7 +9,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 thiserror  = "1"
 rand       = "0.8"
 tokio      = { version = "1", features = ["sync", "rt-multi-thread"] }
-rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
+rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
 axum       = "0.8"
 
 [dev-dependencies]

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -7,6 +7,7 @@ use mcp_compressor_core::client_gen::cli::CliGenerator;
 use mcp_compressor_core::client_gen::{ClientGenerator, GeneratorConfig};
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::proxy::ToolProxyServer;
+use mcp_compressor_core::server::registration::FrontendServer;
 use mcp_compressor_core::server::{
     BackendConfigSource, BackendServerConfig, CompressedServer, CompressedServerConfig,
     ProxyTransformMode,
@@ -96,13 +97,12 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
 }
 
 async fn run_compressed_listing(server: CompressedServer) -> Result<(), CliError> {
-    for tool in server
-        .list_frontend_tools()
+    rmcp::serve_server(FrontendServer::new(server), rmcp::transport::stdio())
         .await
         .map_err(|error| CliError::Runtime(error.to_string()))?
-    {
-        println!("{}", tool.name);
-    }
+        .waiting()
+        .await
+        .map_err(|error| CliError::Runtime(error.to_string()))?;
     Ok(())
 }
 

--- a/crates/mcp-compressor-core/src/server/registration.rs
+++ b/crates/mcp-compressor-core/src/server/registration.rs
@@ -1,4 +1,109 @@
-//! Tool registration helpers: attaches the 2–3 compression wrapper tools to
-//! the frontend MCP server.
+//! Frontend MCP server registration for compressed wrapper tools.
 
-// Stub — full implementation added in Phase 1 build.
+use std::sync::Arc;
+
+use rmcp::handler::server::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ErrorCode, InitializeResult, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData as McpError, RoleServer};
+use serde_json::{Map, Value};
+
+use crate::server::CompressedServer;
+
+/// Dynamic frontend MCP service that exposes compressed wrapper tools and
+/// delegates their calls to [`CompressedServer`].
+#[derive(Debug)]
+pub struct FrontendServer {
+    compressed: CompressedServer,
+}
+
+impl FrontendServer {
+    pub fn new(compressed: CompressedServer) -> Self {
+        Self { compressed }
+    }
+}
+
+impl ServerHandler for FrontendServer {
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("Compressed MCP frontend server")
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        let tools = self
+            .compressed
+            .list_frontend_tools()
+            .await
+            .map_err(mcp_error)?
+            .into_iter()
+            .map(convert_tool)
+            .collect();
+        Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let wrapper_name = request.name.to_string();
+        let arguments = request.arguments.unwrap_or_default();
+        let output = if wrapper_name.ends_with("get_tool_schema") {
+            let tool_name = required_string(&arguments, "tool_name")?;
+            self.compressed
+                .get_tool_schema(&wrapper_name, &tool_name)
+                .await
+        } else if wrapper_name.ends_with("invoke_tool") {
+            let tool_name = required_string(&arguments, "tool_name")?;
+            let tool_input = arguments
+                .get("tool_input")
+                .cloned()
+                .unwrap_or_else(|| Value::Object(Map::new()));
+            self.compressed
+                .invoke_tool(&wrapper_name, &tool_name, tool_input)
+                .await
+        } else if wrapper_name.ends_with("list_tools") {
+            self.compressed.list_backend_tools(&wrapper_name).await
+        } else {
+            Err(crate::Error::ToolNotFound(wrapper_name))
+        }
+        .map_err(mcp_error)?;
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    fn get_tool(&self, _name: &str) -> Option<Tool> {
+        None
+    }
+}
+
+fn convert_tool(tool: crate::compression::engine::Tool) -> Tool {
+    let input_schema = match tool.input_schema {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    };
+    Tool::new(
+        tool.name,
+        tool.description.unwrap_or_default(),
+        Arc::new(input_schema),
+    )
+}
+
+fn required_string(arguments: &Map<String, Value>, name: &str) -> Result<String, McpError> {
+    arguments
+        .get(name)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| McpError::new(ErrorCode::INVALID_PARAMS, format!("missing {name}"), None))
+}
+
+fn mcp_error(error: crate::Error) -> McpError {
+    McpError::new(ErrorCode::INTERNAL_ERROR, error.to_string(), None)
+}

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -35,6 +35,7 @@ fn rust_cli_invalid_compression_level_exits_nonzero() {
 }
 
 #[test]
+#[ignore = "normal mode is now a long-running stdio MCP server; covered by Python e2e"]
 fn rust_cli_contract_single_server_direct_command_all_compression_levels() {
     for level in ["low", "medium", "high", "max"] {
         let mut cmd = core_cmd();
@@ -55,6 +56,7 @@ fn rust_cli_contract_single_server_direct_command_all_compression_levels() {
 }
 
 #[test]
+#[ignore = "normal mode is now a long-running stdio MCP server; covered by Python e2e"]
 fn rust_cli_contract_single_server_json_config() {
     let tempdir = tempfile::tempdir().unwrap();
     let config_path = tempdir.path().join("mcp.json");
@@ -79,6 +81,7 @@ fn rust_cli_contract_single_server_json_config() {
 }
 
 #[test]
+#[ignore = "normal mode is now a long-running stdio MCP server; covered by Python e2e"]
 fn rust_cli_contract_multi_server_json_config() {
     let tempdir = tempfile::tempdir().unwrap();
     let config_path = tempdir.path().join("mcp.json");

--- a/tests/test_rust_core_normal_mode.py
+++ b/tests/test_rust_core_normal_mode.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+
+async def test_rust_core_normal_stdio_mode_with_fixture_server() -> None:
+    root = Path(__file__).parents[1]
+    alpha = root / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
+    command = [
+        "cargo",
+        "run",
+        "-q",
+        "-p",
+        "mcp-compressor-core",
+        "--",
+        "--compression",
+        "max",
+        "--server-name",
+        "alpha",
+        "--",
+        "python3",
+        str(alpha),
+    ]
+
+    async with Client(StdioTransport(command=command[0], args=command[1:])) as client:
+        tools = {tool.name for tool in await client.list_tools()}
+        assert tools == {
+            "alpha_get_tool_schema",
+            "alpha_invoke_tool",
+            "alpha_list_tools",
+        }
+
+        result = await client.call_tool(
+            "alpha_invoke_tool",
+            {
+                "tool_name": "echo",
+                "tool_input": {"message": "hello"},
+            },
+        )
+        assert result.content[0].text == "alpha:hello"
+
+        schema = await client.call_tool(
+            "alpha_get_tool_schema",
+            {"tool_name": "echo"},
+        )
+        assert "echo" in schema.content[0].text
+        assert "message" in schema.content[0].text
+
+        listed = await client.call_tool("alpha_list_tools", {})
+        assert "echo" in listed.content[0].text
+        assert "add" in listed.content[0].text


### PR DESCRIPTION
## Summary
- implement a dynamic rmcp ServerHandler frontend for compressed wrapper tools
- wire normal Rust CLI mode to serve MCP over stdio instead of printing a one-shot listing
- enable rmcp transport-io for stdio server transport
- add Python/FastMCP e2e coverage that connects to the Rust binary as an MCP server and invokes the fixture backend through compressed wrappers
- mark stale one-shot normal-mode CLI binary contracts ignored now that normal mode is a long-running MCP server

## Validation
- uv run pytest -q tests/test_rust_core_normal_mode.py
- cargo test -p mcp-compressor-core --test cli_binary -- --nocapture
- cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core --tests --no-run

## Notes
This implements normal stdio MCP frontend mode for compressed tools. Streamable HTTP frontend, resource/prompt frontend handlers, and Just Bash remain follow-up work.