### PR TITLE
Add remote backend auth headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +328,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -526,6 +551,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -812,6 +853,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdede44f9a69cab2899a2049e2c3bd49bf911a157f6a3353d4a91c61abbce44"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +903,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +963,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1068,15 +1176,19 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1148,6 +1260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1279,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "schemars"
@@ -1183,6 +1313,29 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1460,6 +1613,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1770,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"
@@ -2044,6 +2213,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -9,7 +9,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 thiserror  = "1"
 rand       = "0.8"
 tokio      = { version = "1", features = ["sync", "rt-multi-thread"] }
-rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
+rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest", "reqwest-native-tls"] }
 axum       = "0.8"
 
 [dev-dependencies]

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -85,7 +85,14 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
             .await
             .map_err(|error| CliError::Runtime(error.to_string()))
     } else if !cli.multi_servers.is_empty() {
-        CompressedServer::connect_multi_stdio(config, cli.multi_servers.clone())
+        CompressedServer::connect_multi_stdio(
+            config,
+            cli.multi_servers
+                .clone()
+                .into_iter()
+                .map(apply_backend_auth)
+                .collect(),
+        )
             .await
             .map_err(|error| CliError::Runtime(error.to_string()))
     } else {
@@ -99,7 +106,11 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
             .unwrap_or_else(|| "server".to_string());
         CompressedServer::connect_stdio(
             config,
-            BackendServerConfig::new(backend_name, command.clone(), args.to_vec()),
+            apply_backend_auth(BackendServerConfig::new(
+                backend_name,
+                command.clone(),
+                args.to_vec(),
+            )),
         )
         .await
         .map_err(|error| CliError::Runtime(error.to_string()))
@@ -341,6 +352,19 @@ impl CliOptions {
         }
         Ok(options)
     }
+}
+
+fn apply_backend_auth(mut backend: BackendServerConfig) -> BackendServerConfig {
+    if let Ok(headers) = std::env::var("MCP_COMPRESSOR_BACKEND_HEADER") {
+        backend = backend.with_headers(
+            headers
+                .split('\n')
+                .filter_map(|header| header.split_once(':'))
+                .map(|(name, value)| (name.trim().to_string(), value.trim().to_string()))
+                .filter(|(name, value)| !name.is_empty() && !value.is_empty()),
+        );
+    }
+    backend
 }
 
 fn parse_multi_server(

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -8,12 +8,15 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::process::Stdio;
+use std::str::FromStr;
 
+use axum::http::{HeaderName, HeaderValue};
 use rmcp::model::{
     CallToolRequestParams, Content, GetPromptRequestParams, GetPromptResult, Prompt, RawContent,
     ReadResourceRequestParams, ResourceContents,
 };
 use rmcp::service::RunningService;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use rmcp::transport::{ConfigureCommandExt, StreamableHttpClientTransport, TokioChildProcess};
 use rmcp::{RoleClient, ServiceExt};
 use serde_json::Value;
@@ -40,6 +43,7 @@ pub struct BackendServerConfig {
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
     pub transport: BackendTransport,
+    pub headers: HashMap<String, String>,
 }
 
 impl BackendServerConfig {
@@ -54,12 +58,19 @@ impl BackendServerConfig {
         } else {
             BackendTransport::Stdio
         };
+        let raw_args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+        let (args, headers) = if transport == BackendTransport::StreamableHttp {
+            parse_http_backend_args(raw_args)
+        } else {
+            (raw_args, HashMap::new())
+        };
         Self {
             name: name.into(),
             command,
-            args: args.into_iter().map(Into::into).collect(),
+            args,
             env: HashMap::new(),
             transport,
+            headers,
         }
     }
 
@@ -68,6 +79,16 @@ impl BackendServerConfig {
         env: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> Self {
         self.env = env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+    pub fn with_headers(
+        mut self,
+        headers: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.headers = headers
+            .into_iter()
+            .map(|(name, value)| (name.into(), value.into()))
+            .collect();
         self
     }
 }
@@ -479,10 +500,116 @@ async fn connect_streamable_http_backend(
             "streamable HTTP backend URLs do not accept command arguments".to_string(),
         ));
     }
-    let transport = StreamableHttpClientTransport::from_uri(backend.command.clone());
+    let mut config = StreamableHttpClientTransportConfig::with_uri(backend.command.clone());
+    let headers = backend_http_headers(backend)?;
+    if !headers.is_empty() {
+        config = config.custom_headers(headers);
+    }
+    let transport = StreamableHttpClientTransport::from_config(config);
     ().serve(transport)
         .await
