### PR TITLE
Support prompt get in Rust normal mode

### DIFF
--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -10,7 +10,8 @@ use std::net::SocketAddr;
 use std::process::Stdio;
 
 use rmcp::model::{
-    CallToolRequestParams, Content, RawContent, ReadResourceRequestParams, ResourceContents,
+    CallToolRequestParams, Content, GetPromptRequestParams, GetPromptResult, Prompt, RawContent,
+    ReadResourceRequestParams, ResourceContents,
 };
 use rmcp::service::RunningService;
 use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
@@ -131,7 +132,7 @@ struct ConnectedBackend {
     client: RunningService<RoleClient, ()>,
     tools: Vec<Tool>,
     resources: Vec<String>,
-    prompts: Vec<String>,
+    prompts: Vec<Prompt>,
 }
 
 impl CompressedServer {
@@ -305,8 +306,30 @@ impl CompressedServer {
         Ok(self
             .backends
             .iter()
-            .flat_map(|backend| backend.prompts.clone())
+            .flat_map(|backend| backend.prompts.iter().map(|prompt| prompt.name.clone()))
             .collect())
+    }
+
+    /// Fetch a prompt from the backend that owns it.
+    pub async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<serde_json::Map<String, Value>>,
+    ) -> Result<GetPromptResult, Error> {
+        let backend = self
+            .backends
+            .iter()
+            .find(|backend| backend.prompts.iter().any(|prompt| prompt.name == name))
+            .ok_or_else(|| Error::ToolNotFound(name.to_string()))?;
+        let mut request = GetPromptRequestParams::new(name);
+        if let Some(arguments) = arguments {
+            request = request.with_arguments(arguments);
+        }
+        backend
+            .client
+            .get_prompt(request)
+            .await
+            .map_err(|error| Error::Config(error.to_string()))
     }
 
     /// Return backend tools when the runtime has exactly one backend.
@@ -412,11 +435,7 @@ async fn connect_backend(
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    let prompts = client
-        .list_all_prompts()
-        .await
-        .map(|prompts| prompts.into_iter().map(|prompt| prompt.name).collect::<Vec<_>>())
-        .unwrap_or_default();
+    let prompts = client.list_all_prompts().await.unwrap_or_default();
 
     Ok(ConnectedBackend {
         public_name,

--- a/crates/mcp-compressor-core/src/server/registration.rs
+++ b/crates/mcp-compressor-core/src/server/registration.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
-    Annotated, CallToolRequestParams, CallToolResult, Content, ErrorCode, InitializeResult,
-    ListPromptsResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams, Prompt,
+    Annotated, CallToolRequestParams, CallToolResult, Content, ErrorCode, GetPromptRequestParams,
+    GetPromptResult, InitializeResult, ListPromptsResult, ListResourcesResult, ListToolsResult,
+    PaginatedRequestParams, Prompt,
     RawResource, ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents,
     ServerCapabilities, Tool,
 };
@@ -132,6 +133,17 @@ impl ServerHandler for FrontendServer {
             .map(|name| Prompt::new(name, Option::<String>::None, None))
             .collect();
         Ok(ListPromptsResult::with_all_items(prompts))
+    }
+
+    async fn get_prompt(
+        &self,
+        request: GetPromptRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        self.compressed
+            .get_prompt(&request.name, request.arguments)
+            .await
+            .map_err(mcp_error)
     }
 
     fn get_tool(&self, _name: &str) -> Option<Tool> {

--- a/tests/test_rust_core_normal_mode.py
+++ b/tests/test_rust_core_normal_mode.py
@@ -66,3 +66,6 @@ async def test_rust_core_normal_stdio_mode_with_fixture_server() -> None:
 
         prompts = {prompt.name for prompt in await client.list_prompts()}
         assert "alpha_prompt" in prompts
+
+        prompt = await client.get_prompt("alpha_prompt")
+        assert prompt.messages[0].content.text == "alpha prompt"


### PR DESCRIPTION
## Summary
- keep full rmcp Prompt metadata in CompressedServer instead of only prompt names
- add CompressedServer::get_prompt passthrough to the owning backend
- implement frontend prompts/get in the Rust normal-mode MCP server
- extend the FastMCP normal-mode e2e to call alpha_prompt and assert returned prompt text

## Validation
- uv run pytest -q tests/test_rust_core_normal_mode.py
- cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture
- cargo test -p mcp-compressor-core --test cli_binary -- --nocapture
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core --tests --no-run