### PR TITLE
Support remote streamable HTTP backends

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check typing
         run: uv run ty check
 
-  rust-core-compile:
+  rust-core-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Check out

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -14,7 +14,7 @@ use rmcp::model::{
     ReadResourceRequestParams, ResourceContents,
 };
 use rmcp::service::RunningService;
-use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use rmcp::transport::{ConfigureCommandExt, StreamableHttpClientTransport, TokioChildProcess};
 use rmcp::{RoleClient, ServiceExt};
 use serde_json::Value;
 
@@ -23,13 +23,23 @@ use crate::compression::engine::{CompressionEngine, Tool};
 use crate::compression::CompressionLevel;
 use crate::Error;
 
-/// Configuration for one upstream MCP server process reached over stdio.
+/// Transport type used to reach an upstream MCP server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendTransport {
+    /// Spawn a local command and speak MCP over stdio.
+    Stdio,
+    /// Connect to a remote streamable HTTP MCP endpoint.
+    StreamableHttp,
+}
+
+/// Configuration for one upstream MCP server.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackendServerConfig {
     pub name: String,
     pub command: String,
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
+    pub transport: BackendTransport,
 }
 
 impl BackendServerConfig {
@@ -38,11 +48,18 @@ impl BackendServerConfig {
         command: impl Into<String>,
         args: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
+        let command = command.into();
+        let transport = if is_http_url(&command) {
+            BackendTransport::StreamableHttp
+        } else {
+            BackendTransport::Stdio
+        };
         Self {
             name: name.into(),
-            command: command.into(),
+            command,
             args: args.into_iter().map(Into::into).collect(),
             env: HashMap::new(),
+            transport,
         }
     }
 
@@ -403,21 +420,10 @@ async fn connect_backend(
     backend: BackendServerConfig,
     public_name: String,
 ) -> Result<ConnectedBackend, Error> {
-    let mut command = tokio::process::Command::new(&backend.command);
-    command
-        .args(&backend.args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped());
-    command.stderr(Stdio::inherit());
-    for (key, value) in &backend.env {
-        command.env(key, value);
-    }
-
-    let transport = TokioChildProcess::new(command.configure(|_| {})).map_err(Error::Io)?;
-    let client = ()
-        .serve(transport)
-        .await
-        .map_err(|error| Error::Config(error.to_string()))?;
+    let client = match backend.transport {
+        BackendTransport::Stdio => connect_stdio_backend(&backend).await?,
+        BackendTransport::StreamableHttp => connect_streamable_http_backend(&backend).await?,
+    };
 
     let rmcp_tools = client
         .list_all_tools()
@@ -444,6 +450,43 @@ async fn connect_backend(
         resources,
         prompts,
     })
+}
+
+async fn connect_stdio_backend(
+    backend: &BackendServerConfig,
+) -> Result<RunningService<RoleClient, ()>, Error> {
+    let mut command = tokio::process::Command::new(&backend.command);
+    command
+        .args(&backend.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped());
+    command.stderr(Stdio::inherit());
+    for (key, value) in &backend.env {
+        command.env(key, value);
+    }
+
+    let transport = TokioChildProcess::new(command.configure(|_| {})).map_err(Error::Io)?;
+    ().serve(transport)
+        .await
+        .map_err(|error| Error::Config(error.to_string()))
+}
+
+async fn connect_streamable_http_backend(
+    backend: &BackendServerConfig,
+) -> Result<RunningService<RoleClient, ()>, Error> {
+    if !backend.args.is_empty() {
+        return Err(Error::Config(
+            "streamable HTTP backend URLs do not accept command arguments".to_string(),
+        ));
+    }
+    let transport = StreamableHttpClientTransport::from_uri(backend.command.clone());
+    ().serve(transport)
+        .await
+        .map_err(|error| Error::Config(error.to_string()))
+}
+
+fn is_http_url(value: &str) -> bool {
+    value.starts_with("http://") || value.starts_with("https://")
 }
 
 fn convert_tool(tool: rmcp::model::Tool) -> Tool {

--- a/tests/test_rust_core_normal_mode.py
+++ b/tests/test_rust_core_normal_mode.py
@@ -183,6 +183,68 @@ async def test_rust_core_normal_streamable_http_mode_with_fixture_server() -> No
         process.wait(timeout=10)
 
 
+async def test_rust_core_normal_stdio_mode_with_remote_streamable_http_backend() -> None:
+    root = Path(__file__).parents[1]
+    alpha = root / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
+    upstream = rust_core_command(
+        "--compression",
+        "max",
+        "--server-name",
+        "upstream",
+        "--transport",
+        "streamable-http",
+        "--port",
+        "0",
+        "--",
+        "python3",
+        str(alpha),
+    )
+    process = subprocess.Popen(  # noqa: S603
+        upstream,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stderr is not None
+        deadline = time.monotonic() + 30
+        url = None
+        while time.monotonic() < deadline:
+            line = process.stderr.readline()
+            if "Streamable HTTP MCP server listening on " in line:
+                url = line.rsplit(" ", 1)[1].strip()
+                break
+            if process.poll() is not None:
+                raise AssertionError(f"upstream Rust server exited early with {process.returncode}")
+        assert url is not None
+
+        command = rust_core_command(
+            "--compression",
+            "max",
+            "--server-name",
+            "remote",
+            "--",
+            url,
+        )
+        async with Client(StdioTransport(command=command[0], args=command[1:])) as client:
+            tools = {tool.name for tool in await client.list_tools()}
+            assert tools == {
+                "remote_get_tool_schema",
+                "remote_invoke_tool",
+                "remote_list_tools",
+            }
+            result = await client.call_tool(
+                "remote_invoke_tool",
+                {
+                    "tool_name": "upstream_invoke_tool",
+                    "tool_input": {"tool_name": "echo", "tool_input": {"message": "remote"}},
+                },
+            )
+            assert result.content[0].text == "alpha:remote"
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+
+
 async def test_rust_core_normal_stdio_mode_with_json_config(tmp_path: Path) -> None:
     root = Path(__file__).parents[1]
     fixture_dir = root / "crates" / "mcp-compressor-core" / "tests" / "fixtures"


### PR DESCRIPTION
## Summary
- detect http:// and https:// backend commands and connect using rmcp StreamableHttpClientTransport
- keep stdio backend behavior unchanged
- add a normal-mode e2e that composes two Rust processes: one serving a fixture over streamable HTTP and one consuming that HTTP URL as a remote backend
- rename the Rust CI job from rust-core-compile to rust-core-tests

## Validation
- uv run pytest -q tests/test_rust_core_normal_mode.py
- uv run pytest -q tests/test_rust_core_normal_mode.py::test_rust_core_normal_stdio_mode_with_remote_streamable_http_backend
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture
- cargo test -p mcp-compressor-core --test proxy_http -- --nocapture
- cargo test -p mcp-compressor-core --tests --no-run

## Notes
This adds unauthenticated remote streamable HTTP backend support. OAuth/authenticated remote servers remain follow-up work.