### PR TITLE
ci: split rust core checks into parallel jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check typing
         run: uv run ty check
 
-  rust-core-tests:
+  rust-core-unit:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
@@ -60,9 +60,6 @@ jobs:
 
       - name: Set up the Python environment
         uses: ./.github/actions/setup-python-env
-
-      - name: Set up Bun for generated TypeScript client e2e
-        uses: oven-sh/setup-bun@v2
 
       - name: Check Rust core library
         run: cargo check -p mcp-compressor-core
@@ -77,6 +74,21 @@ jobs:
           PYTHON: ${{ github.workspace }}/.venv/bin/python3
         run: cargo test -p mcp-compressor-core --lib -- --nocapture
 
+  rust-core-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up the Python environment
+        uses: ./.github/actions/setup-python-env
+
+      - name: Set up Bun for generated TypeScript client e2e
+        uses: oven-sh/setup-bun@v2
+
       - name: Run Rust core integration tests
         env:
           PYTHON: ${{ github.workspace }}/.venv/bin/python3
@@ -88,9 +100,31 @@ jobs:
           cargo test -p mcp-compressor-core --test proxy_http -- --nocapture
           cargo test -p mcp-compressor-core --test generated_clients -- --nocapture
           cargo test -p mcp-compressor-core --test cli_binary -- --nocapture
+          cargo test -p mcp-compressor-core --test transform_modes -- --nocapture
+
+  rust-binary-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up the Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Run Rust binary normal-mode FastMCP e2e
         run: uv run pytest -q tests/test_rust_core_normal_mode.py
+
+  rust-contract-compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Compile all Rust core integration targets
         run: cargo test -p mcp-compressor-core --tests --no-run


### PR DESCRIPTION
## Summary
- split the monolithic Rust CI job into focused parallel jobs
- add separate jobs for Rust unit/feature checks, Rust integration tests, Rust binary FastMCP e2e, and contract compile checks
- keep the existing Python/TypeScript/doc jobs unchanged

## Rust jobs
- `rust-core-unit`: core checks, optional Python/Node feature checks, lib tests
- `rust-core-integration`: Rust integration tests including generated clients
- `rust-binary-e2e`: FastMCP black-box tests against the Rust binary
- `rust-contract-compile`: compile all Rust integration targets

## Validation
- `cargo check -p mcp-compressor-core`
- `cargo check -p mcp-compressor-core --features python`
- `cargo check -p mcp-compressor-core --features node`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python3" cargo test -p mcp-compressor-core --lib -- --nocapture`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python3" cargo test -p mcp-compressor-core --test generated_clients -- --nocapture`
- `uv run pytest -q tests/test_rust_core_normal_mode.py`
- `cargo test -p mcp-compressor-core --tests --no-run`
- all remaining named Rust integration tests run locally