### PR TITLE
Cover Rust normal mode multi-server configs

### DIFF
--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -65,17 +65,25 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
         exclude_tools: Vec::new(),
         toonify: false,
         transform_mode: cli.transform_mode,
-        config_source: if cli.config_path.is_some() {
-            BackendConfigSource::SingleServerJsonConfig
-        } else {
-            BackendConfigSource::Command
-        },
+        config_source: BackendConfigSource::Command,
     };
 
     if let Some(config_path) = &cli.config_path {
         let json = std::fs::read_to_string(config_path)
             .map_err(|error| CliError::Runtime(error.to_string()))?;
+        let mut config = config;
+        let parsed = mcp_compressor_core::config::topology::MCPConfig::from_json(&json)
+            .map_err(|error| CliError::Runtime(error.to_string()))?;
+        config.config_source = if parsed.server_names().len() == 1 {
+            BackendConfigSource::SingleServerJsonConfig
+        } else {
+            BackendConfigSource::MultiServerJsonConfig
+        };
         CompressedServer::connect_mcp_config_json(config, &json)
+            .await
+            .map_err(|error| CliError::Runtime(error.to_string()))
+    } else if !cli.multi_servers.is_empty() {
+        CompressedServer::connect_multi_stdio(config, cli.multi_servers.clone())
             .await
             .map_err(|error| CliError::Runtime(error.to_string()))
     } else {
@@ -210,6 +218,7 @@ struct CliOptions {
     server_name: Option<String>,
     transform_mode: ProxyTransformMode,
     command: Vec<String>,
+    multi_servers: Vec<BackendServerConfig>,
 }
 
 impl CliOptions {
@@ -220,6 +229,7 @@ impl CliOptions {
             server_name: None,
             transform_mode: ProxyTransformMode::CompressedTools,
             command: Vec::new(),
+            multi_servers: Vec::new(),
         };
         let mut index = 0;
         while index < args.len() {
@@ -242,6 +252,11 @@ impl CliOptions {
                 "--server-name" => {
                     options.server_name = Some(required_value(args, index, "--server-name")?);
                     index += 2;
+                }
+                "--multi-server" => {
+                    let (backend, next_index) = parse_multi_server(args, index)?;
+                    options.multi_servers.push(backend);
+                    index = next_index;
                 }
                 "--transport" => {
                     let value = required_value(args, index, "--transport")?;
@@ -279,6 +294,32 @@ impl CliOptions {
         }
         Ok(options)
     }
+}
+
+fn parse_multi_server(
+    args: &[String],
+    index: usize,
+) -> Result<(BackendServerConfig, usize), CliError> {
+    let spec = required_value(args, index, "--multi-server")?;
+    let (name, command) = spec
+        .split_once('=')
+        .filter(|(name, command)| !name.is_empty() && !command.is_empty())
+        .ok_or_else(|| {
+            CliError::Usage("--multi-server requires <name=command> followed by args".to_string())
+        })?;
+    let mut next_index = index + 2;
+    let mut backend_args = Vec::new();
+    while next_index < args.len() {
+        if args[next_index] == "--multi-server" {
+            break;
+        }
+        backend_args.push(args[next_index].clone());
+        next_index += 1;
+    }
+    Ok((
+        BackendServerConfig::new(name.to_string(), command.to_string(), backend_args),
+        next_index,
+    ))
 }
 
 fn required_value(args: &[String], index: usize, flag: &str) -> Result<String, CliError> {

--- a/tests/test_rust_core_normal_mode.py
+++ b/tests/test_rust_core_normal_mode.py
@@ -1,21 +1,28 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from fastmcp import Client
 from fastmcp.client.transports import StdioTransport
 
 
-async def test_rust_core_normal_stdio_mode_with_fixture_server() -> None:
-    root = Path(__file__).parents[1]
-    alpha = root / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
-    command = [
+def rust_core_command(*args: str) -> list[str]:
+    return [
         "cargo",
         "run",
         "-q",
         "-p",
         "mcp-compressor-core",
         "--",
+        *args,
+    ]
+
+
+async def test_rust_core_normal_stdio_mode_with_fixture_server() -> None:
+    root = Path(__file__).parents[1]
+    alpha = root / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
+    command = rust_core_command(
         "--compression",
         "max",
         "--server-name",
@@ -23,7 +30,7 @@ async def test_rust_core_normal_stdio_mode_with_fixture_server() -> None:
         "--",
         "python3",
         str(alpha),
-    ]
+    )
 
     async with Client(StdioTransport(command=command[0], args=command[1:])) as client:
         tools = {tool.name for tool in await client.list_tools()}
@@ -69,3 +76,97 @@ async def test_rust_core_normal_stdio_mode_with_fixture_server() -> None:
 
         prompt = await client.get_prompt("alpha_prompt")
         assert prompt.messages[0].content.text == "alpha prompt"
+
+
+async def test_rust_core_normal_stdio_mode_with_multi_server_direct_config() -> None:
+    root = Path(__file__).parents[1]
+    fixture_dir = root / "crates" / "mcp-compressor-core" / "tests" / "fixtures"
+    alpha = fixture_dir / "alpha_server.py"
+    beta = fixture_dir / "beta_server.py"
+    command = rust_core_command(
+        "--compression",
+        "max",
+        "--server-name",
+        "suite",
+        "--multi-server",
+        "alpha=python3",
+        str(alpha),
+        "--multi-server",
+        "beta=python3",
+        str(beta),
+    )
+
+    async with Client(StdioTransport(command=command[0], args=command[1:])) as client:
+        tools = {tool.name for tool in await client.list_tools()}
+        assert tools == {
+            "suite_alpha_get_tool_schema",
+            "suite_alpha_invoke_tool",
+            "suite_alpha_list_tools",
+            "suite_beta_get_tool_schema",
+            "suite_beta_invoke_tool",
+            "suite_beta_list_tools",
+        }
+
+        alpha_result = await client.call_tool(
+            "suite_alpha_invoke_tool",
+            {"tool_name": "add", "tool_input": {"a": 3, "b": 7}},
+        )
+        assert alpha_result.content[0].text == "10"
+
+        beta_result = await client.call_tool(
+            "suite_beta_invoke_tool",
+            {"tool_name": "multiply", "tool_input": {"a": 4, "b": 5}},
+        )
+        assert beta_result.content[0].text == "20"
+
+        resources = {str(resource.uri) for resource in await client.list_resources()}
+        assert "fixture://alpha-resource" in resources
+        assert "fixture://beta-resource" in resources
+        assert "compressor://suite_alpha/uncompressed-tools" in resources
+        assert "compressor://suite_beta/uncompressed-tools" in resources
+
+        prompts = {prompt.name for prompt in await client.list_prompts()}
+        assert "alpha_prompt" in prompts
+        assert "beta_prompt" in prompts
+
+
+async def test_rust_core_normal_stdio_mode_with_json_config(tmp_path: Path) -> None:
+    root = Path(__file__).parents[1]
+    fixture_dir = root / "crates" / "mcp-compressor-core" / "tests" / "fixtures"
+    alpha = fixture_dir / "alpha_server.py"
+    beta = fixture_dir / "beta_server.py"
+    config = tmp_path / "mcp.json"
+    config.write_text(
+        json.dumps({
+            "mcpServers": {
+                "alpha": {"command": "python3", "args": [str(alpha)]},
+                "beta": {"command": "python3", "args": [str(beta)]},
+            }
+        }),
+        encoding="utf-8",
+    )
+    command = rust_core_command(
+        "--compression",
+        "max",
+        "--server-name",
+        "suite",
+        "--config",
+        str(config),
+    )
+
+    async with Client(StdioTransport(command=command[0], args=command[1:])) as client:
+        tools = {tool.name for tool in await client.list_tools()}
+        assert "suite_alpha_invoke_tool" in tools
+        assert "suite_beta_invoke_tool" in tools
+
+        alpha_result = await client.call_tool(
+            "suite_alpha_invoke_tool",
+            {"tool_name": "echo", "tool_input": {"message": "json"}},
+        )
+        assert alpha_result.content[0].text == "alpha:json"
+
+        beta_result = await client.call_tool(
+            "suite_beta_invoke_tool",
+            {"tool_name": "echo", "tool_input": {"message": "json"}},
+        )
+        assert beta_result.content[0].text == "beta:json"


### PR DESCRIPTION
## Summary
- add FastMCP e2e coverage for Rust normal stdio mode with multiple direct-configured backend servers
- add FastMCP e2e coverage for Rust normal stdio mode with multi-server MCP JSON config
- add minimal --multi-server <name=command> CLI parsing for direct multi-server normal-mode tests
- verify multi-server wrapper routing, resources, and prompt listing through a real MCP client

## Validation
- uv run pytest -q tests/test_rust_core_normal_mode.py
- cargo test -p mcp-compressor-core --test cli_binary -- --nocapture
- cargo test -p mcp-compressor-core --test multi_server -- --nocapture
- cargo test -p mcp-compressor-core --test config_sources -- --nocapture
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core --tests --no-run

## Notes
The --multi-server CLI syntax is intentionally minimal for local stdio fixtures; JSON config remains the stable multi-server input path.