### PR TITLE
ci: check optional rust binding features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Check Rust core library
         run: cargo check -p mcp-compressor-core
 
+      - name: Check optional Rust binding features
+        run: |
+          cargo check -p mcp-compressor-core --features python
+          cargo check -p mcp-compressor-core --features node
+
+      - name: Run optional PyO3 binding scaffold tests
+        run: cargo test -p mcp-compressor-core --features python ffi::python -- --nocapture
+
       - name: Run Rust core library tests
         run: cargo test -p mcp-compressor-core --lib -- --nocapture
 


### PR DESCRIPTION
## Summary
- extend Rust CI to check optional Python and Node binding feature surfaces
- run `cargo check --features python` and `cargo check --features node`
- run optional PyO3 scaffold tests in CI
- keep napi-rs at check-only because N-API symbols are provided by Node's native-addon loader during packaging

## Validation
- `cargo check -p mcp-compressor-core`
- `cargo check -p mcp-compressor-core --features python`
- `cargo check -p mcp-compressor-core --features node`
- `cargo test -p mcp-compressor-core --features python ffi::python -- --nocapture`

Stacked on #69 / `rust-napi-binding-scaffold`.