### PR TITLE
feat: add native remote oauth flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,9 +898,12 @@ name = "mcp-compressor-core"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "async-trait",
  "axum",
+ "dirs",
  "predicates",
  "rand 0.8.6",
+ "reqwest",
  "rmcp",
  "serde",
  "serde_json",
@@ -1014,6 +1047,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pastey"
@@ -1181,6 +1220,17 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "ref-cast"

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -11,6 +11,9 @@ rand       = "0.8"
 tokio      = { version = "1", features = ["sync", "rt-multi-thread"] }
 rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest", "reqwest-native-tls", "auth"] }
 axum       = "0.8"
+async-trait = "0.1"
+dirs = "6"
+reqwest = { version = "0.13.3", default-features = false, features = ["native-tls"] }
 
 [dev-dependencies]
 # async test runtime and macros (#[tokio::test])

--- a/crates/mcp-compressor-core/src/lib.rs
+++ b/crates/mcp-compressor-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod compression;
 pub mod config;
 pub mod error;
 pub mod ffi;
+pub mod oauth;
 pub mod proxy;
 pub mod server;
 

--- a/crates/mcp-compressor-core/src/oauth.rs
+++ b/crates/mcp-compressor-core/src/oauth.rs
@@ -1,0 +1,318 @@
+//! OAuth helpers for remote MCP backends.
+//!
+//! The runtime delegates OAuth protocol details to `rmcp`. This module only
+//! provides compressor-specific storage and local callback plumbing.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener};
+use std::path::{Path, PathBuf};
+
+use rmcp::transport::auth::{
+    AuthError, CredentialStore, StateStore, StoredAuthorizationState, StoredCredentials,
+};
+
+/// File-backed OAuth credential store.
+#[derive(Debug, Clone)]
+pub struct FileCredentialStore {
+    path: PathBuf,
+}
+
+impl FileCredentialStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[async_trait::async_trait]
+impl CredentialStore for FileCredentialStore {
+    async fn load(&self) -> Result<Option<StoredCredentials>, AuthError> {
+        let Some(contents) = read_optional(&self.path)? else {
+            return Ok(None);
+        };
+        serde_json::from_str(&contents).map(Some).map_err(|error| {
+            AuthError::InternalError(format!("failed to parse OAuth credentials: {error}"))
+        })
+    }
+
+    async fn save(&self, credentials: StoredCredentials) -> Result<(), AuthError> {
+        write_json(&self.path, &credentials)
+    }
+
+    async fn clear(&self) -> Result<(), AuthError> {
+        remove_optional(&self.path)
+    }
+}
+
+/// File-backed OAuth authorization-state store.
+#[derive(Debug, Clone)]
+pub struct FileStateStore {
+    dir: PathBuf,
+}
+
+impl FileStateStore {
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    fn state_path(&self, csrf_token: &str) -> PathBuf {
+        self.dir
+            .join(format!("{}.json", sanitize_file_component(csrf_token)))
+    }
+}
+
+#[async_trait::async_trait]
+impl StateStore for FileStateStore {
+    async fn save(
+        &self,
+        csrf_token: &str,
+        state: StoredAuthorizationState,
+    ) -> Result<(), AuthError> {
+        write_json(&self.state_path(csrf_token), &state)
+    }
+
+    async fn load(&self, csrf_token: &str) -> Result<Option<StoredAuthorizationState>, AuthError> {
+        let Some(contents) = read_optional(&self.state_path(csrf_token))? else {
+            return Ok(None);
+        };
+        serde_json::from_str(&contents).map(Some).map_err(|error| {
+            AuthError::InternalError(format!("failed to parse OAuth state: {error}"))
+        })
+    }
+
+    async fn delete(&self, csrf_token: &str) -> Result<(), AuthError> {
+        remove_optional(&self.state_path(csrf_token))
+    }
+}
+
+fn read_optional(path: &Path) -> Result<Option<String>, AuthError> {
+    match fs::read_to_string(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(AuthError::InternalError(format!(
+            "failed to read OAuth store {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn write_json<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), AuthError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AuthError::InternalError(format!(
+                "failed to create OAuth store directory {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+    let json = serde_json::to_string_pretty(value).map_err(|error| {
+        AuthError::InternalError(format!("failed to serialize OAuth store: {error}"))
+    })?;
+    fs::write(path, json).map_err(|error| {
+        AuthError::InternalError(format!(
+            "failed to write OAuth store {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn remove_optional(path: &Path) -> Result<(), AuthError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(AuthError::InternalError(format!(
+            "failed to remove OAuth store {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+/// Local OAuth callback listener bound to loopback.
+#[derive(Debug)]
+pub struct OAuthCallbackListener {
+    listener: TcpListener,
+    redirect_uri: String,
+}
+
+impl OAuthCallbackListener {
+    pub fn bind() -> Result<Self, std::io::Error> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let addr = listener.local_addr()?;
+        Ok(Self {
+            listener,
+            redirect_uri: format!("http://{addr}/callback"),
+        })
+    }
+
+    pub fn redirect_uri(&self) -> &str {
+        &self.redirect_uri
+    }
+
+    pub fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {
+        self.listener.local_addr()
+    }
+
+    pub fn wait_for_callback(self) -> Result<OAuthCallback, std::io::Error> {
+        let (mut stream, _) = self.listener.accept()?;
+        let mut request = [0_u8; 4096];
+        let bytes = stream.read(&mut request)?;
+        let request = String::from_utf8_lossy(&request[..bytes]);
+        let callback = parse_callback_request(&request).unwrap_or_else(|| OAuthCallback {
+            code: String::new(),
+            state: String::new(),
+        });
+        let body = if callback.code.is_empty() || callback.state.is_empty() {
+            "OAuth callback was missing code or state. You can close this tab."
+        } else {
+            "OAuth complete. You can close this tab and return to mcp-compressor."
+        };
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(), body
+        );
+        stream.write_all(response.as_bytes())?;
+        Ok(callback)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthCallback {
+    pub code: String,
+    pub state: String,
+}
+
+fn parse_callback_request(request: &str) -> Option<OAuthCallback> {
+    let first_line = request.lines().next()?;
+    let path = first_line.split_whitespace().nth(1)?;
+    let query = path.split_once('?')?.1;
+    let mut code = None;
+    let mut state = None;
+    for pair in query.split('&') {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        match key {
+            "code" => code = Some(percent_decode(value)),
+            "state" => state = Some(percent_decode(value)),
+            _ => {}
+        }
+    }
+    Some(OAuthCallback {
+        code: code?,
+        state: state?,
+    })
+}
+
+fn percent_decode(value: &str) -> String {
+    let mut output = Vec::with_capacity(value.len());
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'+' => {
+                output.push(b' ');
+                index += 1;
+            }
+            b'%' if index + 2 < bytes.len() => {
+                if let (Some(high), Some(low)) =
+                    (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
+                {
+                    output.push((high << 4) | low);
+                    index += 3;
+                } else {
+                    output.push(bytes[index]);
+                    index += 1;
+                }
+            }
+            byte => {
+                output.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&output).into_owned()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn sanitize_file_component(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "state".to_string()
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn file_credential_store_missing_loads_none_and_clear_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileCredentialStore::new(dir.path().join("credentials.json"));
+
+        assert!(store.load().await.unwrap().is_none());
+        store.clear().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_state_store_missing_loads_none_and_delete_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileStateStore::new(dir.path().join("state"));
+
+        assert!(store.load("missing-token").await.unwrap().is_none());
+        store.delete("missing-token").await.unwrap();
+    }
+
+    #[test]
+    fn callback_request_parser_extracts_and_decodes_code_and_state() {
+        let callback = parse_callback_request(
+            "GET /callback?code=abc%20123&state=state+value HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        )
+        .unwrap();
+
+        assert_eq!(callback.code, "abc 123");
+        assert_eq!(callback.state, "state value");
+    }
+
+    #[test]
+    fn callback_request_parser_rejects_missing_fields() {
+        assert!(parse_callback_request("GET /callback?code=abc HTTP/1.1\r\n\r\n").is_none());
+        assert!(parse_callback_request("GET /callback?state=abc HTTP/1.1\r\n\r\n").is_none());
+    }
+
+    #[test]
+    fn state_store_sanitizes_file_components() {
+        let store = FileStateStore::new("state-dir");
+
+        assert_eq!(
+            store.state_path("abc/../def").file_name().unwrap(),
+            "abc____def.json"
+        );
+        assert_eq!(store.state_path("").file_name().unwrap(), "state.json");
+    }
+}

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::str::FromStr;
 
@@ -16,6 +17,7 @@ use rmcp::model::{
     ReadResourceRequestParams, ResourceContents,
 };
 use rmcp::service::RunningService;
+use rmcp::transport::auth::{AuthClient, AuthorizationManager};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use rmcp::transport::{ConfigureCommandExt, StreamableHttpClientTransport, TokioChildProcess};
 use rmcp::{RoleClient, ServiceExt};
@@ -24,6 +26,7 @@ use serde_json::Value;
 use crate::compression::engine::{CompressionEngine, Tool};
 use crate::compression::CompressionLevel;
 use crate::config::topology::MCPConfig;
+use crate::oauth::{FileCredentialStore, FileStateStore, OAuthCallbackListener};
 use crate::Error;
 
 /// Transport type used to reach an upstream MCP server.
@@ -537,10 +540,7 @@ async fn connect_streamable_http_backend(
         ));
     }
     if backend.should_use_oauth() {
-        return Err(Error::Config(format!(
-            "native OAuth for remote streamable HTTP backend {} is not implemented yet; pass an explicit Authorization header with `-H \"Authorization=...\"` to skip OAuth for now",
-            backend.command
-        )));
+        return connect_oauth_streamable_http_backend(backend).await;
     }
     let mut config = StreamableHttpClientTransportConfig::with_uri(backend.command.clone());
     let headers = backend_http_headers(backend)?;
@@ -551,6 +551,93 @@ async fn connect_streamable_http_backend(
     ().serve(transport)
         .await
         .map_err(|error| remote_backend_error(&backend.command, error.to_string()))
+}
+
+async fn connect_oauth_streamable_http_backend(
+    backend: &BackendServerConfig,
+) -> Result<RunningService<RoleClient, ()>, Error> {
+    let mut manager = AuthorizationManager::new(backend.command.as_str())
+        .await
+        .map_err(|error| Error::Config(format!("failed to initialize OAuth manager: {error}")))?;
+    let store_dir = oauth_store_dir(&backend.command, &backend.name)?;
+    let credential_store = FileCredentialStore::new(store_dir.join("credentials.json"));
+    let state_store = FileStateStore::new(store_dir.join("state"));
+    manager.set_credential_store(credential_store.clone());
+    manager.set_state_store(state_store.clone());
+
+    if !manager
+        .initialize_from_store()
+        .await
+        .map_err(|error| Error::Config(format!("failed to load OAuth credentials: {error}")))?
+    {
+        let listener = OAuthCallbackListener::bind().map_err(Error::Io)?;
+        let redirect_uri = listener.redirect_uri().to_string();
+        let mut state = rmcp::transport::auth::OAuthState::new(backend.command.as_str(), None)
+            .await
+            .map_err(|error| Error::Config(format!("failed to initialize OAuth state: {error}")))?;
+        if let rmcp::transport::auth::OAuthState::Unauthorized(ref mut state_manager) = state {
+            state_manager.set_credential_store(credential_store);
+            state_manager.set_state_store(state_store);
+        }
+        state
+            .start_authorization(&[], &redirect_uri, Some("mcp-compressor"))
+            .await
+            .map_err(|error| {
+                Error::Config(format!("failed to start OAuth authorization: {error}"))
+            })?;
+        let auth_url = state.get_authorization_url().await.map_err(|error| {
+            Error::Config(format!("failed to get OAuth authorization URL: {error}"))
+        })?;
+        eprintln!(
+            "Open this URL to authorize {name}:\n{auth_url}",
+            name = backend.name
+        );
+        let callback = listener.wait_for_callback().map_err(Error::Io)?;
+        state
+            .handle_callback(&callback.code, &callback.state)
+            .await
+            .map_err(|error| {
+                Error::Config(format!("failed to complete OAuth authorization: {error}"))
+            })?;
+        manager = state.into_authorization_manager().ok_or_else(|| {
+            Error::Config("OAuth authorization did not produce an authorized manager".to_string())
+        })?;
+    }
+
+    let client = AuthClient::new(reqwest::Client::default(), manager);
+    let transport = StreamableHttpClientTransport::with_client(
+        client,
+        StreamableHttpClientTransportConfig::with_uri(backend.command.clone()),
+    );
+    ().serve(transport)
+        .await
+        .map_err(|error| remote_backend_error(&backend.command, error.to_string()))
+}
+
+fn oauth_store_dir(uri: &str, name: &str) -> Result<PathBuf, Error> {
+    let base = dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("mcp-compressor")
+        .join("oauth-tokens-rust");
+    Ok(base.join(sanitize_oauth_store_component(&format!("{name}-{uri}"))))
+}
+
+fn sanitize_oauth_store_component(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "server".to_string()
+    } else {
+        sanitized
+    }
 }
 
 fn parse_http_backend_args(


### PR DESCRIPTION
## Summary
- add Rust OAuth helper module with file-backed rmcp credential/state stores
- add loopback OAuth callback listener and callback parser
- wire remote streamable HTTP backends in OAuth mode through rmcp AuthorizationManager/AuthClient
- use persisted credentials when available; otherwise print/open authorization URL and wait for callback
- keep explicit Authorization header behavior unchanged

## Validation
- `cargo check -p mcp-compressor-core`
- `cargo test -p mcp-compressor-core oauth:: -- --nocapture`
- `cargo test -p mcp-compressor-core server::compressed::tests -- --nocapture`
- `cargo test -p mcp-compressor-core --tests --no-run`
- smoke-tested Atlassian OAuth startup to authorization URL with timeout