### PR TITLE
feat: prepare remote backend oauth mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,7 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -222,11 +231,30 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -268,6 +296,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -442,14 +480,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -897,6 +947,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1283,7 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "oauth2",
  "pastey",
  "pin-project-lite",
  "process-wrap",
@@ -1230,6 +1300,7 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -1420,6 +1491,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -1731,6 +1813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +1840,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1776,6 +1865,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -9,7 +9,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 thiserror  = "1"
 rand       = "0.8"
 tokio      = { version = "1", features = ["sync", "rt-multi-thread"] }
-rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest", "reqwest-native-tls"] }
+rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest", "reqwest-native-tls", "auth"] }
 axum       = "0.8"
 
 [dev-dependencies]

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -87,14 +87,10 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
     } else if !cli.multi_servers.is_empty() {
         CompressedServer::connect_multi_stdio(
             config,
-            cli.multi_servers
-                .clone()
-                .into_iter()
-                .map(apply_backend_auth)
-                .collect(),
+            cli.multi_servers.clone().into_iter().collect(),
         )
-            .await
-            .map_err(|error| CliError::Runtime(error.to_string()))
+        .await
+        .map_err(|error| CliError::Runtime(error.to_string()))
     } else {
         let (command, args) = cli
             .command
@@ -106,11 +102,7 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
             .unwrap_or_else(|| "server".to_string());
         CompressedServer::connect_stdio(
             config,
-            apply_backend_auth(BackendServerConfig::new(
-                backend_name,
-                command.clone(),
-                args.to_vec(),
-            )),
+            BackendServerConfig::new(backend_name, command.clone(), args.to_vec()),
         )
         .await
         .map_err(|error| CliError::Runtime(error.to_string()))
@@ -198,7 +190,10 @@ async fn run_cli_mode(cli: CliOptions, server: CompressedServer) -> Result<(), C
         println!("Invoke with: {} <subcommand> [args...]", script.display());
         println!(
             "Note: {} is not on PATH; add it to PATH to run `{cli_name}` directly.",
-            script.parent().unwrap_or_else(|| std::path::Path::new(".")).display()
+            script
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("."))
+                .display()
         );
     }
     println!("Bridge URL: {}", proxy.bridge_url());