-        .map_err(|error| Error::Config(error.to_string()))
+        .map_err(|error| remote_backend_error(&backend.command, error.to_string()))
+}
+
+fn parse_http_backend_args(args: Vec<String>) -> (Vec<String>, HashMap<String, String>) {
+    let mut remaining = Vec::new();
+    let mut headers = HashMap::new();
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "-H" || arg == "--header" {
+            if let Some(header) = args.get(index + 1) {
+                if let Some((name, value)) = parse_header_arg(header) {
+                    headers.insert(name, value);
+                } else {
+                    remaining.push(arg.clone());
+                    remaining.push(header.clone());
+                }
+                index += 2;
+            } else {
+                remaining.push(arg.clone());
+                index += 1;
+            }
+        } else if let Some(header) = arg.strip_prefix("-H=").or_else(|| arg.strip_prefix("--header=")) {
+            if let Some((name, value)) = parse_header_arg(header) {
+                headers.insert(name, value);
+            } else {
+                remaining.push(arg.clone());
+            }
+            index += 1;
+        } else {
+            remaining.push(arg.clone());
+            index += 1;
+        }
+    }
+    (remaining, headers)
+}
+
+fn parse_header_arg(header: &str) -> Option<(String, String)> {
+    let (name, value) = header
+        .split_once('=')
+        .or_else(|| header.split_once(':'))?;
+    let name = name.trim();
+    let value = value.trim();
+    if name.is_empty() || value.is_empty() {
+        return None;
+    }
+    Some((name.to_string(), interpolate_env(value)))
+}
+
+fn interpolate_env(value: &str) -> String {
+    let mut output = String::new();
+    let chars = value.chars().collect::<Vec<_>>();
+    let mut index = 0;
+    while index < chars.len() {
+        if chars[index] == '$' && chars.get(index + 1) == Some(&'{') {
+            if let Some(end) = chars[index + 2..].iter().position(|ch| *ch == '}') {
+                let name = chars[index + 2..index + 2 + end].iter().collect::<String>();
+                output.push_str(&std::env::var(&name).unwrap_or_else(|_| format!("${{{name}}}")));
+                index += end + 3;
+                continue;
+            }
+        }
+        output.push(chars[index]);
+        index += 1;
+    }
+    output
+}
+
+fn backend_http_headers(
+    backend: &BackendServerConfig,
+) -> Result<HashMap<HeaderName, HeaderValue>, Error> {
+    backend
+        .headers
+        .iter()
+        .map(|(name, value)| {
+            let name = HeaderName::from_str(name).map_err(|error| {
+                Error::Config(format!("invalid HTTP header name {name:?}: {error}"))
+            })?;
+            let value = HeaderValue::from_str(value).map_err(|error| {
+                Error::Config(format!("invalid HTTP header value for {name:?}: {error}"))
+            })?;
+            Ok((name, value))
+        })
+        .collect()
+}
+
+fn remote_backend_error(uri: &str, error: String) -> Error {
+    let auth_hint = if error.contains("401")
+        || error.contains("403")
+        || error.contains("WWW-Authenticate")
+        || error.to_ascii_lowercase().contains("unauthorized")
+    {
+        "\n\nThis remote MCP server appears to require authentication. \
+Pass explicit backend headers after the URL, for example: \
+`-- <url> -H \"Authorization=Bearer <token>\"`. Native OAuth support is not implemented yet."
+    } else {
+        "\n\nIf this remote MCP server requires authentication, pass explicit backend headers after the URL, \
+for example: `-- <url> -H \"Authorization=Bearer <token>\"`. Native OAuth support is not implemented yet."
+    };
+    Error::Config(format!(
+        "failed to initialize remote streamable HTTP backend {uri}: {error}{auth_hint}"
+    ))
 }
 
 fn is_http_url(value: &str) -> bool {
@@ -549,5 +676,63 @@ fn value_to_string(value: &Value) -> String {
             value_to_string(&map["result"])
         }
         _ => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_backend_url_parses_curl_style_headers_after_separator() {
+        let backend = BackendServerConfig::new(
+            "remote",
+            "https://example.test/mcp",
+            ["-H", "Authorization=Basic token", "--header", "X-Test=yes"],
+        );
+
+        assert_eq!(backend.transport, BackendTransport::StreamableHttp);
+        assert!(backend.args.is_empty());
+        assert_eq!(backend.headers["Authorization"], "Basic token");
+        assert_eq!(backend.headers["X-Test"], "yes");
+    }
+
+    #[test]
+    fn http_backend_url_parses_equals_header_forms() {
+        let backend = BackendServerConfig::new(
+            "remote",
+            "https://example.test/mcp",
+            ["-H=Authorization=Bearer token", "--header=X-Test=yes"],
+        );
+
+        assert!(backend.args.is_empty());
+        assert_eq!(backend.headers["Authorization"], "Bearer token");
+        assert_eq!(backend.headers["X-Test"], "yes");
+    }
+
+    #[test]
+    fn http_backend_header_values_preserve_missing_environment_variables() {
+        let backend = BackendServerConfig::new(
+            "remote",
+            "https://example.test/mcp",
+            ["-H", "Authorization=Bearer ${MCP_COMPRESSOR_MISSING_TEST_TOKEN}"],
+        );
+
+        assert_eq!(
+            backend.headers["Authorization"],
+            "Bearer ${MCP_COMPRESSOR_MISSING_TEST_TOKEN}"
+        );
+    }
+
+    #[test]
+    fn http_backend_url_preserves_unrecognized_args_for_validation() {
+        let backend = BackendServerConfig::new(
+            "remote",
+            "https://example.test/mcp",
+            ["--timeout", "30", "-H"],
+        );
+
+        assert_eq!(backend.args, ["--timeout", "30", "-H"]);
+        assert!(backend.headers.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- add optional bearer-token and custom-header fields to BackendServerConfig
- apply bearer/custom headers to rmcp StreamableHttpClientTransportConfig for remote HTTP backends
- support manual CLI/env auth via MCP_COMPRESSOR_BACKEND_BEARER_TOKEN and MCP_COMPRESSOR_BACKEND_HEADER
- improve remote backend initialize failures with an auth-oriented hint and mcp-remote workaround

## Validation
- cargo check -p mcp-compressor-core
- uv run pytest -q tests/test_rust_core_normal_mode.py
- uv run pytest -q tests/test_rust_core_normal_mode.py::test_rust_core_normal_stdio_mode_with_remote_streamable_http_backend
- cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture
- cargo test -p mcp-compressor-core --test proxy_http -- --nocapture
- cargo test -p mcp-compressor-core --tests --no-run

## Notes
This is not native OAuth yet. It provides a pragmatic bearer/custom-header bridge for remote MCP servers and clearer errors while native OAuth/token persistence is implemented separately.