### PR TITLE
Run Rust core test suite in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,13 +61,31 @@ jobs:
       - name: Set up the Python environment
         uses: ./.github/actions/setup-python-env
 
+      - name: Set up Bun for generated TypeScript client e2e
+        uses: oven-sh/setup-bun@v2
+
       - name: Check Rust core library
         run: cargo check -p mcp-compressor-core
 
-      - name: Compile Rust core unit-test targets without running intentional TODO tests
-        run: cargo test -p mcp-compressor-core --lib --no-run
+      - name: Run Rust core library tests
+        run: cargo test -p mcp-compressor-core --lib -- --nocapture
 
-      - name: Compile Rust core integration contracts without running intentional TODO tests
+      - name: Run Rust core integration tests
+        env:
+          PYTHON: ${{ github.workspace }}/.venv/bin/python3
+        run: |
+          cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture
+          cargo test -p mcp-compressor-core --test compression_levels -- --nocapture
+          cargo test -p mcp-compressor-core --test config_sources -- --nocapture
+          cargo test -p mcp-compressor-core --test multi_server -- --nocapture
+          cargo test -p mcp-compressor-core --test proxy_http -- --nocapture
+          cargo test -p mcp-compressor-core --test generated_clients -- --nocapture
+          cargo test -p mcp-compressor-core --test cli_binary -- --nocapture
+
+      - name: Run Rust binary normal-mode FastMCP e2e
+        run: uv run pytest -q tests/test_rust_core_normal_mode.py
+
+      - name: Compile all Rust core integration targets
         run: cargo test -p mcp-compressor-core --tests --no-run
 
   check-docs:


### PR DESCRIPTION
## Summary
- upgrade the Rust CI job from compile-only to executing the passing Rust core test suite
- run all Rust library tests
- run the Rust integration tests for stdio runtime, compression levels, config sources, multi-server routing, proxy runtime, generated clients, and CLI binary behavior
- run the FastMCP e2e that exercises the Rust binary in normal MCP mode
- keep a final --no-run compile pass for all integration targets

## Validation
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core --lib -- --nocapture
- cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture
- cargo test -p mcp-compressor-core --test compression_levels -- --nocapture
- cargo test -p mcp-compressor-core --test config_sources -- --nocapture
- cargo test -p mcp-compressor-core --test multi_server -- --nocapture
- cargo test -p mcp-compressor-core --test proxy_http -- --nocapture
- cargo test -p mcp-compressor-core --test generated_clients -- --nocapture
- cargo test -p mcp-compressor-core --test cli_binary -- --nocapture
- uv run pytest -q tests/test_rust_core_normal_mode.py
- cargo test -p mcp-compressor-core --tests --no-run