@@ -236,7 +231,11 @@ fn candidate_script_dirs() -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     if cfg!(windows) {
         if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {
-            candidates.push(PathBuf::from(local_app_data).join("Microsoft").join("WindowsApps"));
+            candidates.push(
+                PathBuf::from(local_app_data)
+                    .join("Microsoft")
+                    .join("WindowsApps"),
+            );
         }
         if let Some(home) = &home {
             candidates.push(home.join(".local").join("bin"));
@@ -295,13 +294,14 @@ impl CliOptions {
                 }
                 "--compression" => {
                     let value = required_value(args, index, "--compression")?;
-                    options.compression = value
-                        .parse()
-                        .map_err(|_| CliError::Usage(format!("unknown compression level: {value}")))?;
+                    options.compression = value.parse().map_err(|_| {
+                        CliError::Usage(format!("unknown compression level: {value}"))
+                    })?;
                     index += 2;
                 }
                 "--config" => {
-                    options.config_path = Some(PathBuf::from(required_value(args, index, "--config")?));
+                    options.config_path =
+                        Some(PathBuf::from(required_value(args, index, "--config")?));
                     index += 2;
                 }
                 "--server-name" => {
@@ -326,11 +326,8 @@ impl CliOptions {
                     index += 2;
                 }
                 "--transform-mode" => {
-                    options.transform_mode = parse_transform_mode(&required_value(
-                        args,
-                        index,
-                        "--transform-mode",
-                    )?)?;
+                    options.transform_mode =
+                        parse_transform_mode(&required_value(args, index, "--transform-mode")?)?;
                     index += 2;
                 }
                 "--cli-mode" => {
@@ -352,19 +349,6 @@ impl CliOptions {
         }
         Ok(options)
     }
-}
-
-fn apply_backend_auth(mut backend: BackendServerConfig) -> BackendServerConfig {
-    if let Ok(headers) = std::env::var("MCP_COMPRESSOR_BACKEND_HEADER") {
-        backend = backend.with_headers(
-            headers
-                .split('\n')
-                .filter_map(|header| header.split_once(':'))
-                .map(|(name, value)| (name.trim().to_string(), value.trim().to_string()))
-                .filter(|(name, value)| !name.is_empty() && !value.is_empty()),
-        );
-    }
-    backend
 }
 
 fn parse_multi_server(

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -21,9 +21,9 @@ use rmcp::transport::{ConfigureCommandExt, StreamableHttpClientTransport, TokioC
 use rmcp::{RoleClient, ServiceExt};
 use serde_json::Value;
 
-use crate::config::topology::MCPConfig;
 use crate::compression::engine::{CompressionEngine, Tool};
 use crate::compression::CompressionLevel;
+use crate::config::topology::MCPConfig;
 use crate::Error;
 
 /// Transport type used to reach an upstream MCP server.
@@ -35,6 +35,18 @@ pub enum BackendTransport {
     StreamableHttp,
 }
 
+/// Authentication strategy for a remote upstream MCP server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendAuthMode {
+    /// Match Python parity: explicit `Authorization` headers are used as-is;
+    /// otherwise native OAuth should be attempted for remote HTTP backends.
+    Auto,
+    /// Use explicit backend headers only; never start OAuth.
+    ExplicitHeaders,
+    /// Force native OAuth. This requires the OAuth runtime flow to be implemented.
+    OAuth,
+}
+
 /// Configuration for one upstream MCP server.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackendServerConfig {
@@ -44,6 +56,7 @@ pub struct BackendServerConfig {
     pub env: HashMap<String, String>,
     pub transport: BackendTransport,
     pub headers: HashMap<String, String>,
+    pub auth_mode: BackendAuthMode,
 }
 
 impl BackendServerConfig {
@@ -59,10 +72,10 @@ impl BackendServerConfig {
             BackendTransport::Stdio
         };
         let raw_args = args.into_iter().map(Into::into).collect::<Vec<_>>();
-        let (args, headers) = if transport == BackendTransport::StreamableHttp {
+        let (args, headers, auth_mode) = if transport == BackendTransport::StreamableHttp {
             parse_http_backend_args(raw_args)
         } else {
-            (raw_args, HashMap::new())
+            (raw_args, HashMap::new(), BackendAuthMode::Auto)
         };
         Self {
             name: name.into(),
@@ -71,6 +84,7 @@ impl BackendServerConfig {
             env: HashMap::new(),
             transport,
             headers,
+            auth_mode,
         }
     }
 
@@ -90,6 +104,26 @@ impl BackendServerConfig {
             .map(|(name, value)| (name.into(), value.into()))
             .collect();
         self
+    }
+
+    pub fn with_auth_mode(mut self, auth_mode: BackendAuthMode) -> Self {
+        self.auth_mode = auth_mode;
+        self
+    }
+
+    pub fn has_authorization_header(&self) -> bool {
+        self.headers
+            .keys()
+            .any(|name| name.eq_ignore_ascii_case("authorization"))
+    }
+
+    pub fn should_use_oauth(&self) -> bool {
+        self.transport == BackendTransport::StreamableHttp
+            && match self.auth_mode {
+                BackendAuthMode::Auto => !self.has_authorization_header(),
+                BackendAuthMode::ExplicitHeaders => false,
+                BackendAuthMode::OAuth => true,
+            }
     }
 }
 
@@ -302,7 +336,8 @@ impl CompressedServer {
         tool_input: Value,
     ) -> Result<String, Error> {
         let backend = self.backend_for_wrapper(_wrapper_tool_name)?;
-        self.invoke_backend(backend, backend_tool_name, tool_input).await
+        self.invoke_backend(backend, backend_tool_name, tool_input)
+            .await
     }
 
     /// List frontend resources, including pass-through backend resources and
@@ -393,7 +428,8 @@ impl CompressedServer {
             .first()
             .filter(|_| self.backends.len() == 1)
             .ok_or_else(|| Error::ToolNotFound(backend_tool_name.to_string()))?;
-        self.invoke_backend(backend, backend_tool_name, tool_input).await
+        self.invoke_backend(backend, backend_tool_name, tool_input)
+            .await
     }
 
     async fn invoke_backend(
@@ -500,6 +536,12 @@ async fn connect_streamable_http_backend(
             "streamable HTTP backend URLs do not accept command arguments".to_string(),
         ));
     }
+    if backend.should_use_oauth() {
+        return Err(Error::Config(format!(
+            "native OAuth for remote streamable HTTP backend {} is not implemented yet; pass an explicit Authorization header with `-H \"Authorization=...\"` to skip OAuth for now",
+            backend.command
+        )));
+    }
     let mut config = StreamableHttpClientTransportConfig::with_uri(backend.command.clone());
     let headers = backend_http_headers(backend)?;
     if !headers.is_empty() {
@@ -511,9 +553,12 @@ async fn connect_streamable_http_backend(
         .map_err(|error| remote_backend_error(&backend.command, error.to_string()))
 }
 
-fn parse_http_backend_args(args: Vec<String>) -> (Vec<String>, HashMap<String, String>) {
+fn parse_http_backend_args(
+    args: Vec<String>,
+) -> (Vec<String>, HashMap<String, String>, BackendAuthMode) {
     let mut remaining = Vec::new();
     let mut headers = HashMap::new();
+    let mut auth_mode = BackendAuthMode::Auto;
     let mut index = 0;
     while index < args.len() {
         let arg = &args[index];
@@ -530,7 +575,40 @@ fn parse_http_backend_args(args: Vec<String>) -> (Vec<String>, HashMap<String, S
                 remaining.push(arg.clone());
                 index += 1;
             }
-        } else if let Some(header) = arg.strip_prefix("-H=").or_else(|| arg.strip_prefix("--header=")) {
+        } else if let Some(mode) = arg.strip_prefix("--auth=") {
+            match mode {
+                "explicit-headers" | "headers" | "none" => {
+                    auth_mode = BackendAuthMode::ExplicitHeaders;
+                }
+                "oauth" => {
+                    auth_mode = BackendAuthMode::OAuth;
+                }
+                _ => remaining.push(arg.clone()),
+            }
+            index += 1;
+        } else if arg == "--auth" {
+            if let Some(mode) = args.get(index + 1) {
+                match mode.as_str() {
+                    "explicit-headers" | "headers" | "none" => {
+                        auth_mode = BackendAuthMode::ExplicitHeaders;
+                    }
+                    "oauth" => {
+                        auth_mode = BackendAuthMode::OAuth;
+                    }
+                    _ => {
+                        remaining.push(arg.clone());
+                        remaining.push(mode.clone());
+                    }
+                }
+                index += 2;
+            } else {
+                remaining.push(arg.clone());
+                index += 1;
+            }
+        } else if let Some(header) = arg
+            .strip_prefix("-H=")
+            .or_else(|| arg.strip_prefix("--header="))
+        {
             if let Some((name, value)) = parse_header_arg(header) {
                 headers.insert(name, value);
             } else {
@@ -542,13 +620,11 @@ fn parse_http_backend_args(args: Vec<String>) -> (Vec<String>, HashMap<String, S
             index += 1;
         }
     }
-    (remaining, headers)
+    (remaining, headers, auth_mode)
 }
 
 fn parse_header_arg(header: &str) -> Option<(String, String)> {
-    let (name, value) = header
-        .split_once('=')
-        .or_else(|| header.split_once(':'))?;
+    let (name, value) = header.split_once('=').or_else(|| header.split_once(':'))?;
     let name = name.trim();
     let value = value.trim();
     if name.is_empty() || value.is_empty() {
@@ -715,13 +791,80 @@ mod tests {
         let backend = BackendServerConfig::new(
             "remote",
             "https://example.test/mcp",
-            ["-H", "Authorization=Bearer ${MCP_COMPRESSOR_MISSING_TEST_TOKEN}"],
+            [
+                "-H",
+                "Authorization=Bearer ${MCP_COMPRESSOR_MISSING_TEST_TOKEN}",
+            ],
         );
 
         assert_eq!(
             backend.headers["Authorization"],
             "Bearer ${MCP_COMPRESSOR_MISSING_TEST_TOKEN}"
         );
+    }
+
+    #[test]
+    fn remote_http_auto_auth_uses_oauth_without_authorization_header() {
+        let backend =
+            BackendServerConfig::new("remote", "https://example.test/mcp", [] as [&str; 0]);
+
+        assert!(backend.should_use_oauth());
+    }
+
+    #[test]
+    fn remote_http_auto_auth_skips_oauth_with_authorization_header() {
+        let backend = BackendServerConfig::new(
+            "remote",
+            "https://example.test/mcp",
+            ["-H", "Authorization=Basic token"],
+        );
+
+        assert!(backend.has_authorization_header());
+        assert!(!backend.should_use_oauth());
+    }
+
+    #[test]
+    fn http_backend_url_parses_auth_mode_args() {
+        let explicit = BackendServerConfig::new(
+            "remote",
+            "https://example.test/mcp",
+            ["--auth", "explicit-headers"],
+        );
+        let oauth =
+            BackendServerConfig::new("remote", "https://example.test/mcp", ["--auth=oauth"]);
+
+        assert_eq!(explicit.auth_mode, BackendAuthMode::ExplicitHeaders);
+        assert!(explicit.args.is_empty());
+        assert_eq!(oauth.auth_mode, BackendAuthMode::OAuth);
+        assert!(oauth.args.is_empty());
+    }
+
+    #[test]
+    fn explicit_headers_auth_mode_skips_oauth_without_authorization_header() {
+        let backend =
+            BackendServerConfig::new("remote", "https://example.test/mcp", [] as [&str; 0])
+                .with_auth_mode(BackendAuthMode::ExplicitHeaders);
+
+        assert!(!backend.should_use_oauth());
+    }
+
+    #[test]
+    fn forced_oauth_auth_mode_uses_oauth_even_with_authorization_header() {
+        let backend = BackendServerConfig::new(
+            "remote",
+            "https://example.test/mcp",
+            ["-H", "Authorization=Basic token"],
+        )
+        .with_auth_mode(BackendAuthMode::OAuth);
+
+        assert!(backend.should_use_oauth());
+    }
+
+    #[test]
+    fn stdio_backend_never_uses_oauth() {
+        let backend = BackendServerConfig::new("local", "python", ["server.py"]);
+
+        assert!(!backend.should_use_oauth());
     }
 
     #[test]

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -207,7 +207,7 @@ Status as of 2026-05-01:
 - Remote backend transports:
   - streamable HTTP backend client
   - SSE backend client if still required for parity
-- OAuth/token persistence for remote MCP servers.
+- Native OAuth/token persistence for remote MCP servers. Rust remote backends now model the Python parity rule that explicit `Authorization` headers skip OAuth, but the browser callback/token-store flow is not implemented yet.
 - Just Bash runtime transform mode.
 - Richer generated CLI help parity, if desired:
   - argument descriptions

--- a/tests/test_rust_core_normal_mode.py
+++ b/tests/test_rust_core_normal_mode.py
@@ -224,6 +224,8 @@ async def test_rust_core_normal_stdio_mode_with_remote_streamable_http_backend()
             "remote",
             "--",
             url,
+            "--auth",
+            "explicit-headers",
         )
         async with Client(StdioTransport(command=command[0], args=command[1:])) as client:
             tools = {tool.name for tool in await client.list_tools()}


### PR DESCRIPTION
## Summary
- add explicit remote backend auth mode modeling: auto, explicit headers, and oauth
- model Python parity: explicit Authorization headers skip OAuth; remote HTTP without Authorization now gates on native OAuth not-yet-implemented
- add backend URL args for auth mode: `--auth explicit-headers` / `--auth=oauth`
- remove the ad-hoc backend-header environment helper so backend args after `--` remain the source of backend command/url/header/auth options
- enable rmcp's `auth` feature for the upcoming native OAuth implementation
- update the Rust design doc status and the unauthenticated local remote-backend e2e to opt out with `--auth explicit-headers`

## Validation
- `cargo test -p mcp-compressor-core server::compressed::tests -- --nocapture`
- `cargo check -p mcp-compressor-core`
- `uv run pytest -q tests/test_rust_core_normal_mode.py::test_rust_core_normal_stdio_mode_with_remote_streamable_http_backend`
- `cargo test -p mcp-compressor-core --tests --no-run`