### PR TITLE
feat: add optional napi binding scaffold

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Check Rust core library
         run: cargo check -p mcp-compressor-core
 
+      - name: Check optional Rust binding features
+        run: |
+          cargo check -p mcp-compressor-core --features python
+          cargo check -p mcp-compressor-core --features node
+
+      - name: Run optional PyO3 binding scaffold tests
+        run: cargo test -p mcp-compressor-core --features python ffi::python -- --nocapture
+
       - name: Run Rust core library tests
         run: cargo test -p mcp-compressor-core --lib -- --nocapture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +355,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
 name = "darling"
@@ -976,6 +991,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1042,8 @@ dependencies = [
  "axum",
  "clap",
  "dirs",
+ "napi",
+ "napi-derive",
  "open",
  "predicates",
  "pyo3",
@@ -1055,6 +1082,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "napi"
+version = "3.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+dependencies = [
+ "bitflags",
+ "ctor",
+ "futures",
+ "napi-build",
+ "napi-sys",
+ "nohash-hasher",
+ "rustc-hash",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+
+[[package]]
+name = "napi-derive"
+version = "3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+dependencies = [
+ "convert_case",
+ "ctor",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn",
+]
+
+[[package]]
+name = "napi-sys"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1166,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "normalize-line-endings"
@@ -1572,6 +1662,12 @@ dependencies = [
  "serde_json",
  "syn",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2097,6 +2193,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -18,10 +18,13 @@ clap = { version = "4", features = ["derive"] }
 open = "5.3"
 toon-format = { version = "0.4.5", default-features = false }
 pyo3 = { version = "0.28.3", optional = true }
+napi = { version = "3.8.6", optional = true, default-features = false, features = ["napi4"] }
+napi-derive = { version = "3.5.5", optional = true }
 
 [features]
 default = []
 python = ["dep:pyo3"]
+node = ["dep:napi", "dep:napi-derive"]
 
 [dev-dependencies]
 # async test runtime and macros (#[tokio::test])

--- a/crates/mcp-compressor-core/src/ffi/mod.rs
+++ b/crates/mcp-compressor-core/src/ffi/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "node")]
+pub mod node;
 #[cfg(feature = "python")]
 pub mod python;
 pub mod types;

--- a/crates/mcp-compressor-core/src/ffi/node.rs
+++ b/crates/mcp-compressor-core/src/ffi/node.rs
@@ -1,0 +1,67 @@
+//! Optional napi-rs binding scaffold for the Rust core.
+//!
+//! Like the PyO3 scaffold, this starts with a JSON-string based surface so the
+//! TypeScript package can wrap stable Rust behavior without committing to final
+//! packaging details yet.
+
+use napi::Error as NapiError;
+use napi_derive::napi;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::compression::CompressionLevel;
+use crate::ffi::types::{
+    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response,
+    list_oauth_credentials, parse_mcp_config, parse_tool_argv, FfiTool,
+};
+
+fn napi_error(error: impl std::fmt::Display) -> NapiError {
+    NapiError::from_reason(error.to_string())
+}
+
+fn parse_json<T: for<'de> Deserialize<'de>>(value: &str) -> napi::Result<T> {
+    serde_json::from_str(value).map_err(napi_error)
+}
+
+#[napi]
+pub fn compress_tool_listing_json(level: String, tools_json: String) -> napi::Result<String> {
+    let level = level.parse::<CompressionLevel>().map_err(napi_error)?;
+    let tools = parse_json::<Vec<FfiTool>>(&tools_json)?;
+    Ok(compress_tool_listing(level, tools))
+}
+
+#[napi]
+pub fn format_tool_schema_response_json(tool_json: String) -> napi::Result<String> {
+    let tool = parse_json::<FfiTool>(&tool_json)?;
+    Ok(format_tool_schema_response(tool))
+}
+
+#[napi]
+pub fn parse_tool_argv_json(tool_json: String, argv_json: String) -> napi::Result<String> {
+    let tool = parse_json::<FfiTool>(&tool_json)?;
+    let argv = parse_json::<Vec<String>>(&argv_json)?;
+    let parsed = parse_tool_argv(tool, argv).map_err(napi_error)?;
+    serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn parse_mcp_config_json(config_json: String) -> napi::Result<String> {
+    let parsed = parse_mcp_config(&config_json).map_err(napi_error)?;
+    serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn list_oauth_credentials_json() -> napi::Result<String> {
+    let entries = list_oauth_credentials().map_err(napi_error)?;
+    serde_json::to_string(&entries).map_err(napi_error)
+}
+
+#[napi]
+pub fn clear_oauth_credentials_json(target: Option<String>) -> napi::Result<String> {
+    let paths = clear_oauth_credentials(target.as_deref()).map_err(napi_error)?;
+    let values = paths
+        .into_iter()
+        .map(|path| Value::String(path.to_string_lossy().into_owned()))
+        .collect::<Vec<_>>();
+    serde_json::to_string(&values).map_err(napi_error)
+}


### PR DESCRIPTION
## Summary
- add optional `node` Cargo feature with napi-rs dependencies
- add initial `ffi::node` module exposing JSON-string based helper functions for pure Rust core behavior
- mirror the PyO3 scaffold surface for compression listing, schema formatting, argv parsing, MCP config parsing, and OAuth list/clear helpers
- keep TypeScript package packaging/cutover unchanged; this is only a Rust-side N-API scaffold

## Validation
- `cargo check -p mcp-compressor-core --features node`
- `cargo check -p mcp-compressor-core`
- `cargo test -p mcp-compressor-core --tests --no-run`

Note: normal Rust unit tests are not run with the `node` feature because N-API symbols are provided by Node's loader when packaged as a native addon. Packaging should be a later dedicated PR.

Stacked on #68 / `rust-python-binding-scaffold`.