### PR TITLE
refactor: use clap for rust cli parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,10 +21,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
 
 [[package]]
 name = "anyhow"
@@ -212,6 +256,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation"
@@ -831,6 +921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +996,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "axum",
+ "clap",
  "dirs",
  "predicates",
  "rand 0.8.6",
@@ -1003,6 +1100,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -1898,6 +2001,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -14,6 +14,7 @@ axum       = "0.8"
 async-trait = "0.1"
 dirs = "6"
 reqwest = { version = "0.13.3", default-features = false, features = ["native-tls"] }
+clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 # async test runtime and macros (#[tokio::test])

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -3,8 +3,10 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::str::FromStr;
 use std::sync::Arc;
 
+use clap::{ArgAction, Parser, ValueEnum};
 use mcp_compressor_core::client_gen::cli::CliGenerator;
 use mcp_compressor_core::client_gen::{ClientGenerator, GeneratorConfig};
 use mcp_compressor_core::compression::CompressionLevel;
@@ -15,13 +17,11 @@ use mcp_compressor_core::server::{
     ProxyTransformMode,
 };
 
-const HELP: &str = "mcp-compressor-core\n\nUSAGE:\n    mcp-compressor-core [OPTIONS] [-- <COMMAND>...]\n\nOPTIONS:\n    --help                      Print help\n    --compression <LEVEL>       low | medium | high | max\n    --config <PATH>             MCP config JSON file\n    --server-name <NAME>        Frontend server name/prefix\n    --transport <TYPE>          stdio | streamable-http\n    --port <PORT>               Port for streamable-http frontend (0 chooses one)\n    --transform-mode <MODE>     compressed-tools | cli | just-bash\n    --cli-mode                  Alias for --transform-mode cli\n    --just-bash                 Alias for --transform-mode just-bash\n";
-
 fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(CliError::Usage(message)) => {
-            eprintln!("error: {message}\n\n{HELP}");
+            eprintln!("error: {message}");
             ExitCode::from(2)
         }
         Err(CliError::Runtime(message)) => {
@@ -32,14 +32,7 @@ fn main() -> ExitCode {
 }
 
 fn run() -> Result<(), CliError> {
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
-
-    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
-        println!("{HELP}");
-        return Ok(());
-    }
-
-    let cli = CliOptions::parse(&args)?;
+    let cli = CliOptions::parse();
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -50,7 +43,7 @@ fn run() -> Result<(), CliError> {
 async fn run_async(cli: CliOptions) -> Result<(), CliError> {
     let server = build_server(&cli).await?;
 
-    match cli.transform_mode {
+    match cli.transform_mode() {
         ProxyTransformMode::Cli => run_cli_mode(cli, server).await,
         ProxyTransformMode::CompressedTools => run_compressed_server(&cli, server).await,
         ProxyTransformMode::JustBash => run_just_bash_mode(cli, server).await,
@@ -59,12 +52,12 @@ async fn run_async(cli: CliOptions) -> Result<(), CliError> {
 
 async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
     let config = CompressedServerConfig {
-        level: cli.compression.clone(),
+        level: cli.compression(),
         server_name: cli.server_name.clone(),
         include_tools: Vec::new(),
         exclude_tools: Vec::new(),
         toonify: false,
-        transform_mode: cli.transform_mode,
+        transform_mode: cli.transform_mode(),
         config_source: BackendConfigSource::Command,
     };
 
@@ -82,14 +75,15 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
         CompressedServer::connect_mcp_config_json(config, &json)
             .await
             .map_err(|error| CliError::Runtime(error.to_string()))
-    } else if !cli.multi_servers.is_empty() {
-        CompressedServer::connect_multi_stdio(
-            config,
-            cli.multi_servers.clone().into_iter().collect(),
-        )
-        .await
-        .map_err(|error| CliError::Runtime(error.to_string()))
     } else {
+        if !cli.multi_server.is_empty() {
+            return CompressedServer::connect_multi_stdio(
+                config,
+                cli.multi_server.iter().cloned().map(Into::into).collect(),
+            )
+            .await
+            .map_err(|error| CliError::Runtime(error.to_string()));
+        }
         let (command, args) = cli
             .command
             .split_first()
@@ -159,7 +153,10 @@ async fn run_just_bash_mode(cli: CliOptions, server: CompressedServer) -> Result
     let proxy = ToolProxyServer::start(server)
         .await
         .map_err(|error| CliError::Runtime(error.to_string()))?;
-    let cli_name = cli.server_name.clone().unwrap_or_else(|| "bash".to_string());
+    let cli_name = cli
+        .server_name
+        .clone()
+        .unwrap_or_else(|| "bash".to_string());
 
     println!("Just Bash ready");
     println!("Bridge URL: {}", proxy.bridge_url());
@@ -279,149 +276,172 @@ fn path_dirs() -> Vec<PathBuf> {
         .unwrap_or_default()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Parser)]
+#[command(
+    name = "mcp-compressor-core",
+    about = "Standalone Rust MCP compressor core binary",
+    disable_help_subcommand = true
+)]
 struct CliOptions {
-    compression: CompressionLevel,
+    /// Compression level: low, medium, high, or max.
+    #[arg(long, value_enum, default_value = "medium")]
+    compression: CompressionLevelArg,
+
+    /// MCP config JSON file.
+    #[arg(long = "config")]
     config_path: Option<PathBuf>,
+
+    /// Frontend server name/prefix.
+    #[arg(long)]
     server_name: Option<String>,
-    transform_mode: ProxyTransformMode,
-    command: Vec<String>,
-    multi_servers: Vec<BackendServerConfig>,
+
+    /// Frontend transform mode.
+    #[arg(long, value_enum, default_value = "compressed-tools")]
+    transform_mode: TransformModeArg,
+
+    /// Alias for --transform-mode cli.
+    #[arg(long, action = ArgAction::SetTrue)]
+    cli_mode: bool,
+
+    /// Alias for --transform-mode just-bash.
+    #[arg(long, action = ArgAction::SetTrue)]
+    just_bash: bool,
+
+    /// Multi-server backend spec: name=command [args...]. Repeat for each backend.
+    #[arg(long = "multi-server", value_name = "NAME=COMMAND [ARGS...]", action = ArgAction::Append)]
+    multi_server: Vec<MultiServerArg>,
+
+    /// Frontend transport.
+    #[arg(long, value_enum, default_value = "stdio")]
     transport: FrontendTransport,
+
+    /// Port for streamable-http frontend; 0 chooses an available port.
+    #[arg(long, default_value_t = 8000)]
     port: u16,
+
+    /// Backend command, URL, and arguments. All backend server arguments belong after `--`.
+    #[arg(value_name = "COMMAND", allow_hyphen_values = true, last = true)]
+    command: Vec<String>,
 }
 
 impl CliOptions {
-    fn parse(args: &[String]) -> Result<Self, CliError> {
-        let mut options = Self {
-            compression: CompressionLevel::Medium,
-            config_path: None,
-            server_name: None,
-            transform_mode: ProxyTransformMode::CompressedTools,
-            command: Vec::new(),
-            multi_servers: Vec::new(),
-            transport: FrontendTransport::Stdio,
-            port: 8000,
-        };
-        let mut index = 0;
-        while index < args.len() {
-            match args[index].as_str() {
-                "--" => {
-                    options.command = args[index + 1..].to_vec();
-                    break;
-                }
-                "--compression" => {
-                    let value = required_value(args, index, "--compression")?;
-                    options.compression = value.parse().map_err(|_| {
-                        CliError::Usage(format!("unknown compression level: {value}"))
-                    })?;
-                    index += 2;
-                }
-                "--config" => {
-                    options.config_path =
-                        Some(PathBuf::from(required_value(args, index, "--config")?));
-                    index += 2;
-                }
-                "--server-name" => {
-                    options.server_name = Some(required_value(args, index, "--server-name")?);
-                    index += 2;
-                }
-                "--multi-server" => {
-                    let (backend, next_index) = parse_multi_server(args, index)?;
-                    options.multi_servers.push(backend);
-                    index = next_index;
-                }
-                "--transport" => {
-                    let value = required_value(args, index, "--transport")?;
-                    options.transport = parse_frontend_transport(&value)?;
-                    index += 2;
-                }
-                "--port" => {
-                    let value = required_value(args, index, "--port")?;
-                    options.port = value
-                        .parse()
-                        .map_err(|_| CliError::Usage(format!("invalid port: {value}")))?;
-                    index += 2;
-                }
-                "--transform-mode" => {
-                    options.transform_mode =
-                        parse_transform_mode(&required_value(args, index, "--transform-mode")?)?;
-                    index += 2;
-                }
-                "--cli-mode" => {
-                    options.transform_mode = ProxyTransformMode::Cli;
-                    index += 1;
-                }
-                "--just-bash" => {
-                    options.transform_mode = ProxyTransformMode::JustBash;
-                    index += 1;
-                }
-                option if option.starts_with('-') => {
-                    return Err(CliError::Usage(format!("unknown option: {option}")));
-                }
-                _ => {
-                    options.command = args[index..].to_vec();
-                    break;
-                }
-            }
+    fn compression(&self) -> CompressionLevel {
+        self.compression.into()
+    }
+
+    fn transform_mode(&self) -> ProxyTransformMode {
+        if self.just_bash {
+            ProxyTransformMode::JustBash
+        } else if self.cli_mode {
+            ProxyTransformMode::Cli
+        } else {
+            self.transform_mode.into()
         }
-        Ok(options)
     }
 }
 
-fn parse_multi_server(
-    args: &[String],
-    index: usize,
-) -> Result<(BackendServerConfig, usize), CliError> {
-    let spec = required_value(args, index, "--multi-server")?;
-    let (name, command) = spec
-        .split_once('=')
-        .filter(|(name, command)| !name.is_empty() && !command.is_empty())
-        .ok_or_else(|| {
-            CliError::Usage("--multi-server requires <name=command> followed by args".to_string())
-        })?;
-    let mut next_index = index + 2;
-    let mut backend_args = Vec::new();
-    while next_index < args.len() {
-        if args[next_index] == "--multi-server" {
-            break;
-        }
-        backend_args.push(args[next_index].clone());
-        next_index += 1;
+#[derive(Debug, Clone)]
+struct MultiServerArg {
+    name: String,
+    command: String,
+    args: Vec<String>,
+}
+
+impl FromStr for MultiServerArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut parts = value.split_whitespace();
+        let spec = parts
+            .next()
+            .ok_or_else(|| "expected name=command".to_string())?;
+        let (name, command) = spec
+            .split_once('=')
+            .filter(|(name, command)| !name.is_empty() && !command.is_empty())
+            .ok_or_else(|| "expected name=command".to_string())?;
+        Ok(Self {
+            name: name.to_string(),
+            command: command.to_string(),
+            args: parts.map(ToString::to_string).collect(),
+        })
     }
-    Ok((
-        BackendServerConfig::new(name.to_string(), command.to_string(), backend_args),
-        next_index,
-    ))
 }
 
-fn required_value(args: &[String], index: usize, flag: &str) -> Result<String, CliError> {
-    args.get(index + 1)
-        .filter(|value| !value.starts_with('-'))
-        .cloned()
-        .ok_or_else(|| CliError::Usage(format!("{flag} requires a value")))
+impl From<MultiServerArg> for BackendServerConfig {
+    fn from(value: MultiServerArg) -> Self {
+        BackendServerConfig::new(value.name, value.command, value.args)
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CompressionLevelArg {
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+impl std::fmt::Display for CompressionLevelArg {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Max => "max",
+        })
+    }
+}
+
+impl From<CompressionLevelArg> for CompressionLevel {
+    fn from(value: CompressionLevelArg) -> Self {
+        match value {
+            CompressionLevelArg::Low => CompressionLevel::Low,
+            CompressionLevelArg::Medium => CompressionLevel::Medium,
+            CompressionLevelArg::High => CompressionLevel::High,
+            CompressionLevelArg::Max => CompressionLevel::Max,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum TransformModeArg {
+    CompressedTools,
+    Cli,
+    JustBash,
+}
+
+impl std::fmt::Display for TransformModeArg {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::CompressedTools => "compressed-tools",
+            Self::Cli => "cli",
+            Self::JustBash => "just-bash",
+        })
+    }
+}
+
+impl From<TransformModeArg> for ProxyTransformMode {
+    fn from(value: TransformModeArg) -> Self {
+        match value {
+            TransformModeArg::CompressedTools => ProxyTransformMode::CompressedTools,
+            TransformModeArg::Cli => ProxyTransformMode::Cli,
+            TransformModeArg::JustBash => ProxyTransformMode::JustBash,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum FrontendTransport {
     Stdio,
     StreamableHttp,
 }
 
-fn parse_frontend_transport(value: &str) -> Result<FrontendTransport, CliError> {
-    match value {
-        "stdio" => Ok(FrontendTransport::Stdio),
-        "streamable-http" => Ok(FrontendTransport::StreamableHttp),
-        _ => Err(CliError::Usage(format!("unsupported transport: {value}"))),
-    }
-}
-
-fn parse_transform_mode(value: &str) -> Result<ProxyTransformMode, CliError> {
-    match value {
-        "compressed-tools" => Ok(ProxyTransformMode::CompressedTools),
-        "cli" => Ok(ProxyTransformMode::Cli),
-        "just-bash" => Ok(ProxyTransformMode::JustBash),
-        _ => Err(CliError::Usage(format!("unknown transform mode: {value}"))),
+impl std::fmt::Display for FrontendTransport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Stdio => "stdio",
+            Self::StreamableHttp => "streamable-http",
+        })
     }
 }
 

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -17,9 +17,9 @@ fn rust_cli_help_describes_supported_modes() {
     cmd.arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("--compression <LEVEL>"))
-        .stdout(predicate::str::contains("--config <PATH>"))
-        .stdout(predicate::str::contains("--transform-mode <MODE>"))
+        .stdout(predicate::str::contains("--compression <COMPRESSION>"))
+        .stdout(predicate::str::contains("--config <CONFIG_PATH>"))
+        .stdout(predicate::str::contains("--transform-mode <TRANSFORM_MODE>"))
         .stdout(predicate::str::contains("--cli-mode"))
         .stdout(predicate::str::contains("--just-bash"));
 }
@@ -31,7 +31,7 @@ fn rust_cli_invalid_compression_level_exits_nonzero() {
         .assert()
         .failure()
         .code(2)
-        .stderr(predicate::str::contains("unknown compression level: verbose"));
+        .stderr(predicate::str::contains("invalid value 'verbose'"));
 }
 
 #[test]

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -268,7 +268,7 @@ The desired split is:
 - `clio-auth` handles the local CLI UX pieces if it can be integrated cleanly: loopback listener, browser opening, callback parsing, user-facing success/error page.
 - `mcp-compressor-core` owns only compressor-specific policy: token-store location, explicit `Authorization` header bypass behavior, clear errors, and parity with Python configuration semantics.
 
-If `clio-auth` cannot be integrated without duplicating or bypassing `rmcp`'s OAuth state machine, prefer staying with `rmcp` and improving the small custom callback layer rather than reimplementing protocol behavior locally.
+A follow-up spike against `clio-auth` 0.8.0 found that its public API is centered on an `oauth2::Client` and performs its own PKCE/state/callback flow; the lower-level callback server and browser-opening helpers are not exposed independently. That makes it a poor direct fit for the current `rmcp` integration, because using it would duplicate or bypass `rmcp`'s MCP-specific OAuth state machine. For now, prefer staying with `rmcp` and improving the small custom callback layer rather than adding `clio-auth` as an unused or conflicting dependency.
 
 ## Open Questions
 

--- a/tests/test_rust_core_normal_mode.py
+++ b/tests/test_rust_core_normal_mode.py
@@ -91,11 +91,9 @@ async def test_rust_core_normal_stdio_mode_with_multi_server_direct_config() -> 
         "--server-name",
         "suite",
         "--multi-server",
-        "alpha=python3",
-        str(alpha),
+        f"alpha=python3 {alpha}",
         "--multi-server",
-        "beta=python3",
-        str(beta),
+        f"beta=python3 {beta}",
     )
 
     async with Client(StdioTransport(command=command[0], args=command[1:])) as client:


### PR DESCRIPTION
## Summary
- replace hand-rolled Rust binary top-level CLI parsing with clap derive
- let clap own help, validation, value enums, defaults, and raw backend args after `--`
- keep generated backend tool argv parsing untouched in `cli/parser.rs`
- model `--multi-server` as a repeated typed clap option instead of custom argv scanning
- update tests for clap-generated help/error output and the explicit multi-server value shape

## Validation
- `cargo check -p mcp-compressor-core`
- `cargo test -p mcp-compressor-core --test cli_binary -- --nocapture`
- `cargo test -p mcp-compressor-core --test config_sources -- --nocapture`
- `cargo test -p mcp-compressor-core --test transform_modes -- --nocapture`
- `cargo test -p mcp-compressor-core --tests --no-run`
- `cargo test -p mcp-compressor-core --lib -- --nocapture`
- `uv run pytest -q tests/test_rust_core_normal_mode.py`