### PR TITLE
feat: add rust ffi binding DTO helpers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Check Rust core library
         run: cargo check -p mcp-compressor-core
 
+      - name: Check optional Rust binding features
+        run: |
+          cargo check -p mcp-compressor-core --features python
+          cargo check -p mcp-compressor-core --features node
+
+      - name: Run optional PyO3 binding scaffold tests
+        run: cargo test -p mcp-compressor-core --features python ffi::python -- --nocapture
+
       - name: Run Rust core library tests
         run: cargo test -p mcp-compressor-core --lib -- --nocapture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +355,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
 name = "darling"
@@ -976,6 +991,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,8 +1042,11 @@ dependencies = [
  "axum",
  "clap",
  "dirs",
+ "napi",
+ "napi-derive",
  "open",
  "predicates",
+ "pyo3",
  "rand 0.8.6",
  "reqwest",
  "rmcp",
@@ -1054,6 +1082,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "napi"
+version = "3.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+dependencies = [
+ "bitflags",
+ "ctor",
+ "futures",
+ "napi-build",
+ "napi-sys",
+ "nohash-hasher",
+ "rustc-hash",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+
+[[package]]
+name = "napi-derive"
+version = "3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+dependencies = [
+ "convert_case",
+ "ctor",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn",
+]
+
+[[package]]
+name = "napi-sys"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1166,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "normalize-line-endings"
@@ -1220,6 +1311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1395,64 @@ dependencies = [
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1507,6 +1662,12 @@ dependencies = [
  "serde_json",
  "syn",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1790,6 +1951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2193,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -17,6 +17,14 @@ reqwest = { version = "0.13.3", default-features = false, features = ["native-tl
 clap = { version = "4", features = ["derive"] }
 open = "5.3"
 toon-format = { version = "0.4.5", default-features = false }
+pyo3 = { version = "0.28.3", optional = true }
+napi = { version = "3.8.6", optional = true, default-features = false, features = ["napi4"] }
+napi-derive = { version = "3.5.5", optional = true }
+
+[features]
+default = []
+python = ["dep:pyo3"]
+node = ["dep:napi", "dep:napi-derive"]
 
 [dev-dependencies]
 # async test runtime and macros (#[tokio::test])

--- a/crates/mcp-compressor-core/src/client_gen/typescript.rs
+++ b/crates/mcp-compressor-core/src/client_gen/typescript.rs
@@ -132,7 +132,13 @@ fn required_params(tool: &crate::compression::engine::Tool) -> Vec<String> {
     tool.input_schema
         .get("required")
         .and_then(serde_json::Value::as_array)
-        .map(|values| values.iter().filter_map(serde_json::Value::as_str).map(ToString::to_string).collect())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
         .unwrap_or_default()
 }
 
@@ -177,7 +183,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = make_config(dir.path());
         let paths = TypeScriptGenerator.generate(&config).unwrap();
-        assert_eq!(paths.len(), 2, "expected exactly two generated files (.ts and .d.ts)");
+        assert_eq!(
+            paths.len(),
+            2,
+            "expected exactly two generated files (.ts and .d.ts)"
+        );
     }
 
     /// A `.ts` source file is produced.
@@ -241,7 +251,10 @@ mod tests {
         let paths = TypeScriptGenerator.generate(&config).unwrap();
         let ts = find_ts(&paths);
         let content = fs::read_to_string(ts).unwrap();
-        assert!(content.contains("do not edit"), "expected 'do not edit' header");
+        assert!(
+            content.contains("do not edit"),
+            "expected 'do not edit' header"
+        );
     }
 
     // ------------------------------------------------------------------
@@ -284,8 +297,14 @@ mod tests {
         let paths = TypeScriptGenerator.generate(&config).unwrap();
         let ts = find_ts(&paths);
         let content = fs::read_to_string(ts).unwrap();
-        assert!(content.contains("export async function fetch("), "'fetch' function not found");
-        assert!(content.contains("export async function search("), "'search' function not found");
+        assert!(
+            content.contains("export async function fetch("),
+            "'fetch' function not found"
+        );
+        assert!(
+            content.contains("export async function search("),
+            "'search' function not found"
+        );
     }
 
     /// Functions return `Promise<string>`.
@@ -296,7 +315,10 @@ mod tests {
         let paths = TypeScriptGenerator.generate(&config).unwrap();
         let ts = find_ts(&paths);
         let content = fs::read_to_string(ts).unwrap();
-        assert!(content.contains("Promise<string>"), "Promise<string> return type not found");
+        assert!(
+            content.contains("Promise<string>"),
+            "Promise<string> return type not found"
+        );
     }
 
     /// A multi-word snake_case tool name is exported as camelCase.
@@ -317,6 +339,36 @@ mod tests {
     // ------------------------------------------------------------------
     // .d.ts content
     // ------------------------------------------------------------------
+
+    /// Generated TypeScript intentionally uses Web-standard APIs only so the
+    /// public client remains portable to future V8-isolate/WASM packaging.
+    #[test]
+    fn ts_uses_fetch_and_avoids_node_native_imports() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = make_config(dir.path());
+        let paths = TypeScriptGenerator.generate(&config).unwrap();
+        let ts = find_ts(&paths);
+        let content = fs::read_to_string(ts).unwrap();
+
+        assert!(content.contains("fetch("));
+        for forbidden in [
+            "from 'node:",
+            "from \"node:",
+            "require(",
+            "Buffer",
+            "process.",
+            "fs.",
+            "net.",
+            "http.",
+            "EventEmitter",
+            "Readable",
+        ] {
+            assert!(
+                !content.contains(forbidden),
+                "generated TypeScript should avoid Node-native API marker {forbidden:?}"
+            );
+        }
+    }
 
     /// The `.d.ts` file contains `export` declarations.
     #[test]

--- a/crates/mcp-compressor-core/src/ffi/mod.rs
+++ b/crates/mcp-compressor-core/src/ffi/mod.rs
@@ -1,1 +1,3 @@
 pub mod types;
+
+pub use types::*;

--- a/crates/mcp-compressor-core/src/ffi/mod.rs
+++ b/crates/mcp-compressor-core/src/ffi/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "node")]
+pub mod node;
+#[cfg(feature = "python")]
+pub mod python;
 pub mod types;
 
 pub use types::*;

--- a/crates/mcp-compressor-core/src/ffi/node.rs
+++ b/crates/mcp-compressor-core/src/ffi/node.rs
@@ -1,0 +1,67 @@
+//! Optional napi-rs binding scaffold for the Rust core.
+//!
+//! Like the PyO3 scaffold, this starts with a JSON-string based surface so the
+//! TypeScript package can wrap stable Rust behavior without committing to final
+//! packaging details yet.
+
+use napi::Error as NapiError;
+use napi_derive::napi;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::compression::CompressionLevel;
+use crate::ffi::types::{
+    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response,
+    list_oauth_credentials, parse_mcp_config, parse_tool_argv, FfiTool,
+};
+
+fn napi_error(error: impl std::fmt::Display) -> NapiError {
+    NapiError::from_reason(error.to_string())
+}
+
+fn parse_json<T: for<'de> Deserialize<'de>>(value: &str) -> napi::Result<T> {
+    serde_json::from_str(value).map_err(napi_error)
+}
+
+#[napi]
+pub fn compress_tool_listing_json(level: String, tools_json: String) -> napi::Result<String> {
+    let level = level.parse::<CompressionLevel>().map_err(napi_error)?;
+    let tools = parse_json::<Vec<FfiTool>>(&tools_json)?;
+    Ok(compress_tool_listing(level, tools))
+}
+
+#[napi]
+pub fn format_tool_schema_response_json(tool_json: String) -> napi::Result<String> {
+    let tool = parse_json::<FfiTool>(&tool_json)?;
+    Ok(format_tool_schema_response(tool))
+}
+
+#[napi]
+pub fn parse_tool_argv_json(tool_json: String, argv_json: String) -> napi::Result<String> {
+    let tool = parse_json::<FfiTool>(&tool_json)?;
+    let argv = parse_json::<Vec<String>>(&argv_json)?;
+    let parsed = parse_tool_argv(tool, argv).map_err(napi_error)?;
+    serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn parse_mcp_config_json(config_json: String) -> napi::Result<String> {
+    let parsed = parse_mcp_config(&config_json).map_err(napi_error)?;
+    serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn list_oauth_credentials_json() -> napi::Result<String> {
+    let entries = list_oauth_credentials().map_err(napi_error)?;
+    serde_json::to_string(&entries).map_err(napi_error)
+}
+
+#[napi]
+pub fn clear_oauth_credentials_json(target: Option<String>) -> napi::Result<String> {
+    let paths = clear_oauth_credentials(target.as_deref()).map_err(napi_error)?;
+    let values = paths
+        .into_iter()
+        .map(|path| Value::String(path.to_string_lossy().into_owned()))
+        .collect::<Vec<_>>();
+    serde_json::to_string(&values).map_err(napi_error)
+}

--- a/crates/mcp-compressor-core/src/ffi/python.rs
+++ b/crates/mcp-compressor-core/src/ffi/python.rs
@@ -1,0 +1,111 @@
+//! Optional PyO3 binding scaffold for the Rust core.
+//!
+//! This intentionally exposes a small JSON-string based surface first. Python
+//! package integration can wrap these functions in idiomatic classes later,
+//! while this module proves the Rust core can be built as a Python extension
+//! without duplicating core behavior.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::compression::CompressionLevel;
+use crate::ffi::types::{
+    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response,
+    list_oauth_credentials, parse_mcp_config, parse_tool_argv, FfiTool,
+};
+
+fn py_value_error(error: impl std::fmt::Display) -> PyErr {
+    PyValueError::new_err(error.to_string())
+}
+
+fn parse_json<T: for<'de> Deserialize<'de>>(value: &str) -> PyResult<T> {
+    serde_json::from_str(value).map_err(py_value_error)
+}
+
+#[pyfunction]
+fn compress_tool_listing_json(level: &str, tools_json: &str) -> PyResult<String> {
+    let level = level.parse::<CompressionLevel>().map_err(py_value_error)?;
+    let tools = parse_json::<Vec<FfiTool>>(tools_json)?;
+    Ok(compress_tool_listing(level, tools))
+}
+
+#[pyfunction]
+fn format_tool_schema_response_json(tool_json: &str) -> PyResult<String> {
+    let tool = parse_json::<FfiTool>(tool_json)?;
+    Ok(format_tool_schema_response(tool))
+}
+
+#[pyfunction]
+fn parse_tool_argv_json(tool_json: &str, argv_json: &str) -> PyResult<String> {
+    let tool = parse_json::<FfiTool>(tool_json)?;
+    let argv = parse_json::<Vec<String>>(argv_json)?;
+    let parsed = parse_tool_argv(tool, argv).map_err(py_value_error)?;
+    serde_json::to_string(&parsed).map_err(py_value_error)
+}
+
+#[pyfunction]
+fn parse_mcp_config_json(config_json: &str) -> PyResult<String> {
+    let parsed = parse_mcp_config(config_json).map_err(py_value_error)?;
+    serde_json::to_string(&parsed).map_err(py_value_error)
+}
+
+#[pyfunction]
+fn list_oauth_credentials_json() -> PyResult<String> {
+    let entries = list_oauth_credentials().map_err(py_value_error)?;
+    serde_json::to_string(&entries).map_err(py_value_error)
+}
+
+#[pyfunction]
+fn clear_oauth_credentials_json(target: Option<&str>) -> PyResult<String> {
+    let paths = clear_oauth_credentials(target).map_err(py_value_error)?;
+    let values = paths
+        .into_iter()
+        .map(|path| Value::String(path.to_string_lossy().into_owned()))
+        .collect::<Vec<_>>();
+    serde_json::to_string(&values).map_err(py_value_error)
+}
+
+#[pymodule]
+fn _mcp_compressor_core(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(compress_tool_listing_json, module)?)?;
+    module.add_function(wrap_pyfunction!(format_tool_schema_response_json, module)?)?;
+    module.add_function(wrap_pyfunction!(parse_tool_argv_json, module)?)?;
+    module.add_function(wrap_pyfunction!(parse_mcp_config_json, module)?)?;
+    module.add_function(wrap_pyfunction!(list_oauth_credentials_json, module)?)?;
+    module.add_function(wrap_pyfunction!(clear_oauth_credentials_json, module)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_tool_json() -> String {
+        json!({
+            "name": "echo",
+            "description": "Echo a value.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"message": {"type": "string"}},
+                "required": ["message"]
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn python_binding_scaffold_compresses_listing() {
+        let listing =
+            compress_tool_listing_json("high", &format!("[{}]", sample_tool_json())).unwrap();
+        assert_eq!(listing, "<tool>echo(message)</tool>");
+    }
+
+    #[test]
+    fn python_binding_scaffold_parses_tool_argv() {
+        let parsed = parse_tool_argv_json(&sample_tool_json(), r#"["--message","hello"]"#).unwrap();
+        assert_eq!(parsed, r#"{"message":"hello"}"#);
+    }
+}

--- a/crates/mcp-compressor-core/src/ffi/types.rs
+++ b/crates/mcp-compressor-core/src/ffi/types.rs
@@ -1,3 +1,183 @@
-//! FFI-safe structs and C-ABI surface for PyO3 / napi-rs language bindings.
+//! JSON-serializable DTOs and helpers for PyO3 / napi-rs language bindings.
+//!
+//! These are not a C ABI. They are intentionally plain Rust data-transfer
+//! objects that binding crates can expose idiomatically in Python and
+//! TypeScript while sharing the same core behavior.
 
-// Stub — implementation added in Phase 2 (language bindings).
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::cli::parser::parse_argv;
+use crate::compression::engine::{CompressionEngine, Tool};
+use crate::compression::CompressionLevel;
+use crate::config::topology::MCPConfig;
+use crate::server::{JustBashCommandSpec, JustBashProviderSpec};
+use crate::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FfiTool {
+    pub name: String,
+    pub description: Option<String>,
+    pub input_schema: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FfiMcpServer {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub cli_prefix: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FfiJustBashProviderSpec {
+    pub provider_name: String,
+    pub help_tool_name: String,
+    pub tools: Vec<FfiJustBashCommandSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FfiJustBashCommandSpec {
+    pub command_name: String,
+    pub backend_tool_name: String,
+    pub description: Option<String>,
+    pub input_schema: Value,
+    pub invoke_tool_name: String,
+}
+
+pub fn compress_tool_listing(level: CompressionLevel, tools: Vec<FfiTool>) -> String {
+    let tools = tools.into_iter().map(Into::into).collect::<Vec<Tool>>();
+    CompressionEngine::new(level).format_listing(&tools)
+}
+
+pub fn format_tool_schema_response(tool: FfiTool) -> String {
+    CompressionEngine::format_schema_response(&tool.into())
+}
+
+pub fn parse_tool_argv(tool: FfiTool, argv: Vec<String>) -> Result<Value, Error> {
+    parse_argv(&argv, &tool.into())
+}
+
+pub fn parse_mcp_config(config_json: &str) -> Result<Vec<FfiMcpServer>, Error> {
+    let config = MCPConfig::from_json(config_json)?;
+    Ok(config
+        .server_names()
+        .into_iter()
+        .filter_map(|name| {
+            let server = config.server(&name)?;
+            Some(FfiMcpServer {
+                cli_prefix: config.cli_prefix(&name),
+                name,
+                command: server.command.clone(),
+                args: server.args.clone(),
+                env: server
+                    .env
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect(),
+            })
+        })
+        .collect())
+}
+
+impl From<FfiTool> for Tool {
+    fn from(value: FfiTool) -> Self {
+        Tool::new(value.name, value.description, value.input_schema)
+    }
+}
+
+impl From<Tool> for FfiTool {
+    fn from(value: Tool) -> Self {
+        Self {
+            name: value.name,
+            description: value.description,
+            input_schema: value.input_schema,
+        }
+    }
+}
+
+impl From<JustBashProviderSpec> for FfiJustBashProviderSpec {
+    fn from(value: JustBashProviderSpec) -> Self {
+        Self {
+            provider_name: value.provider_name,
+            help_tool_name: value.help_tool_name,
+            tools: value.tools.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<JustBashCommandSpec> for FfiJustBashCommandSpec {
+    fn from(value: JustBashCommandSpec) -> Self {
+        Self {
+            command_name: value.command_name,
+            backend_tool_name: value.backend_tool_name,
+            description: value.description,
+            input_schema: value.input_schema,
+            invoke_tool_name: value.invoke_tool_name,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_tool() -> FfiTool {
+        FfiTool {
+            name: "echo".to_string(),
+            description: Some("Echo a message.".to_string()),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "message": { "type": "string" }
+                },
+                "required": ["message"]
+            }),
+        }
+    }
+
+    #[test]
+    fn ffi_compresses_tool_listing() {
+        let listing = compress_tool_listing(CompressionLevel::High, vec![sample_tool()]);
+        assert_eq!(listing, "<tool>echo(message)</tool>");
+    }
+
+    #[test]
+    fn ffi_formats_schema_response() {
+        let schema = format_tool_schema_response(sample_tool());
+        assert!(schema.contains("Echo a message."));
+        assert!(schema.contains("message"));
+    }
+
+    #[test]
+    fn ffi_parses_tool_argv() {
+        let parsed = parse_tool_argv(
+            sample_tool(),
+            vec!["--message".to_string(), "hello".to_string()],
+        )
+        .unwrap();
+        assert_eq!(parsed, json!({ "message": "hello" }));
+    }
+
+    #[test]
+    fn ffi_parses_mcp_config() {
+        let parsed = parse_mcp_config(
+            r#"{
+                "mcpServers": {
+                    "my server": {
+                        "command": "python3",
+                        "args": ["server.py"],
+                        "env": { "A": "B" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].name, "my server");
+        assert_eq!(parsed[0].cli_prefix, "my-server");
+        assert_eq!(parsed[0].env, vec![("A".to_string(), "B".to_string())]);
+    }
+}

--- a/crates/mcp-compressor-core/src/ffi/types.rs
+++ b/crates/mcp-compressor-core/src/ffi/types.rs
@@ -4,15 +4,62 @@
 //! objects that binding crates can expose idiomatically in Python and
 //! TypeScript while sharing the same core behavior.
 
+use std::path::PathBuf;
+#[cfg(test)]
+use std::process::{Command, Stdio};
+#[cfg(test)]
+use std::time::{Duration, Instant};
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::cli::parser::parse_argv;
+use crate::client_gen::cli::CliGenerator;
+use crate::client_gen::generator::{ClientGenerator, GeneratorConfig};
+use crate::client_gen::python::PythonGenerator;
+use crate::client_gen::typescript::TypeScriptGenerator;
 use crate::compression::engine::{CompressionEngine, Tool};
 use crate::compression::CompressionLevel;
 use crate::config::topology::MCPConfig;
-use crate::server::{JustBashCommandSpec, JustBashProviderSpec};
+use crate::oauth::{
+    clear_oauth_store, list_oauth_stores, oauth_store_root, remember_oauth_store,
+    OAuthStoreIndexEntry,
+};
+use crate::proxy::ToolProxyServer;
+use crate::server::{
+    BackendServerConfig, CompressedServer, CompressedServerConfig, JustBashCommandSpec,
+    JustBashProviderSpec, ProxyTransformMode,
+};
 use crate::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FfiOAuthStoreEntry {
+    pub backend_name: String,
+    pub backend_uri: String,
+    pub store_dir: PathBuf,
+}
+
+pub fn oauth_store_path() -> PathBuf {
+    oauth_store_root()
+}
+
+pub fn remember_oauth_backend(
+    backend_uri: &str,
+    backend_name: &str,
+    store_dir: PathBuf,
+) -> Result<(), Error> {
+    remember_oauth_store(backend_uri, backend_name, &store_dir).map_err(Error::Io)
+}
+
+pub fn list_oauth_credentials() -> Result<Vec<FfiOAuthStoreEntry>, Error> {
+    list_oauth_stores()
+        .map(|entries| entries.into_iter().map(Into::into).collect())
+        .map_err(Error::Io)
+}
+
+pub fn clear_oauth_credentials(target: Option<&str>) -> Result<Vec<PathBuf>, Error> {
+    clear_oauth_store(target).map_err(Error::Io)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FfiTool {
@@ -59,6 +106,156 @@ pub fn parse_tool_argv(tool: FfiTool, argv: Vec<String>) -> Result<Value, Error>
     parse_argv(&argv, &tool.into())
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FfiGeneratorConfig {
+    pub cli_name: String,
+    pub bridge_url: String,
+    pub token: String,
+    pub tools: Vec<FfiTool>,
+    pub session_pid: u32,
+    pub output_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum FfiClientArtifactKind {
+    Cli,
+    Python,
+    TypeScript,
+}
+
+pub fn generate_client_artifacts(
+    kind: FfiClientArtifactKind,
+    config: FfiGeneratorConfig,
+) -> Result<Vec<PathBuf>, Error> {
+    let config = GeneratorConfig::from(config);
+    match kind {
+        FfiClientArtifactKind::Cli => CliGenerator.generate(&config),
+        FfiClientArtifactKind::Python => PythonGenerator.generate(&config),
+        FfiClientArtifactKind::TypeScript => TypeScriptGenerator.generate(&config),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FfiBackendConfig {
+    pub name: String,
+    pub command_or_url: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FfiCompressedSessionConfig {
+    pub compression_level: String,
+    pub server_name: Option<String>,
+    #[serde(default)]
+    pub include_tools: Vec<String>,
+    #[serde(default)]
+    pub exclude_tools: Vec<String>,
+    #[serde(default)]
+    pub toonify: bool,
+    pub transform_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FfiCompressedSessionInfo {
+    pub bridge_url: String,
+    pub token: String,
+    pub frontend_tools: Vec<FfiTool>,
+    pub just_bash_providers: Vec<FfiJustBashProviderSpec>,
+}
+
+pub struct FfiCompressedSession {
+    info: FfiCompressedSessionInfo,
+}
+
+impl FfiCompressedSession {
+    pub fn bridge_url(&self) -> &str {
+        &self.info.bridge_url
+    }
+
+    pub fn token(&self) -> &str {
+        &self.info.token
+    }
+
+    pub fn info(&self) -> FfiCompressedSessionInfo {
+        self.info.clone()
+    }
+}
+
+fn parse_ffi_transform_mode(value: Option<&str>) -> Result<ProxyTransformMode, Error> {
+    match value.unwrap_or("compressed-tools") {
+        "compressed-tools" | "compressed" | "normal" => Ok(ProxyTransformMode::CompressedTools),
+        "cli" | "cli-mode" => Ok(ProxyTransformMode::Cli),
+        "just-bash" | "just_bash" => Ok(ProxyTransformMode::JustBash),
+        other => Err(Error::Config(format!("invalid transform mode: {other}"))),
+    }
+}
+
+async fn compressed_session_from_server(
+    server: CompressedServer,
+) -> Result<FfiCompressedSession, Error> {
+    let frontend_tools = server
+        .list_frontend_tools()
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    let just_bash_providers = server
+        .just_bash_provider_specs()
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    let proxy = ToolProxyServer::start(server).await?;
+    Ok(FfiCompressedSession {
+        info: FfiCompressedSessionInfo {
+            bridge_url: proxy.bridge_url().to_string(),
+            token: proxy.token_value().to_string(),
+            frontend_tools,
+            just_bash_providers,
+        },
+    })
+}
+
+pub async fn start_compressed_session(
+    config: FfiCompressedSessionConfig,
+    backends: Vec<FfiBackendConfig>,
+) -> Result<FfiCompressedSession, Error> {
+    let server = CompressedServer::connect_multi_stdio(
+        CompressedServerConfig {
+            level: config.compression_level.parse()?,
+            server_name: config.server_name,
+            include_tools: config.include_tools,
+            exclude_tools: config.exclude_tools,
+            toonify: config.toonify,
+            transform_mode: parse_ffi_transform_mode(config.transform_mode.as_deref())?,
+            ..CompressedServerConfig::default()
+        },
+        backends.into_iter().map(Into::into).collect(),
+    )
+    .await?;
+    compressed_session_from_server(server).await
+}
+
+pub async fn start_compressed_session_from_mcp_config(
+    config: FfiCompressedSessionConfig,
+    mcp_config_json: &str,
+) -> Result<FfiCompressedSession, Error> {
+    let server = CompressedServer::connect_mcp_config_json(
+        CompressedServerConfig {
+            level: config.compression_level.parse()?,
+            server_name: config.server_name,
+            include_tools: config.include_tools,
+            exclude_tools: config.exclude_tools,
+            toonify: config.toonify,
+            transform_mode: parse_ffi_transform_mode(config.transform_mode.as_deref())?,
+            ..CompressedServerConfig::default()
+        },
+        mcp_config_json,
+    )
+    .await?;
+    compressed_session_from_server(server).await
+}
+
 pub fn parse_mcp_config(config_json: &str) -> Result<Vec<FfiMcpServer>, Error> {
     let config = MCPConfig::from_json(config_json)?;
     Ok(config
@@ -79,6 +276,35 @@ pub fn parse_mcp_config(config_json: &str) -> Result<Vec<FfiMcpServer>, Error> {
             })
         })
         .collect())
+}
+
+impl From<OAuthStoreIndexEntry> for FfiOAuthStoreEntry {
+    fn from(value: OAuthStoreIndexEntry) -> Self {
+        Self {
+            backend_name: value.name,
+            backend_uri: value.uri,
+            store_dir: value.store_dir.into(),
+        }
+    }
+}
+
+impl From<FfiBackendConfig> for BackendServerConfig {
+    fn from(value: FfiBackendConfig) -> Self {
+        BackendServerConfig::new(value.name, value.command_or_url, value.args)
+    }
+}
+
+impl From<FfiGeneratorConfig> for GeneratorConfig {
+    fn from(value: FfiGeneratorConfig) -> Self {
+        Self {
+            cli_name: value.cli_name,
+            bridge_url: value.bridge_url,
+            token: value.token,
+            tools: value.tools.into_iter().map(Into::into).collect(),
+            session_pid: value.session_pid,
+            output_dir: value.output_dir,
+        }
+    }
 }
 
 impl From<FfiTool> for Tool {
@@ -139,6 +365,38 @@ mod tests {
     }
 
     #[test]
+    fn ffi_lists_and_clears_oauth_credentials() {
+        let dir = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", dir.path());
+
+        let store_dir = oauth_store_path().join("example-store");
+        std::fs::create_dir_all(&store_dir).unwrap();
+        remember_oauth_backend("https://example.test/mcp", "example", store_dir.clone()).unwrap();
+
+        let entries = list_oauth_credentials().unwrap();
+        let entry = entries
+            .iter()
+            .find(|entry| entry.backend_name == "example")
+            .expect("remembered entry");
+        assert_eq!(entry.backend_uri, "https://example.test/mcp");
+        assert_eq!(entry.store_dir, store_dir);
+
+        let cleared = clear_oauth_credentials(Some("example")).unwrap();
+        assert!(cleared.iter().any(|path| path.ends_with("example-store")));
+        assert!(!list_oauth_credentials()
+            .unwrap()
+            .iter()
+            .any(|entry| entry.backend_name == "example"));
+
+        if let Some(value) = previous {
+            std::env::set_var("XDG_CONFIG_HOME", value);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+    }
+
+    #[test]
     fn ffi_compresses_tool_listing() {
         let listing = compress_tool_listing(CompressionLevel::High, vec![sample_tool()]);
         assert_eq!(listing, "<tool>echo(message)</tool>");
@@ -159,6 +417,355 @@ mod tests {
         )
         .unwrap();
         assert_eq!(parsed, json!({ "message": "hello" }));
+    }
+
+    fn generator_config(output_dir: &std::path::Path) -> FfiGeneratorConfig {
+        FfiGeneratorConfig {
+            cli_name: "ffi-server".to_string(),
+            bridge_url: "http://127.0.0.1:12345".to_string(),
+            token: "token".repeat(16),
+            tools: vec![sample_tool()],
+            session_pid: 42,
+            output_dir: output_dir.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn ffi_generates_cli_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths =
+            generate_client_artifacts(FfiClientArtifactKind::Cli, generator_config(dir.path()))
+                .unwrap();
+        assert_eq!(paths.len(), 1);
+        let content = std::fs::read_to_string(&paths[0]).unwrap();
+        assert!(content.contains("ffi-server - the ffi-server toolset"));
+    }
+
+    #[test]
+    fn ffi_generates_python_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths =
+            generate_client_artifacts(FfiClientArtifactKind::Python, generator_config(dir.path()))
+                .unwrap();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(
+            paths[0].extension().and_then(|ext| ext.to_str()),
+            Some("py")
+        );
+    }
+
+    #[test]
+    fn ffi_generates_typescript_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = generate_client_artifacts(
+            FfiClientArtifactKind::TypeScript,
+            generator_config(dir.path()),
+        )
+        .unwrap();
+        assert_eq!(paths.len(), 2);
+        assert!(paths
+            .iter()
+            .any(|path| path.extension().and_then(|ext| ext.to_str()) == Some("ts")));
+        assert!(paths.iter().any(|path| path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".d.ts"))));
+    }
+
+    async fn invoke_session(
+        info: &FfiCompressedSessionInfo,
+        tool: &str,
+        tool_name: &str,
+        tool_input: Value,
+    ) -> String {
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!("{}/exec", info.bridge_url))
+            .bearer_auth(&info.token)
+            .json(&serde_json::json!({
+                "tool": tool,
+                "input": {
+                    "tool_name": tool_name,
+                    "tool_input": tool_input
+                }
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert!(response.status().is_success());
+        response.text().await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn ffi_starts_compressed_session_and_proxy() {
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("alpha_server.py");
+        let session = start_compressed_session(
+            FfiCompressedSessionConfig {
+                compression_level: "max".to_string(),
+                server_name: Some("alpha".to_string()),
+                include_tools: Vec::new(),
+                exclude_tools: Vec::new(),
+                toonify: false,
+                transform_mode: None,
+            },
+            vec![FfiBackendConfig {
+                name: "alpha".to_string(),
+                command_or_url: std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
+                args: vec![fixture.to_string_lossy().into_owned()],
+            }],
+        )
+        .await
+        .unwrap();
+        let info = session.info();
+        assert!(info.bridge_url.starts_with("http://127.0.0.1:"));
+        assert!(!info.token.is_empty());
+        let invoke_tool_name = info
+            .frontend_tools
+            .iter()
+            .find(|tool| tool.name.ends_with("invoke_tool"))
+            .map(|tool| tool.name.clone())
+            .expect("invoke wrapper tool");
+
+        assert_eq!(
+            invoke_session(
+                &info,
+                &invoke_tool_name,
+                "echo",
+                serde_json::json!({"message": "ffi"})
+            )
+            .await,
+            "alpha:ffi"
+        );
+    }
+
+    #[tokio::test]
+    async fn ffi_starts_compressed_session_from_mcp_config_and_routes_multiple_servers() {
+        let fixture_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures");
+        let python = std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string());
+        let config_json = serde_json::json!({
+            "mcpServers": {
+                "alpha": {
+                    "command": python,
+                    "args": [fixture_dir.join("alpha_server.py").to_string_lossy()]
+                },
+                "beta": {
+                    "command": std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
+                    "args": [fixture_dir.join("beta_server.py").to_string_lossy()]
+                }
+            }
+        })
+        .to_string();
+        let session = start_compressed_session_from_mcp_config(
+            FfiCompressedSessionConfig {
+                compression_level: "max".to_string(),
+                server_name: None,
+                include_tools: Vec::new(),
+                exclude_tools: Vec::new(),
+                toonify: false,
+                transform_mode: None,
+            },
+            &config_json,
+        )
+        .await
+        .unwrap();
+        let info = session.info();
+        assert!(info
+            .frontend_tools
+            .iter()
+            .any(|tool| tool.name == "alpha_invoke_tool"));
+        assert!(info
+            .frontend_tools
+            .iter()
+            .any(|tool| tool.name == "beta_invoke_tool"));
+        assert_eq!(
+            invoke_session(
+                &info,
+                "alpha_invoke_tool",
+                "add",
+                serde_json::json!({"a": 2, "b": 5})
+            )
+            .await,
+            "7"
+        );
+        assert_eq!(
+            invoke_session(
+                &info,
+                "beta_invoke_tool",
+                "multiply",
+                serde_json::json!({"a": 3, "b": 4})
+            )
+            .await,
+            "12"
+        );
+    }
+
+    #[tokio::test]
+    async fn ffi_session_can_request_cli_transform_mode() {
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("alpha_server.py");
+        let session = start_compressed_session(
+            FfiCompressedSessionConfig {
+                compression_level: "max".to_string(),
+                server_name: Some("alpha".to_string()),
+                include_tools: Vec::new(),
+                exclude_tools: Vec::new(),
+                toonify: false,
+                transform_mode: Some("cli".to_string()),
+            },
+            vec![FfiBackendConfig {
+                name: "alpha".to_string(),
+                command_or_url: std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
+                args: vec![fixture.to_string_lossy().into_owned()],
+            }],
+        )
+        .await
+        .unwrap();
+        let info = session.info();
+        assert_eq!(info.frontend_tools.len(), 1);
+        assert!(info.frontend_tools[0].name.ends_with("alpha_help"));
+    }
+
+    #[tokio::test]
+    async fn ffi_session_can_request_just_bash_transform_mode() {
+        let fixture_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures");
+        let python = std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string());
+        let session = start_compressed_session(
+            FfiCompressedSessionConfig {
+                compression_level: "max".to_string(),
+                server_name: None,
+                include_tools: Vec::new(),
+                exclude_tools: Vec::new(),
+                toonify: false,
+                transform_mode: Some("just-bash".to_string()),
+            },
+            vec![
+                FfiBackendConfig {
+                    name: "alpha".to_string(),
+                    command_or_url: python.clone(),
+                    args: vec![fixture_dir
+                        .join("alpha_server.py")
+                        .to_string_lossy()
+                        .into_owned()],
+                },
+                FfiBackendConfig {
+                    name: "beta".to_string(),
+                    command_or_url: python,
+                    args: vec![fixture_dir
+                        .join("beta_server.py")
+                        .to_string_lossy()
+                        .into_owned()],
+                },
+            ],
+        )
+        .await
+        .unwrap();
+        let info = session.info();
+        assert!(info
+            .frontend_tools
+            .iter()
+            .any(|tool| tool.name == "bash_tool"));
+        assert!(info
+            .frontend_tools
+            .iter()
+            .any(|tool| tool.name == "alpha_help"));
+        assert_eq!(info.just_bash_providers.len(), 2);
+        assert!(info
+            .just_bash_providers
+            .iter()
+            .any(|provider| provider.provider_name == "alpha"));
+    }
+
+    #[tokio::test]
+    async fn ffi_starts_compressed_session_with_remote_streamable_http_backend() {
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("alpha_server.py");
+        let binary = std::env::var("CARGO_BIN_EXE_mcp-compressor-core").unwrap_or_else(|_| {
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../target/debug/mcp-compressor-core")
+                .to_string_lossy()
+                .into_owned()
+        });
+        let mut process = Command::new(binary)
+            .args([
+                "--compression",
+                "max",
+                "--server-name",
+                "upstream",
+                "--transport",
+                "streamable-http",
+                "--port",
+                "0",
+                "--",
+                &std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
+                &fixture.to_string_lossy(),
+            ])
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let mut stderr = std::io::BufReader::new(process.stderr.take().unwrap());
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut url = None;
+        while Instant::now() < deadline {
+            let mut line = String::new();
+            use std::io::BufRead;
+            stderr.read_line(&mut line).unwrap();
+            if let Some(rest) = line.strip_prefix("Streamable HTTP MCP server listening on ") {
+                url = Some(rest.trim().to_string());
+                break;
+            }
+            if let Some(status) = process.try_wait().unwrap() {
+                panic!("upstream exited early: {status}");
+            }
+        }
+        let url = url.expect("upstream streamable HTTP URL");
+
+        let session = start_compressed_session(
+            FfiCompressedSessionConfig {
+                compression_level: "max".to_string(),
+                server_name: Some("remote".to_string()),
+                include_tools: Vec::new(),
+                exclude_tools: Vec::new(),
+                toonify: false,
+                transform_mode: None,
+            },
+            vec![FfiBackendConfig {
+                name: "remote".to_string(),
+                command_or_url: url,
+                args: vec!["--auth".to_string(), "explicit-headers".to_string()],
+            }],
+        )
+        .await
+        .unwrap();
+        let info = session.info();
+        let invoke_tool_name = info
+            .frontend_tools
+            .iter()
+            .find(|tool| tool.name.ends_with("invoke_tool"))
+            .map(|tool| tool.name.clone())
+            .expect("invoke wrapper tool");
+        assert_eq!(
+            invoke_session(
+                &info,
+                &invoke_tool_name,
+                "upstream_invoke_tool",
+                serde_json::json!({"tool_name": "echo", "tool_input": {"message": "remote-ffi"}}),
+            )
+            .await,
+            "alpha:remote-ffi"
+        );
+        process.kill().ok();
+        process.wait().ok();
     }
 
     #[test]

--- a/crates/mcp-compressor-core/src/oauth.rs
+++ b/crates/mcp-compressor-core/src/oauth.rs
@@ -388,6 +388,10 @@ pub fn remember_oauth_store(uri: &str, name: &str, store_dir: &Path) -> Result<(
     )
 }
 
+pub fn list_oauth_stores() -> Result<Vec<OAuthStoreIndexEntry>, std::io::Error> {
+    read_oauth_store_index_from(&oauth_store_root().join("index.json"))
+}
+
 pub fn clear_oauth_store(target: Option<&str>) -> Result<Vec<PathBuf>, std::io::Error> {
     let root = oauth_store_root();
     let index_path = root.join("index.json");

--- a/crates/mcp-compressor-core/src/server/mod.rs
+++ b/crates/mcp-compressor-core/src/server/mod.rs
@@ -4,6 +4,6 @@ pub mod tool_cache;
 
 pub use compressed::{
     BackendConfigSource, BackendServerConfig, CompressedServer, CompressedServerConfig,
-    ProxyTransformMode, RunningCompressedServer,
+    JustBashCommandSpec, JustBashProviderSpec, ProxyTransformMode, RunningCompressedServer,
 };
 pub use tool_cache::ToolCache;


### PR DESCRIPTION
## Summary
- add JSON-serializable DTOs for future PyO3/napi-rs bindings
- expose helpers for compression listing, schema response formatting, schema-driven argv parsing, and MCP config parsing
- expose Just Bash provider specs through FFI DTOs for Python/TS binding integration
- re-export FFI helper surface from `ffi::mod`

## Validation
- `cargo test -p mcp-compressor-core ffi:: -- --nocapture`
- `cargo check -p mcp-compressor-core`

Stacked on #59 / `rust-just-bash-exec-mvp`.