### PR TITLE
build: add rust-backed typescript native addon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Set up root Python environment for fixture servers
+        uses: ./.github/actions/setup-python-env
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
 
@@ -150,6 +153,8 @@ jobs:
 
       - name: Run rust-backed Python package tests
         working-directory: python/mcp-compressor-rust
+        env:
+          PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: uv run pytest -q tests
 
       - name: Run rust-backed Python package lint and type checks
@@ -182,8 +187,8 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Set up uv (needed for e2e tests that launch Python fixture servers)
-        uses: astral-sh/setup-uv@v6
+      - name: Set up Python environment (needed for e2e tests that launch Python fixture servers)
+        uses: ./.github/actions/setup-python-env
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -192,4 +197,6 @@ jobs:
         run: bun run build:native
 
       - name: Run TypeScript package checks
+        env:
+          PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: bun run check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Check Rust-backed Python extension crate
         run: cargo check -p mcp-compressor-python
 
+      - name: Check Rust-backed Node extension crate
+        run: cargo check -p mcp-compressor-node
+
       - name: Run Rust core library tests
         env:
           PYTHON: ${{ github.workspace }}/.venv/bin/python3
@@ -184,6 +187,9 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Build Rust native addon
+        run: bun run build:native
 
       - name: Run TypeScript package checks
         run: bun run check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build Rust core binary
+        run: bun run build:core
+
       - name: Build Rust native addon
         run: bun run build:native
 

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,11 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# Native addon build outputs
+*.node
+typescript/native/index.js
+typescript/native/index.d.ts
+
 # Abstra
 # Abstra is an AI-powered process automation framework.
 # Ignore directories containing user credentials, local state, and settings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +355,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
 name = "darling"
@@ -976,6 +991,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1056,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcp-compressor-node"
+version = "0.1.0"
+dependencies = [
+ "mcp-compressor-core",
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mcp-compressor-python"
 version = "0.1.0"
 dependencies = [
@@ -1064,6 +1101,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "napi"
+version = "3.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+dependencies = [
+ "bitflags",
+ "ctor",
+ "futures",
+ "napi-build",
+ "napi-sys",
+ "nohash-hasher",
+ "rustc-hash",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+
+[[package]]
+name = "napi-derive"
+version = "3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+dependencies = [
+ "convert_case",
+ "ctor",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn",
+]
+
+[[package]]
+name = "napi-sys"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1185,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "normalize-line-endings"
@@ -1580,6 +1680,12 @@ dependencies = [
  "serde_json",
  "syn",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2105,6 +2211,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "pyo3",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1113,6 +1114,7 @@ dependencies = [
  "napi-sys",
  "nohash-hasher",
  "rustc-hash",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members  = ["crates/mcp-compressor-core", "crates/mcp-compressor-python"]
+members  = ["crates/mcp-compressor-core", "crates/mcp-compressor-python", "crates/mcp-compressor-node"]

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -239,7 +239,13 @@ impl CompressedServer {
             .server_name
             .clone()
             .unwrap_or_else(|| backend.name.clone());
-        let backend = connect_backend(backend, public_name).await?;
+        let backend = connect_backend(
+            backend,
+            public_name,
+            &config.include_tools,
+            &config.exclude_tools,
+        )
+        .await?;
         Ok(Self {
             config,
             backends: vec![backend],
@@ -258,7 +264,15 @@ impl CompressedServer {
                 Some(prefix) => format!("{prefix}_{}", backend.name),
                 None => backend.name.clone(),
             };
-            connected.push(connect_backend(backend, public_name).await?);
+            connected.push(
+                connect_backend(
+                    backend,
+                    public_name,
+                    &config.include_tools,
+                    &config.exclude_tools,
+                )
+                .await?,
+            );
         }
         Ok(Self {
             config,
@@ -286,7 +300,13 @@ impl CompressedServer {
         if backends.len() == 1 {
             let backend = backends.into_iter().next().expect("one backend exists");
             let public_name = config.server_name.clone().unwrap_or_default();
-            let backend = connect_backend(backend, public_name).await?;
+            let backend = connect_backend(
+                backend,
+                public_name,
+                &config.include_tools,
+                &config.exclude_tools,
+            )
+            .await?;
             Ok(Self {
                 config,
                 backends: vec![backend],
@@ -490,6 +510,9 @@ impl CompressedServer {
         backend_tool_name: &str,
         tool_input: Value,
     ) -> Result<String, Error> {
+        if !backend.tools.iter().any(|tool| tool.name == backend_tool_name) {
+            return Err(Error::ToolNotFound(backend_tool_name.to_string()));
+        }
         let arguments = match tool_input {
             Value::Object(map) => Some(map),
             _ => None,
@@ -578,6 +601,8 @@ impl CompressedServer {
 async fn connect_backend(
     backend: BackendServerConfig,
     public_name: String,
+    include_tools: &[String],
+    exclude_tools: &[String],
 ) -> Result<ConnectedBackend, Error> {
     let client = match backend.transport {
         BackendTransport::Stdio => connect_stdio_backend(&backend).await?,
@@ -588,7 +613,13 @@ async fn connect_backend(
         .list_all_tools()
         .await
         .map_err(|error| Error::Config(error.to_string()))?;
-    let tools = rmcp_tools.into_iter().map(convert_tool).collect::<Vec<_>>();
+    let mut tools = rmcp_tools.into_iter().map(convert_tool).collect::<Vec<_>>();
+    if !include_tools.is_empty() {
+        tools.retain(|tool| include_tools.iter().any(|include| include == &tool.name));
+    }
+    if !exclude_tools.is_empty() {
+        tools.retain(|tool| !exclude_tools.iter().any(|exclude| exclude == &tool.name));
+    }
 
     let resources = client
         .list_all_resources()

--- a/crates/mcp-compressor-node/Cargo.toml
+++ b/crates/mcp-compressor-node/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name    = "mcp-compressor-node"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[build-dependencies]
+napi-build = "2.3.1"
+
+[dependencies]
+mcp-compressor-core = { path = "../mcp-compressor-core" }
+napi = { version = "3.8.6", default-features = false, features = ["napi4"] }
+napi-derive = "3.5.5"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/mcp-compressor-node/Cargo.toml
+++ b/crates/mcp-compressor-node/Cargo.toml
@@ -11,7 +11,7 @@ napi-build = "2.3.1"
 
 [dependencies]
 mcp-compressor-core = { path = "../mcp-compressor-core" }
-napi = { version = "3.8.6", default-features = false, features = ["napi4"] }
+napi = { version = "3.8.6", default-features = false, features = ["napi4", "async"] }
 napi-derive = "3.5.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/mcp-compressor-node/build.rs
+++ b/crates/mcp-compressor-node/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -1,0 +1,61 @@
+use napi::Error as NapiError;
+use napi_derive::napi;
+use serde::Deserialize;
+use serde_json::Value;
+
+use mcp_compressor_core::compression::CompressionLevel;
+use mcp_compressor_core::ffi::{
+    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response, list_oauth_credentials,
+    parse_mcp_config, parse_tool_argv, FfiTool,
+};
+
+fn napi_error(error: impl std::fmt::Display) -> NapiError {
+    NapiError::from_reason(error.to_string())
+}
+
+fn parse_json<T: for<'de> Deserialize<'de>>(value: &str) -> napi::Result<T> {
+    serde_json::from_str(value).map_err(napi_error)
+}
+
+#[napi]
+pub fn compress_tool_listing_json(level: String, tools_json: String) -> napi::Result<String> {
+    let level = level.parse::<CompressionLevel>().map_err(napi_error)?;
+    let tools = parse_json::<Vec<FfiTool>>(&tools_json)?;
+    Ok(compress_tool_listing(level, tools))
+}
+
+#[napi]
+pub fn format_tool_schema_response_json(tool_json: String) -> napi::Result<String> {
+    let tool = parse_json::<FfiTool>(&tool_json)?;
+    Ok(format_tool_schema_response(tool))
+}
+
+#[napi]
+pub fn parse_tool_argv_json(tool_json: String, argv_json: String) -> napi::Result<String> {
+    let tool = parse_json::<FfiTool>(&tool_json)?;
+    let argv = parse_json::<Vec<String>>(&argv_json)?;
+    let parsed = parse_tool_argv(tool, argv).map_err(napi_error)?;
+    serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn parse_mcp_config_json(config_json: String) -> napi::Result<String> {
+    let parsed = parse_mcp_config(&config_json).map_err(napi_error)?;
+    serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn list_oauth_credentials_json() -> napi::Result<String> {
+    let entries = list_oauth_credentials().map_err(napi_error)?;
+    serde_json::to_string(&entries).map_err(napi_error)
+}
+
+#[napi]
+pub fn clear_oauth_credentials_json(target: Option<String>) -> napi::Result<String> {
+    let paths = clear_oauth_credentials(target.as_deref()).map_err(napi_error)?;
+    let values = paths
+        .into_iter()
+        .map(|path| Value::String(path.to_string_lossy().into_owned()))
+        .collect::<Vec<_>>();
+    serde_json::to_string(&values).map_err(napi_error)
+}

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -5,8 +5,11 @@ use serde_json::Value;
 
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
-    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response, list_oauth_credentials,
-    parse_mcp_config, parse_tool_argv, FfiTool,
+    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response, generate_client_artifacts,
+    list_oauth_credentials, parse_mcp_config, parse_tool_argv, remember_oauth_backend,
+    start_compressed_session,
+    start_compressed_session_from_mcp_config, FfiBackendConfig, FfiClientArtifactKind,
+    FfiCompressedSession, FfiCompressedSessionConfig, FfiGeneratorConfig, FfiTool,
 };
 
 fn napi_error(error: impl std::fmt::Display) -> NapiError {
@@ -39,9 +42,35 @@ pub fn parse_tool_argv_json(tool_json: String, argv_json: String) -> napi::Resul
 }
 
 #[napi]
+pub fn generate_client_artifacts_json(kind: String, config_json: String) -> napi::Result<String> {
+    let kind = match kind.as_str() {
+        "cli" => FfiClientArtifactKind::Cli,
+        "python" => FfiClientArtifactKind::Python,
+        "typescript" | "ts" => FfiClientArtifactKind::TypeScript,
+        other => return Err(napi_error(format!("invalid client artifact kind: {other}"))),
+    };
+    let config = parse_json::<FfiGeneratorConfig>(&config_json)?;
+    let paths = generate_client_artifacts(kind, config).map_err(napi_error)?;
+    let values = paths
+        .into_iter()
+        .map(|path| Value::String(path.to_string_lossy().into_owned()))
+        .collect::<Vec<_>>();
+    serde_json::to_string(&values).map_err(napi_error)
+}
+
+#[napi]
 pub fn parse_mcp_config_json(config_json: String) -> napi::Result<String> {
     let parsed = parse_mcp_config(&config_json).map_err(napi_error)?;
     serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn remember_oauth_backend_json(
+    backend_uri: String,
+    backend_name: String,
+    store_dir: String,
+) -> napi::Result<()> {
+    remember_oauth_backend(&backend_uri, &backend_name, store_dir.into()).map_err(napi_error)
 }
 
 #[napi]
@@ -58,4 +87,40 @@ pub fn clear_oauth_credentials_json(target: Option<String>) -> napi::Result<Stri
         .map(|path| Value::String(path.to_string_lossy().into_owned()))
         .collect::<Vec<_>>();
     serde_json::to_string(&values).map_err(napi_error)
+}
+
+#[napi]
+pub struct NativeCompressedSession {
+    inner: FfiCompressedSession,
+}
+
+#[napi]
+impl NativeCompressedSession {
+    #[napi]
+    pub fn info_json(&self) -> napi::Result<String> {
+        serde_json::to_string(&self.inner.info()).map_err(napi_error)
+    }
+}
+
+#[napi]
+pub async fn start_compressed_session_json(
+    config_json: String,
+    backends_json: String,
+) -> napi::Result<NativeCompressedSession> {
+    let config = parse_json::<FfiCompressedSessionConfig>(&config_json)?;
+    let backends = parse_json::<Vec<FfiBackendConfig>>(&backends_json)?;
+    let inner = start_compressed_session(config, backends).await.map_err(napi_error)?;
+    Ok(NativeCompressedSession { inner })
+}
+
+#[napi]
+pub async fn start_compressed_session_from_mcp_config_json(
+    config_json: String,
+    mcp_config_json: String,
+) -> napi::Result<NativeCompressedSession> {
+    let config = parse_json::<FfiCompressedSessionConfig>(&config_json)?;
+    let inner = start_compressed_session_from_mcp_config(config, &mcp_config_json)
+        .await
+        .map_err(napi_error)?;
+    Ok(NativeCompressedSession { inner })
 }

--- a/crates/mcp-compressor-python/Cargo.toml
+++ b/crates/mcp-compressor-python/Cargo.toml
@@ -12,3 +12,4 @@ mcp-compressor-core = { path = "../mcp-compressor-core" }
 pyo3 = { version = "0.28.3", features = ["extension-module"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/crates/mcp-compressor-python/src/lib.rs
+++ b/crates/mcp-compressor-python/src/lib.rs
@@ -6,7 +6,9 @@ use serde_json::Value;
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
     clear_oauth_credentials, compress_tool_listing, format_tool_schema_response, list_oauth_credentials,
-    parse_mcp_config, parse_tool_argv, FfiTool,
+    parse_mcp_config, parse_tool_argv, start_compressed_session,
+    start_compressed_session_from_mcp_config, FfiBackendConfig, FfiCompressedSession,
+    FfiCompressedSessionConfig, FfiTool,
 };
 
 fn py_value_error(error: impl std::fmt::Display) -> PyErr {
@@ -50,6 +52,47 @@ fn list_oauth_credentials_json() -> PyResult<String> {
     serde_json::to_string(&entries).map_err(py_value_error)
 }
 
+#[pyclass]
+struct PyCompressedSession {
+    inner: FfiCompressedSession,
+    #[allow(dead_code)]
+    runtime: tokio::runtime::Runtime,
+}
+
+#[pymethods]
+impl PyCompressedSession {
+    fn info_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner.info()).map_err(py_value_error)
+    }
+}
+
+#[pyfunction]
+fn start_compressed_session_json(
+    config_json: &str,
+    backends_json: &str,
+) -> PyResult<PyCompressedSession> {
+    let config = parse_json::<FfiCompressedSessionConfig>(config_json)?;
+    let backends = parse_json::<Vec<FfiBackendConfig>>(backends_json)?;
+    let runtime = tokio::runtime::Runtime::new().map_err(py_value_error)?;
+    let inner = runtime
+        .block_on(start_compressed_session(config, backends))
+        .map_err(py_value_error)?;
+    Ok(PyCompressedSession { inner, runtime })
+}
+
+#[pyfunction]
+fn start_compressed_session_from_mcp_config_json(
+    config_json: &str,
+    mcp_config_json: &str,
+) -> PyResult<PyCompressedSession> {
+    let config = parse_json::<FfiCompressedSessionConfig>(config_json)?;
+    let runtime = tokio::runtime::Runtime::new().map_err(py_value_error)?;
+    let inner = runtime
+        .block_on(start_compressed_session_from_mcp_config(config, mcp_config_json))
+        .map_err(py_value_error)?;
+    Ok(PyCompressedSession { inner, runtime })
+}
+
 #[pyfunction]
 fn clear_oauth_credentials_json(target: Option<&str>) -> PyResult<String> {
     let paths = clear_oauth_credentials(target).map_err(py_value_error)?;
@@ -62,10 +105,13 @@ fn clear_oauth_credentials_json(target: Option<&str>) -> PyResult<String> {
 
 #[pymodule]
 fn _mcp_compressor_core(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PyCompressedSession>()?;
     module.add_function(wrap_pyfunction!(compress_tool_listing_json, module)?)?;
     module.add_function(wrap_pyfunction!(format_tool_schema_response_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_tool_argv_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_mcp_config_json, module)?)?;
+    module.add_function(wrap_pyfunction!(start_compressed_session_json, module)?)?;
+    module.add_function(wrap_pyfunction!(start_compressed_session_from_mcp_config_json, module)?)?;
     module.add_function(wrap_pyfunction!(list_oauth_credentials_json, module)?)?;
     module.add_function(wrap_pyfunction!(clear_oauth_credentials_json, module)?)?;
     Ok(())

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -230,13 +230,14 @@ Status as of 2026-05-01, after the first Rust runtime implementation pass:
 - **Python/TypeScript binding cutover remains TODO, but package scaffolding has started:**
   - `mcp-compressor-core` now keeps only pure JSON-serializable FFI DTO/helper surfaces and does not depend on PyO3 or napi-rs.
   - A separate Rust-backed Python package scaffold lives under `python/mcp-compressor-rust`, backed by the `crates/mcp-compressor-python` PyO3 extension crate.
-  - The next work is expanding package coverage, adding runtime/session wrappers, adding an analogous TypeScript/native-addon package, and writing parity tests against legacy Python/TS behavior.
+  - A dedicated `crates/mcp-compressor-node` napi-rs extension crate now exposes the same initial native helper surface to the existing TypeScript package via `typescript/src/rust_core.ts`.
+  - The next work is expanding package coverage into runtime/session wrappers and writing parity tests against legacy Python/TS behavior.
 - **WASM/V8-isolate strategy remains future design work, not an initial implementation target.**
 
 ### Recommended next implementation order
 
 1. Expand the separate Rust-backed Python package (`python/mcp-compressor-rust`) beyond pure helpers into runtime/session wrappers.
-2. Add the analogous Rust-backed TypeScript package / napi-rs packaging surface without disturbing the legacy `typescript/` package.
+2. Expand the TypeScript napi-rs wrapper beyond pure helpers into runtime/session wrappers without disturbing existing legacy behavior paths.
 3. Wire Python/TypeScript Just Bash bindings to consume Rust provider specs and register backend MCP tools as custom commands.
 4. Add parity tests comparing legacy Python/TS behavior with Rust-backed packages before any cutover.
 5. Add packaging/release automation for Rust-backed Python wheels, TypeScript native addons, and the Rust binary.
@@ -846,6 +847,26 @@ The Rust CLI e2e test suite should invoke the compiled binary with real fixture 
 These tests are distinct from library-level Rust integration tests. Library tests prove the Rust API works; CLI e2e tests prove the packaged executable, argument parsing, process lifecycle, stdout/stderr behavior, and exit codes work.
 
 #### TypeScript package (`typescript/`)
+
+A dedicated napi-rs native addon crate backs the Rust helper surface:
+
+```
+crates/mcp-compressor-node/
+├── Cargo.toml                  # cdylib extension crate
+├── build.rs                    # napi-rs platform linker setup
+└── src/lib.rs                  # napi module forwarding into mcp-compressor-core FFI helpers
+```
+
+The existing TypeScript package exposes this initial Rust-backed helper surface through a separate subpath:
+
+```
+typescript/src/native.ts        # generated native loader wrapper
+typescript/src/rust_core.ts     # typed TypeScript wrappers over native JSON helpers
+typescript/tests/rust_core.test.ts
+```
+
+The generated napi loader/binaries are build artifacts and are not committed; `bun run build:native` regenerates them.
+
 
 ```
 typescript/

--- a/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
@@ -1,6 +1,9 @@
 """Rust-backed experimental Python API for mcp-compressor."""
 
 from mcp_compressor_rust.core import (
+    BackendConfig,
+    CompressedSession,
+    CompressedSessionConfig,
     RustTool,
     clear_oauth_credentials,
     compress_tool_listing,
@@ -8,9 +11,14 @@ from mcp_compressor_rust.core import (
     list_oauth_credentials,
     parse_mcp_config,
     parse_tool_argv,
+    start_compressed_session,
+    start_compressed_session_from_mcp_config,
 )
 
 __all__ = [
+    "BackendConfig",
+    "CompressedSession",
+    "CompressedSessionConfig",
     "RustTool",
     "clear_oauth_credentials",
     "compress_tool_listing",
@@ -18,4 +26,6 @@ __all__ = [
     "list_oauth_credentials",
     "parse_mcp_config",
     "parse_tool_argv",
+    "start_compressed_session",
+    "start_compressed_session_from_mcp_config",
 ]

--- a/python/mcp-compressor-rust/mcp_compressor_rust/core.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/core.py
@@ -11,6 +11,58 @@ _mcp_compressor_core = importlib.import_module("mcp_compressor_rust._mcp_compres
 
 
 @dataclass(frozen=True)
+class BackendConfig:
+    """Runtime backend configuration accepted by the Rust core extension."""
+
+    name: str
+    command_or_url: str
+    args: list[str] | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "command_or_url": self.command_or_url,
+            "args": self.args or [],
+        }
+
+
+@dataclass(frozen=True)
+class CompressedSessionConfig:
+    """Runtime session configuration accepted by the Rust core extension."""
+
+    compression_level: str = "max"
+    server_name: str | None = None
+    include_tools: list[str] | None = None
+    exclude_tools: list[str] | None = None
+    toonify: bool = False
+    transform_mode: str | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "compression_level": self.compression_level,
+            "server_name": self.server_name,
+            "include_tools": self.include_tools or [],
+            "exclude_tools": self.exclude_tools or [],
+            "toonify": self.toonify,
+            "transform_mode": self.transform_mode,
+        }
+
+
+class CompressedSession:
+    """Python wrapper around a Rust-backed compressed session handle."""
+
+    def __init__(self, native_session: Any) -> None:
+        self._native_session = native_session
+
+    def info(self) -> dict[str, Any]:
+        value = json.loads(self._native_session.info_json())
+        if not isinstance(value, dict):
+            msg = "Rust core session info_json returned non-object JSON"
+            raise TypeError(msg)
+        return value
+
+
+@dataclass(frozen=True)
 class RustTool:
     """JSON-serializable tool DTO accepted by the Rust core extension."""
 
@@ -55,6 +107,30 @@ def parse_tool_argv(tool: RustTool, argv: list[str]) -> dict[str, Any]:
         msg = "Rust core parse_tool_argv_json returned non-object JSON"
         raise TypeError(msg)
     return value
+
+
+def start_compressed_session(
+    config: CompressedSessionConfig,
+    backends: list[BackendConfig],
+) -> CompressedSession:
+    """Start a Rust-backed compressed session and local proxy."""
+    native_session = _mcp_compressor_core.start_compressed_session_json(
+        _json_dumps(config.to_json_dict()),
+        _json_dumps([backend.to_json_dict() for backend in backends]),
+    )
+    return CompressedSession(native_session)
+
+
+def start_compressed_session_from_mcp_config(
+    config: CompressedSessionConfig,
+    mcp_config_json: str,
+) -> CompressedSession:
+    """Start a Rust-backed compressed session from MCP config JSON."""
+    native_session = _mcp_compressor_core.start_compressed_session_from_mcp_config_json(
+        _json_dumps(config.to_json_dict()),
+        mcp_config_json,
+    )
+    return CompressedSession(native_session)
 
 
 def parse_mcp_config(config_json: str) -> list[dict[str, Any]]:

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -1,12 +1,37 @@
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+from urllib import error, request
+
 from mcp_compressor_rust import (
+    BackendConfig,
+    CompressedSessionConfig,
     RustTool,
     compress_tool_listing,
     format_tool_schema_response,
     parse_mcp_config,
     parse_tool_argv,
+    start_compressed_session,
+    start_compressed_session_from_mcp_config,
 )
+
+ROOT = Path(__file__).resolve().parents[2].parent
+FIXTURES = ROOT / "crates" / "mcp-compressor-core" / "tests" / "fixtures"
+PYTHON = os.environ.get("PYTHON") or str(ROOT / ".venv" / "bin" / "python3")
+
+
+def invoke_proxy(bridge_url: str, token: str, tool: str, tool_name: str, tool_input: dict[str, object]) -> str:
+    body = json.dumps({"tool": tool, "input": {"tool_name": tool_name, "tool_input": tool_input}}).encode()
+    req = request.Request(  # noqa: S310 - local Rust test proxy
+        f"{bridge_url}/exec",
+        data=body,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as response:  # noqa: S310 - local Rust test proxy
+        return response.read().decode()
 
 
 def sample_tool() -> RustTool:
@@ -33,6 +58,109 @@ def test_native_extension_formats_schema_response() -> None:
 
 def test_native_extension_parses_tool_argv() -> None:
     assert parse_tool_argv(sample_tool(), ["--message", "hello"]) == {"message": "hello"}
+
+
+def test_native_extension_starts_session_and_invokes_backend() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", server_name="alpha"),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")])],
+    )
+    info = session.info()
+    assert str(info["bridge_url"]).startswith("http://127.0.0.1:")
+    invoke_tool = next(tool for tool in info["frontend_tools"] if tool["name"].endswith("invoke_tool"))
+    assert (
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "echo", {"message": "py"})
+        == "alpha:py"
+    )
+
+
+def test_native_extension_starts_session_from_mcp_config_and_routes() -> None:
+    session = start_compressed_session_from_mcp_config(
+        CompressedSessionConfig(compression_level="max"),
+        json.dumps(
+            {
+                "mcpServers": {
+                    "alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]},
+                    "beta": {"command": PYTHON, "args": [str(FIXTURES / "beta_server.py")]},
+                }
+            }
+        ),
+    )
+    info = session.info()
+    tool_names = {tool["name"] for tool in info["frontend_tools"]}
+    assert "alpha_invoke_tool" in tool_names
+    assert "beta_invoke_tool" in tool_names
+    assert (
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), "alpha_invoke_tool", "add", {"a": 2, "b": 3}) == "5"
+    )
+    assert (
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), "beta_invoke_tool", "multiply", {"a": 4, "b": 5})
+        == "20"
+    )
+
+
+def test_native_extension_toonifies_json_outputs() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", server_name="alpha", toonify=True),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")])],
+    )
+    info = session.info()
+    invoke_tool = next(tool for tool in info["frontend_tools"] if tool["name"].endswith("invoke_tool"))
+    output = invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "structured_data", {})
+    assert "server: alpha" in output
+    assert "values" in output
+    assert not output.strip().startswith("{")
+
+
+def test_native_extension_applies_include_exclude_filters() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(
+            compression_level="max",
+            server_name="alpha",
+            include_tools=["echo", "add"],
+            exclude_tools=["add"],
+        ),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")])],
+    )
+    info = session.info()
+    invoke_tool = next(tool for tool in info["frontend_tools"] if tool["name"].endswith("invoke_tool"))
+    assert (
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "echo", {"message": "filtered"})
+        == "alpha:filtered"
+    )
+    try:
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "add", {"a": 1, "b": 2})
+    except error.HTTPError as exc:
+        assert exc.code == 400
+        assert "not found" in exc.read().decode().lower()
+    else:  # pragma: no cover - defensive assertion for filter enforcement
+        raise AssertionError("excluded add tool unexpectedly invoked")
+
+
+def test_native_extension_supports_cli_transform_mode() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", server_name="alpha", transform_mode="cli"),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")])],
+    )
+    info = session.info()
+    assert [tool["name"] for tool in info["frontend_tools"]] == ["alpha_alpha_help"]
+
+
+def test_native_extension_supports_just_bash_transform_mode() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", transform_mode="just-bash"),
+        [
+            BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")]),
+            BackendConfig(name="beta", command_or_url=PYTHON, args=[str(FIXTURES / "beta_server.py")]),
+        ],
+    )
+    info = session.info()
+    tool_names = {tool["name"] for tool in info["frontend_tools"]}
+    assert {"bash_tool", "alpha_help", "beta_help"}.issubset(tool_names)
+    providers = {provider["provider_name"]: provider for provider in info["just_bash_providers"]}
+    assert set(providers) == {"alpha", "beta"}
+    assert providers["alpha"]["help_tool_name"] == "alpha_help"
+    assert any(command["command_name"] == "echo" for command in providers["alpha"]["tools"])
 
 
 def test_native_extension_parses_mcp_config() -> None:

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -19,7 +19,7 @@ from mcp_compressor_rust import (
 
 ROOT = Path(__file__).resolve().parents[2].parent
 FIXTURES = ROOT / "crates" / "mcp-compressor-core" / "tests" / "fixtures"
-PYTHON = os.environ.get("PYTHON") or str(ROOT / ".venv" / "bin" / "python3")
+PYTHON = os.environ.get("PYTHON") or str(ROOT / ".venv" / "bin" / "python")
 
 
 def invoke_proxy(bridge_url: str, token: str, tool: str, tool_name: str, tool_input: dict[str, object]) -> str:

--- a/typescript/bun.lock
+++ b/typescript/bun.lock
@@ -12,6 +12,7 @@
         "zod": "^4.1.13",
       },
       "devDependencies": {
+        "@napi-rs/cli": "^3.3.4",
         "@types/node": "^24.10.1",
         "just-bash": "^2.14.0",
         "oxfmt": "^0.44.0",
@@ -38,6 +39,38 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@5.1.4", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.9", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.9", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg=="],
+
+    "@inquirer/editor": ["@inquirer/editor@5.1.1", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/external-editor": "^3.0.0", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA=="],
+
+    "@inquirer/expand": ["@inquirer/expand@5.0.13", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g=="],
+
+    "@inquirer/external-editor": ["@inquirer/external-editor@3.0.0", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "@inquirer/input": ["@inquirer/input@5.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q=="],
+
+    "@inquirer/number": ["@inquirer/number@4.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg=="],
+
+    "@inquirer/password": ["@inquirer/password@5.0.12", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@8.4.2", "", { "dependencies": { "@inquirer/checkbox": "^5.1.4", "@inquirer/confirm": "^6.0.12", "@inquirer/editor": "^5.1.1", "@inquirer/expand": "^5.0.13", "@inquirer/input": "^5.0.12", "@inquirer/number": "^4.0.12", "@inquirer/password": "^5.0.12", "@inquirer/rawlist": "^5.2.8", "@inquirer/search": "^4.1.8", "@inquirer/select": "^5.1.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@5.2.8", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg=="],
+
+    "@inquirer/search": ["@inquirer/search@4.1.8", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw=="],
+
+    "@inquirer/select": ["@inquirer/select@5.1.4", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.9", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
     "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
 
     "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
@@ -56,7 +89,133 @@
 
     "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
 
+    "@napi-rs/cli": ["@napi-rs/cli@3.6.2", "", { "dependencies": { "@inquirer/prompts": "^8.0.0", "@napi-rs/cross-toolchain": "^1.0.3", "@napi-rs/wasm-tools": "^1.0.1", "@octokit/rest": "^22.0.1", "clipanion": "^4.0.0-rc.4", "colorette": "^2.0.20", "emnapi": "^1.9.1", "es-toolkit": "^1.41.0", "js-yaml": "^4.1.0", "obug": "^2.0.0", "semver": "^7.7.3", "typanion": "^3.14.0" }, "peerDependencies": { "@emnapi/runtime": "^1.7.1" }, "optionalPeers": ["@emnapi/runtime"], "bin": { "napi": "dist/cli.js", "napi-raw": "cli.mjs" } }, "sha512-jy5rABUh9tbE/vPRzw9kGzGuqZiVslyDQUV8LkvjzqVX/oJMN7g0U1uhtr9L3W1H+iRM/urXHXUf+CE4n8FvLA=="],
+
+    "@napi-rs/cross-toolchain": ["@napi-rs/cross-toolchain@1.0.3", "", { "dependencies": { "@napi-rs/lzma": "^1.4.5", "@napi-rs/tar": "^1.1.0", "debug": "^4.4.1" }, "peerDependencies": { "@napi-rs/cross-toolchain-arm64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-x86_64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-x86_64": "^1.0.3" }, "optionalPeers": ["@napi-rs/cross-toolchain-arm64-target-aarch64", "@napi-rs/cross-toolchain-arm64-target-armv7", "@napi-rs/cross-toolchain-arm64-target-ppc64le", "@napi-rs/cross-toolchain-arm64-target-s390x", "@napi-rs/cross-toolchain-arm64-target-x86_64", "@napi-rs/cross-toolchain-x64-target-aarch64", "@napi-rs/cross-toolchain-x64-target-armv7", "@napi-rs/cross-toolchain-x64-target-ppc64le", "@napi-rs/cross-toolchain-x64-target-s390x", "@napi-rs/cross-toolchain-x64-target-x86_64"] }, "sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg=="],
+
+    "@napi-rs/lzma": ["@napi-rs/lzma@1.4.5", "", { "optionalDependencies": { "@napi-rs/lzma-android-arm-eabi": "1.4.5", "@napi-rs/lzma-android-arm64": "1.4.5", "@napi-rs/lzma-darwin-arm64": "1.4.5", "@napi-rs/lzma-darwin-x64": "1.4.5", "@napi-rs/lzma-freebsd-x64": "1.4.5", "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.5", "@napi-rs/lzma-linux-arm64-gnu": "1.4.5", "@napi-rs/lzma-linux-arm64-musl": "1.4.5", "@napi-rs/lzma-linux-ppc64-gnu": "1.4.5", "@napi-rs/lzma-linux-riscv64-gnu": "1.4.5", "@napi-rs/lzma-linux-s390x-gnu": "1.4.5", "@napi-rs/lzma-linux-x64-gnu": "1.4.5", "@napi-rs/lzma-linux-x64-musl": "1.4.5", "@napi-rs/lzma-wasm32-wasi": "1.4.5", "@napi-rs/lzma-win32-arm64-msvc": "1.4.5", "@napi-rs/lzma-win32-ia32-msvc": "1.4.5", "@napi-rs/lzma-win32-x64-msvc": "1.4.5" } }, "sha512-zS5LuN1OBPAyZpda2ZZgYOEDC+xecUdAGnrvbYzjnLXkrq/OBC3B9qcRvlxbDR3k5H/gVfvef1/jyUqPknqjbg=="],
+
+    "@napi-rs/lzma-android-arm-eabi": ["@napi-rs/lzma-android-arm-eabi@1.4.5", "", { "os": "android", "cpu": "arm" }, "sha512-Up4gpyw2SacmyKWWEib06GhiDdF+H+CCU0LAV8pnM4aJIDqKKd5LHSlBht83Jut6frkB0vwEPmAkv4NjQ5u//Q=="],
+
+    "@napi-rs/lzma-android-arm64": ["@napi-rs/lzma-android-arm64@1.4.5", "", { "os": "android", "cpu": "arm64" }, "sha512-uwa8sLlWEzkAM0MWyoZJg0JTD3BkPknvejAFG2acUA1raXM8jLrqujWCdOStisXhqQjZ2nDMp3FV6cs//zjfuQ=="],
+
+    "@napi-rs/lzma-darwin-arm64": ["@napi-rs/lzma-darwin-arm64@1.4.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0Y0TQLQ2xAjVabrMDem1NhIssOZzF/y/dqetc6OT8mD3xMTDtF8u5BqZoX3MyPc9FzpsZw4ksol+w7DsxHrpMA=="],
+
+    "@napi-rs/lzma-darwin-x64": ["@napi-rs/lzma-darwin-x64@1.4.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-vR2IUyJY3En+V1wJkwmbGWcYiT8pHloTAWdW4pG24+51GIq+intst6Uf6D/r46citObGZrlX0QvMarOkQeHWpw=="],
+
+    "@napi-rs/lzma-freebsd-x64": ["@napi-rs/lzma-freebsd-x64@1.4.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-XpnYQC5SVovO35tF0xGkbHYjsS6kqyNCjuaLQ2dbEblFRr5cAZVvsJ/9h7zj/5FluJPJRDojVNxGyRhTp4z2lw=="],
+
+    "@napi-rs/lzma-linux-arm-gnueabihf": ["@napi-rs/lzma-linux-arm-gnueabihf@1.4.5", "", { "os": "linux", "cpu": "arm" }, "sha512-ic1ZZMoRfRMwtSwxkyw4zIlbDZGC6davC9r+2oX6x9QiF247BRqqT94qGeL5ZP4Vtz0Hyy7TEViWhx5j6Bpzvw=="],
+
+    "@napi-rs/lzma-linux-arm64-gnu": ["@napi-rs/lzma-linux-arm64-gnu@1.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-asEp7FPd7C1Yi6DQb45a3KPHKOFBSfGuJWXcAd4/bL2Fjetb2n/KK2z14yfW8YC/Fv6x3rBM0VAZKmJuz4tysg=="],
+
+    "@napi-rs/lzma-linux-arm64-musl": ["@napi-rs/lzma-linux-arm64-musl@1.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w=="],
+
+    "@napi-rs/lzma-linux-ppc64-gnu": ["@napi-rs/lzma-linux-ppc64-gnu@1.4.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ=="],
+
+    "@napi-rs/lzma-linux-riscv64-gnu": ["@napi-rs/lzma-linux-riscv64-gnu@1.4.5", "", { "os": "linux", "cpu": "none" }, "sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA=="],
+
+    "@napi-rs/lzma-linux-s390x-gnu": ["@napi-rs/lzma-linux-s390x-gnu@1.4.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA=="],
+
+    "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw=="],
+
+    "@napi-rs/lzma-linux-x64-musl": ["@napi-rs/lzma-linux-x64-musl@1.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ=="],
+
+    "@napi-rs/lzma-wasm32-wasi": ["@napi-rs/lzma-wasm32-wasi@1.4.5", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA=="],
+
+    "@napi-rs/lzma-win32-arm64-msvc": ["@napi-rs/lzma-win32-arm64-msvc@1.4.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-eewnqvIyyhHi3KaZtBOJXohLvwwN27gfS2G/YDWdfHlbz1jrmfeHAmzMsP5qv8vGB+T80TMHNkro4kYjeh6Deg=="],
+
+    "@napi-rs/lzma-win32-ia32-msvc": ["@napi-rs/lzma-win32-ia32-msvc@1.4.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-OeacFVRCJOKNU/a0ephUfYZ2Yt+NvaHze/4TgOwJ0J0P4P7X1mHzN+ig9Iyd74aQDXYqc7kaCXA2dpAOcH87Cg=="],
+
+    "@napi-rs/lzma-win32-x64-msvc": ["@napi-rs/lzma-win32-x64-msvc@1.4.5", "", { "os": "win32", "cpu": "x64" }, "sha512-T4I1SamdSmtyZgDXGAGP+y5LEK5vxHUFwe8mz6D4R7Sa5/WCxTcCIgPJ9BD7RkpO17lzhlaM2vmVvMy96Lvk9Q=="],
+
+    "@napi-rs/tar": ["@napi-rs/tar@1.1.0", "", { "optionalDependencies": { "@napi-rs/tar-android-arm-eabi": "1.1.0", "@napi-rs/tar-android-arm64": "1.1.0", "@napi-rs/tar-darwin-arm64": "1.1.0", "@napi-rs/tar-darwin-x64": "1.1.0", "@napi-rs/tar-freebsd-x64": "1.1.0", "@napi-rs/tar-linux-arm-gnueabihf": "1.1.0", "@napi-rs/tar-linux-arm64-gnu": "1.1.0", "@napi-rs/tar-linux-arm64-musl": "1.1.0", "@napi-rs/tar-linux-ppc64-gnu": "1.1.0", "@napi-rs/tar-linux-s390x-gnu": "1.1.0", "@napi-rs/tar-linux-x64-gnu": "1.1.0", "@napi-rs/tar-linux-x64-musl": "1.1.0", "@napi-rs/tar-wasm32-wasi": "1.1.0", "@napi-rs/tar-win32-arm64-msvc": "1.1.0", "@napi-rs/tar-win32-ia32-msvc": "1.1.0", "@napi-rs/tar-win32-x64-msvc": "1.1.0" } }, "sha512-7cmzIu+Vbupriudo7UudoMRH2OA3cTw67vva8MxeoAe5S7vPFI7z0vp0pMXiA25S8IUJefImQ90FeJjl8fjEaQ=="],
+
+    "@napi-rs/tar-android-arm-eabi": ["@napi-rs/tar-android-arm-eabi@1.1.0", "", { "os": "android", "cpu": "arm" }, "sha512-h2Ryndraj/YiKgMV/r5by1cDusluYIRT0CaE0/PekQ4u+Wpy2iUVqvzVU98ZPnhXaNeYxEvVJHNGafpOfaD0TA=="],
+
+    "@napi-rs/tar-android-arm64": ["@napi-rs/tar-android-arm64@1.1.0", "", { "os": "android", "cpu": "arm64" }, "sha512-DJFyQHr1ZxNZorm/gzc1qBNLF/FcKzcH0V0Vwan5P+o0aE2keQIGEjJ09FudkF9v6uOuJjHCVDdK6S6uHtShAw=="],
+
+    "@napi-rs/tar-darwin-arm64": ["@napi-rs/tar-darwin-arm64@1.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Zz2sXRzjIX4e532zD6xm2SjXEym6MkvfCvL2RMpG2+UwNVDVscHNcz3d47Pf3sysP2e2af7fBB3TIoK2f6trPw=="],
+
+    "@napi-rs/tar-darwin-x64": ["@napi-rs/tar-darwin-x64@1.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EI+CptIMNweT0ms9S3mkP/q+J6FNZ1Q6pvpJOEcWglRfyfQpLqjlC0O+dptruTPE8VamKYuqdjxfqD8hifZDOA=="],
+
+    "@napi-rs/tar-freebsd-x64": ["@napi-rs/tar-freebsd-x64@1.1.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J0PIqX+pl6lBIAckL/c87gpodLbjZB1OtIK+RDscKC9NLdpVv6VGOxzUV/fYev/hctcE8EfkLbgFOfpmVQPg2g=="],
+
+    "@napi-rs/tar-linux-arm-gnueabihf": ["@napi-rs/tar-linux-arm-gnueabihf@1.1.0", "", { "os": "linux", "cpu": "arm" }, "sha512-SLgIQo3f3EjkZ82ZwvrEgFvMdDAhsxCYjyoSuWfHCz0U16qx3SuGCp8+FYOPYCECHN3ZlGjXnoAIt9ERd0dEUg=="],
+
+    "@napi-rs/tar-linux-arm64-gnu": ["@napi-rs/tar-linux-arm64-gnu@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-d014cdle52EGaH6GpYTQOP9Py7glMO1zz/+ynJPjjzYFSxvdYx0byrjumZk2UQdIyGZiJO2MEFpCkEEKFSgPYA=="],
+
+    "@napi-rs/tar-linux-arm64-musl": ["@napi-rs/tar-linux-arm64-musl@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-L/y1/26q9L/uBqiW/JdOb/Dc94egFvNALUZV2WCGKQXc6UByPBMgdiEyW2dtoYxYYYYc+AKD+jr+wQPcvX2vrQ=="],
+
+    "@napi-rs/tar-linux-ppc64-gnu": ["@napi-rs/tar-linux-ppc64-gnu@1.1.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EPE1K/80RQvPbLRJDJs1QmCIcH+7WRi0F73+oTe1582y9RtfGRuzAkzeBuAGRXAQEjRQw/RjtNqr6UTJ+8UuWQ=="],
+
+    "@napi-rs/tar-linux-s390x-gnu": ["@napi-rs/tar-linux-s390x-gnu@1.1.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-B2jhWiB1ffw1nQBqLUP1h4+J1ovAxBOoe5N2IqDMOc63fsPZKNqF1PvO/dIem8z7LL4U4bsfmhy3gBfu547oNQ=="],
+
+    "@napi-rs/tar-linux-x64-gnu": ["@napi-rs/tar-linux-x64-gnu@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-tbZDHnb9617lTnsDMGo/eAMZxnsQFnaRe+MszRqHguKfMwkisc9CCJnks/r1o84u5fECI+J/HOrKXgczq/3Oww=="],
+
+    "@napi-rs/tar-linux-x64-musl": ["@napi-rs/tar-linux-x64-musl@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-dV6cODlzbO8u6Anmv2N/ilQHq/AWz0xyltuXoLU3yUyXbZcnWYZuB2rL8OBGPmqNcD+x9NdScBNXh7vWN0naSQ=="],
+
+    "@napi-rs/tar-wasm32-wasi": ["@napi-rs/tar-wasm32-wasi@1.1.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-jIa9nb2HzOrfH0F8QQ9g3WE4aMH5vSI5/1NYVNm9ysCmNjCCtMXCAhlI3WKCdm/DwHf0zLqdrrtDFXODcNaqMw=="],
+
+    "@napi-rs/tar-win32-arm64-msvc": ["@napi-rs/tar-win32-arm64-msvc@1.1.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vfpG71OB0ijtjemp3WTdmBKJm9R70KM8vsSExMsIQtV0lVzP07oM1CW6JbNRPXNLhRoue9ofYLiUDk8bE0Hckg=="],
+
+    "@napi-rs/tar-win32-ia32-msvc": ["@napi-rs/tar-win32-ia32-msvc@1.1.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-hGPyPW60YSpOSgzfy68DLBHgi6HxkAM+L59ZZZPMQ0TOXjQg+p2EW87+TjZfJOkSpbYiEkULwa/f4a2hcVjsqQ=="],
+
+    "@napi-rs/tar-win32-x64-msvc": ["@napi-rs/tar-win32-x64-msvc@1.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-L6Ed1DxXK9YSCMyvpR8MiNAyKNkQLjsHsHK9E0qnHa8NzLFqzDKhvs5LfnWxM2kJ+F7m/e5n9zPm24kHb3LsVw=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+
+    "@napi-rs/wasm-tools": ["@napi-rs/wasm-tools@1.0.1", "", { "optionalDependencies": { "@napi-rs/wasm-tools-android-arm-eabi": "1.0.1", "@napi-rs/wasm-tools-android-arm64": "1.0.1", "@napi-rs/wasm-tools-darwin-arm64": "1.0.1", "@napi-rs/wasm-tools-darwin-x64": "1.0.1", "@napi-rs/wasm-tools-freebsd-x64": "1.0.1", "@napi-rs/wasm-tools-linux-arm64-gnu": "1.0.1", "@napi-rs/wasm-tools-linux-arm64-musl": "1.0.1", "@napi-rs/wasm-tools-linux-x64-gnu": "1.0.1", "@napi-rs/wasm-tools-linux-x64-musl": "1.0.1", "@napi-rs/wasm-tools-wasm32-wasi": "1.0.1", "@napi-rs/wasm-tools-win32-arm64-msvc": "1.0.1", "@napi-rs/wasm-tools-win32-ia32-msvc": "1.0.1", "@napi-rs/wasm-tools-win32-x64-msvc": "1.0.1" } }, "sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ=="],
+
+    "@napi-rs/wasm-tools-android-arm-eabi": ["@napi-rs/wasm-tools-android-arm-eabi@1.0.1", "", { "os": "android", "cpu": "arm" }, "sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw=="],
+
+    "@napi-rs/wasm-tools-android-arm64": ["@napi-rs/wasm-tools-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-WDR7S+aRLV6LtBJAg5fmjKkTZIdrEnnQxgdsb7Cf8pYiMWBHLU+LC49OUVppQ2YSPY0+GeYm9yuZWW3kLjJ7Bg=="],
+
+    "@napi-rs/wasm-tools-darwin-arm64": ["@napi-rs/wasm-tools-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qWTI+EEkiN0oIn/N2gQo7+TVYil+AJ20jjuzD2vATS6uIjVz+Updeqmszi7zq7rdFTLp6Ea3/z4kDKIfZwmR9g=="],
+
+    "@napi-rs/wasm-tools-darwin-x64": ["@napi-rs/wasm-tools-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-bA6hubqtHROR5UI3tToAF/c6TDmaAgF0SWgo4rADHtQ4wdn0JeogvOk50gs2TYVhKPE2ZD2+qqt7oBKB+sxW3A=="],
+
+    "@napi-rs/wasm-tools-freebsd-x64": ["@napi-rs/wasm-tools-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-90+KLBkD9hZEjPQW1MDfwSt5J1L46EUKacpCZWyRuL6iIEO5CgWU0V/JnEgFsDOGyyYtiTvHc5bUdUTWd4I9Vg=="],
+
+    "@napi-rs/wasm-tools-linux-arm64-gnu": ["@napi-rs/wasm-tools-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-rG0QlS65x9K/u3HrKafDf8cFKj5wV2JHGfl8abWgKew0GVPyp6vfsDweOwHbWAjcHtp2LHi6JHoW80/MTHm52Q=="],
+
+    "@napi-rs/wasm-tools-linux-arm64-musl": ["@napi-rs/wasm-tools-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ=="],
+
+    "@napi-rs/wasm-tools-linux-x64-gnu": ["@napi-rs/wasm-tools-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw=="],
+
+    "@napi-rs/wasm-tools-linux-x64-musl": ["@napi-rs/wasm-tools-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ=="],
+
+    "@napi-rs/wasm-tools-wasm32-wasi": ["@napi-rs/wasm-tools-wasm32-wasi@1.0.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA=="],
+
+    "@napi-rs/wasm-tools-win32-arm64-msvc": ["@napi-rs/wasm-tools-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-PFi7oJIBu5w7Qzh3dwFea3sHRO3pojMsaEnUIy22QvsW+UJfNQwJCryVrpoUt8m4QyZXI+saEq/0r4GwdoHYFQ=="],
+
+    "@napi-rs/wasm-tools-win32-ia32-msvc": ["@napi-rs/wasm-tools-win32-ia32-msvc@1.0.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-gXkuYzxQsgkj05Zaq+KQTkHIN83dFAwMcTKa2aQcpYPRImFm2AQzEyLtpXmyCWzJ0F9ZYAOmbSyrNew8/us6bw=="],
+
+    "@napi-rs/wasm-tools-win32-x64-msvc": ["@napi-rs/wasm-tools-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rEAf05nol3e3eei2sRButmgXP+6ATgm0/38MKhz9Isne82T4rPIMYsCIFj0kOisaGeVwoi2fnm7O9oWp5YVnYQ=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.8", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
@@ -214,6 +373,8 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
@@ -223,6 +384,8 @@
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
@@ -240,9 +403,17 @@
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "clipanion": ["clipanion@4.0.0-rc.4", "", { "dependencies": { "typanion": "^3.8.0" } }, "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q=="],
+
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
@@ -288,6 +459,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "emnapi": ["emnapi@1.10.0", "", { "peerDependencies": { "node-addon-api": ">= 6.1.0" }, "optionalPeers": ["node-addon-api"] }, "sha512-swoyZjupDvLoe/KC3HZ4SY1JUN+tviT6eOZ3Px28TZAYdBHtRIiMWWrIUUH+2/9CYY4fNTID1YhYZ+kdFHszHg=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
@@ -303,6 +476,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -326,9 +501,17 @@
 
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
+    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
 
@@ -414,9 +597,13 @@
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
     "just-bash": ["just-bash@2.14.1", "", { "dependencies": { "diff": "^8.0.2", "fast-xml-parser": "^5.3.3", "file-type": "^21.2.0", "ini": "^6.0.0", "minimatch": "^10.1.1", "modern-tar": "^0.7.3", "papaparse": "^5.5.3", "quickjs-emscripten": "^0.32.0", "re2js": "^1.2.1", "seek-bzip": "^2.0.0", "smol-toml": "^1.6.0", "sprintf-js": "^1.1.3", "sql.js": "^1.13.0", "turndown": "^7.2.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mongodb-js/zstd": "^7.0.0", "node-liblzma": "^2.0.3" }, "bin": { "just-bash": "dist/bin/just-bash.js", "just-bash-shell": "dist/bin/shell/shell.js" } }, "sha512-GnErSk35IqEbV1qqxhxAWz/Ve6epm6QTYhDQgp/etYeJmZuyIfwfT4KcoozcO7VS2OkBk9HmIHh/FtrTtfDqAA=="],
 
@@ -479,6 +666,8 @@
     "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -660,6 +849,8 @@
 
     "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
 
+    "typanion": ["typanion@3.14.0", "", {}, "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -671,6 +862,8 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 

--- a/typescript/native/package.json
+++ b/typescript/native/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -51,6 +51,7 @@
   },
   "scripts": {
     "build": "bun run tsc -p tsconfig.build.json",
+    "build:core": "cargo build -p mcp-compressor-core",
     "build:native": "napi build --manifest-path ../crates/mcp-compressor-node/Cargo.toml --platform --release --output-dir native",
     "cli": "bun src/cli.ts",
     "dev": "bun run build && bun run dist/cli.js",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -16,7 +16,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "native"
   ],
   "exports": {
     ".": {
@@ -38,6 +39,10 @@
     "./types": {
       "import": "./dist/types.js",
       "types": "./dist/types.d.ts"
+    },
+    "./rust-core": {
+      "import": "./dist/rust_core.js",
+      "types": "./dist/rust_core.d.ts"
     }
   },
   "bin": {
@@ -46,6 +51,7 @@
   },
   "scripts": {
     "build": "bun run tsc -p tsconfig.build.json",
+    "build:native": "napi build --manifest-path ../crates/mcp-compressor-node/Cargo.toml --platform --release --output-dir native",
     "cli": "bun src/cli.ts",
     "dev": "bun run build && bun run dist/cli.js",
     "format": "oxfmt src/ tests/ '!**/node_modules/**' '!**/dist/**' '!**/coverage/**'",
@@ -76,6 +82,7 @@
     }
   },
   "devDependencies": {
+    "@napi-rs/cli": "^3.3.4",
     "@types/node": "^24.10.1",
     "just-bash": "^2.14.0",
     "oxfmt": "^0.44.0",

--- a/typescript/src/native.ts
+++ b/typescript/src/native.ts
@@ -10,9 +10,23 @@ export interface NativeCore {
   compressToolListingJson(level: string, toolsJson: string): string;
   formatToolSchemaResponseJson(toolJson: string): string;
   parseToolArgvJson(toolJson: string, argvJson: string): string;
+  generateClientArtifactsJson(kind: string, configJson: string): string;
   parseMcpConfigJson(configJson: string): string;
+  rememberOauthBackendJson(backendUri: string, backendName: string, storeDir: string): void;
   listOauthCredentialsJson(): string;
   clearOauthCredentialsJson(target?: string | null): string;
+  startCompressedSessionJson(
+    configJson: string,
+    backendsJson: string,
+  ): Promise<NativeCompressedSession>;
+  startCompressedSessionFromMcpConfigJson(
+    configJson: string,
+    mcpConfigJson: string,
+  ): Promise<NativeCompressedSession>;
+}
+
+export interface NativeCompressedSession {
+  infoJson(): string;
 }
 
 const require = createRequire(import.meta.url);

--- a/typescript/src/native.ts
+++ b/typescript/src/native.ts
@@ -1,0 +1,29 @@
+import { createRequire } from "node:module";
+
+export interface NativeRustTool {
+  name: string;
+  description?: string | null;
+  input_schema: Record<string, unknown>;
+}
+
+export interface NativeCore {
+  compressToolListingJson(level: string, toolsJson: string): string;
+  formatToolSchemaResponseJson(toolJson: string): string;
+  parseToolArgvJson(toolJson: string, argvJson: string): string;
+  parseMcpConfigJson(configJson: string): string;
+  listOauthCredentialsJson(): string;
+  clearOauthCredentialsJson(target?: string | null): string;
+}
+
+const require = createRequire(import.meta.url);
+
+export function loadNativeCore(): NativeCore {
+  try {
+    return require("../native/index.js") as NativeCore;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Rust native addon is not available. Run \`bun run build:native\` before using Rust-backed helpers. Cause: ${message}`,
+    );
+  }
+}

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -1,0 +1,59 @@
+import { loadNativeCore, type NativeRustTool } from "./native.js";
+
+export interface RustTool {
+  name: string;
+  description?: string | null;
+  inputSchema: Record<string, unknown>;
+}
+
+function toNativeTool(tool: RustTool): NativeRustTool {
+  return {
+    name: tool.name,
+    description: tool.description ?? null,
+    input_schema: tool.inputSchema,
+  };
+}
+
+function stringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+export function compressToolListing(level: string, tools: RustTool[]): string {
+  return loadNativeCore().compressToolListingJson(level, stringify(tools.map(toNativeTool)));
+}
+
+export function formatToolSchemaResponse(tool: RustTool): string {
+  return loadNativeCore().formatToolSchemaResponseJson(stringify(toNativeTool(tool)));
+}
+
+export function parseToolArgv(tool: RustTool, argv: string[]): Record<string, unknown> {
+  return JSON.parse(
+    loadNativeCore().parseToolArgvJson(stringify(toNativeTool(tool)), stringify(argv)),
+  ) as Record<string, unknown>;
+}
+
+export interface ParsedMcpServer {
+  name: string;
+  command: string;
+  args: string[];
+  env: Array<[string, string]>;
+  cli_prefix: string;
+}
+
+export function parseMcpConfig(configJson: string): ParsedMcpServer[] {
+  return JSON.parse(loadNativeCore().parseMcpConfigJson(configJson)) as ParsedMcpServer[];
+}
+
+export interface OAuthStoreEntry {
+  backend_name: string;
+  backend_uri: string;
+  store_dir: string;
+}
+
+export function listOAuthCredentials(): OAuthStoreEntry[] {
+  return JSON.parse(loadNativeCore().listOauthCredentialsJson()) as OAuthStoreEntry[];
+}
+
+export function clearOAuthCredentials(target?: string | null): string[] {
+  return JSON.parse(loadNativeCore().clearOauthCredentialsJson(target ?? null)) as string[];
+}

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -1,4 +1,4 @@
-import { loadNativeCore, type NativeRustTool } from "./native.js";
+import { loadNativeCore, type NativeCompressedSession, type NativeRustTool } from "./native.js";
 
 export interface RustTool {
   name: string;
@@ -32,6 +32,126 @@ export function parseToolArgv(tool: RustTool, argv: string[]): Record<string, un
   ) as Record<string, unknown>;
 }
 
+export type ClientArtifactKind = "cli" | "python" | "typescript";
+
+export interface ClientGeneratorConfig {
+  cliName: string;
+  bridgeUrl: string;
+  token: string;
+  tools: RustTool[];
+  sessionPid: number;
+  outputDir: string;
+}
+
+function toNativeGeneratorConfig(config: ClientGeneratorConfig): Record<string, unknown> {
+  return {
+    cli_name: config.cliName,
+    bridge_url: config.bridgeUrl,
+    token: config.token,
+    tools: config.tools.map(toNativeTool),
+    session_pid: config.sessionPid,
+    output_dir: config.outputDir,
+  };
+}
+
+export function generateClientArtifacts(
+  kind: ClientArtifactKind,
+  config: ClientGeneratorConfig,
+): string[] {
+  return JSON.parse(
+    loadNativeCore().generateClientArtifactsJson(kind, stringify(toNativeGeneratorConfig(config))),
+  ) as string[];
+}
+
+export interface BackendConfig {
+  name: string;
+  commandOrUrl: string;
+  args?: string[];
+}
+
+export interface CompressedSessionConfig {
+  compressionLevel: string;
+  serverName?: string | null;
+  includeTools?: string[];
+  excludeTools?: string[];
+  toonify?: boolean;
+  transformMode?: string | null;
+}
+
+export interface JustBashCommandSpec {
+  command_name: string;
+  tool_name: string;
+  description?: string | null;
+  input_schema: Record<string, unknown>;
+  invoke_tool_name: string;
+}
+
+export interface JustBashProviderSpec {
+  provider_name: string;
+  help_tool_name: string;
+  tools: JustBashCommandSpec[];
+}
+
+export interface CompressedSessionInfo {
+  bridge_url: string;
+  token: string;
+  frontend_tools: Array<{
+    name: string;
+    description?: string | null;
+    input_schema: Record<string, unknown>;
+  }>;
+  just_bash_providers: JustBashProviderSpec[];
+}
+
+export class CompressedSession {
+  constructor(private readonly nativeSession: NativeCompressedSession) {}
+
+  info(): CompressedSessionInfo {
+    return JSON.parse(this.nativeSession.infoJson()) as CompressedSessionInfo;
+  }
+}
+
+function toNativeSessionConfig(config: CompressedSessionConfig): Record<string, unknown> {
+  return {
+    compression_level: config.compressionLevel,
+    server_name: config.serverName ?? null,
+    include_tools: config.includeTools ?? [],
+    exclude_tools: config.excludeTools ?? [],
+    toonify: config.toonify ?? false,
+    transform_mode: config.transformMode ?? null,
+  };
+}
+
+function toNativeBackendConfig(backend: BackendConfig): Record<string, unknown> {
+  return {
+    name: backend.name,
+    command_or_url: backend.commandOrUrl,
+    args: backend.args ?? [],
+  };
+}
+
+export async function startCompressedSession(
+  config: CompressedSessionConfig,
+  backends: BackendConfig[],
+): Promise<CompressedSession> {
+  const session = await loadNativeCore().startCompressedSessionJson(
+    stringify(toNativeSessionConfig(config)),
+    stringify(backends.map(toNativeBackendConfig)),
+  );
+  return new CompressedSession(session);
+}
+
+export async function startCompressedSessionFromMcpConfig(
+  config: CompressedSessionConfig,
+  mcpConfigJson: string,
+): Promise<CompressedSession> {
+  const session = await loadNativeCore().startCompressedSessionFromMcpConfigJson(
+    stringify(toNativeSessionConfig(config)),
+    mcpConfigJson,
+  );
+  return new CompressedSession(session);
+}
+
 export interface ParsedMcpServer {
   name: string;
   command: string;
@@ -42,6 +162,14 @@ export interface ParsedMcpServer {
 
 export function parseMcpConfig(configJson: string): ParsedMcpServer[] {
   return JSON.parse(loadNativeCore().parseMcpConfigJson(configJson)) as ParsedMcpServer[];
+}
+
+export function rememberOAuthBackend(
+  backendUri: string,
+  backendName: string,
+  storeDir: string,
+): void {
+  loadNativeCore().rememberOauthBackendJson(backendUri, backendName, storeDir);
 }
 
 export interface OAuthStoreEntry {

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -76,7 +76,7 @@ function fixturePath(name: string): string {
 function alphaBackend() {
   return {
     name: "alpha",
-    commandOrUrl: process.env.PYTHON ?? "python3",
+    commandOrUrl: process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python"),
     args: [fixturePath("alpha_server.py")],
   };
 }
@@ -84,7 +84,7 @@ function alphaBackend() {
 function betaBackend() {
   return {
     name: "beta",
-    commandOrUrl: process.env.PYTHON ?? "python3",
+    commandOrUrl: process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python"),
     args: [fixturePath("beta_server.py")],
   };
 }
@@ -110,12 +110,15 @@ async function startRemoteAlphaUpstream(): Promise<{
       "--port",
       "0",
       "--",
-      process.env.PYTHON ?? "python3",
+      process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python"),
       fixturePath("alpha_server.py"),
     ],
     {
       cwd: join(process.cwd(), ".."),
-      env: { ...process.env, PYTHON: process.env.PYTHON ?? "python3" },
+      env: {
+        ...process.env,
+        PYTHON: process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python"),
+      },
     },
   );
 
@@ -293,7 +296,7 @@ describe("Rust native core wrapper", () => {
       "tests",
       "fixtures",
     );
-    const python = process.env.PYTHON ?? "python3";
+    const python = process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python");
     const session = await startCompressedSessionFromMcpConfig(
       { compressionLevel: "max" },
       JSON.stringify({

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -1,12 +1,164 @@
+import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { request } from "node:http";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
   compressToolListing,
   formatToolSchemaResponse,
+  clearOAuthCredentials,
+  generateClientArtifacts,
+  listOAuthCredentials,
+  rememberOAuthBackend,
+  startCompressedSession,
+  startCompressedSessionFromMcpConfig,
   parseMcpConfig,
   parseToolArgv,
   type RustTool,
 } from "../src/rust_core.js";
+
+function invokeProxy(
+  bridgeUrl: string,
+  token: string,
+  tool: string,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): Promise<string> {
+  const body = JSON.stringify({
+    tool,
+    input: {
+      tool_name: toolName,
+      tool_input: toolInput,
+    },
+  });
+  const url = new URL(`${bridgeUrl}/exec`);
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        method: "POST",
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(data);
+          } else {
+            reject(new Error(`proxy returned ${res.statusCode}: ${data}`));
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function fixturePath(name: string): string {
+  return join(process.cwd(), "..", "crates", "mcp-compressor-core", "tests", "fixtures", name);
+}
+
+function alphaBackend() {
+  return {
+    name: "alpha",
+    commandOrUrl: process.env.PYTHON ?? "python3",
+    args: [fixturePath("alpha_server.py")],
+  };
+}
+
+function betaBackend() {
+  return {
+    name: "beta",
+    commandOrUrl: process.env.PYTHON ?? "python3",
+    args: [fixturePath("beta_server.py")],
+  };
+}
+
+async function startRemoteAlphaUpstream(): Promise<{
+  url: string;
+  child: ChildProcessWithoutNullStreams;
+}> {
+  const child = spawn(
+    "cargo",
+    [
+      "run",
+      "-q",
+      "-p",
+      "mcp-compressor-core",
+      "--",
+      "--compression",
+      "max",
+      "--server-name",
+      "alpha",
+      "--transport",
+      "streamable-http",
+      "--port",
+      "0",
+      "--",
+      process.env.PYTHON ?? "python3",
+      fixturePath("alpha_server.py"),
+    ],
+    {
+      cwd: join(process.cwd(), ".."),
+      env: { ...process.env, PYTHON: process.env.PYTHON ?? "python3" },
+    },
+  );
+
+  const url = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error("timed out waiting for streamable HTTP upstream URL"));
+    }, 30_000);
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      const match = /listening on (http:\/\/127\.0\.0\.1:\d+\/mcp)/.exec(String(chunk));
+      if (match) {
+        clearTimeout(timeout);
+        resolve(match[1]!);
+      }
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`streamable HTTP upstream exited before ready: ${code}`));
+    });
+  });
+
+  return { url, child };
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.killed || child.exitCode !== null) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+    child.kill("SIGTERM");
+    setTimeout(() => {
+      if (!child.killed) {
+        child.kill("SIGKILL");
+      }
+      resolve();
+    }, 2_000).unref();
+  });
+}
 
 const sampleTool: RustTool = {
   name: "echo",
@@ -31,6 +183,237 @@ describe("Rust native core wrapper", () => {
 
   it("parses generated CLI argv through the native addon", () => {
     expect(parseToolArgv(sampleTool, ["--message", "hello"])).toEqual({ message: "hello" });
+  });
+
+  it("generates client artifacts through the native addon", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "mcp-compressor-rust-core-"));
+    mkdirSync(outputDir, { recursive: true });
+    const cliPaths = generateClientArtifacts("cli", {
+      cliName: "native-alpha",
+      bridgeUrl: "http://127.0.0.1:12345",
+      token: "token".repeat(16),
+      tools: [sampleTool],
+      sessionPid: 42,
+      outputDir,
+    });
+    expect(cliPaths).toHaveLength(1);
+    expect(readFileSync(cliPaths[0]!, "utf8")).toContain("native-alpha - the native-alpha toolset");
+
+    const pyPaths = generateClientArtifacts("python", {
+      cliName: "native-alpha",
+      bridgeUrl: "http://127.0.0.1:12345",
+      token: "token".repeat(16),
+      tools: [sampleTool],
+      sessionPid: 42,
+      outputDir,
+    });
+    expect(pyPaths.some((path) => path.endsWith(".py"))).toBe(true);
+
+    const tsPaths = generateClientArtifacts("typescript", {
+      cliName: "native-alpha",
+      bridgeUrl: "http://127.0.0.1:12345",
+      token: "token".repeat(16),
+      tools: [sampleTool],
+      sessionPid: 42,
+      outputDir,
+    });
+    expect(tsPaths.some((path) => path.endsWith(".ts"))).toBe(true);
+    expect(tsPaths.some((path) => path.endsWith(".d.ts"))).toBe(true);
+  });
+
+  it("toonifies JSON outputs through native session config", async () => {
+    const session = await startCompressedSession(
+      {
+        compressionLevel: "max",
+        serverName: "alpha",
+        toonify: true,
+      },
+      [alphaBackend()],
+    );
+    const info = session.info();
+    const invokeTool = info.frontend_tools.find((tool) => tool.name.endsWith("invoke_tool"));
+    expect(invokeTool).toBeDefined();
+    const output = await invokeProxy(
+      info.bridge_url,
+      info.token,
+      invokeTool!.name,
+      "structured_data",
+      {},
+    );
+    expect(output).toContain("server: alpha");
+    expect(output).toContain("values");
+    expect(output.trim()).not.toMatch(/^\{/);
+  });
+
+  it("applies include and exclude filters through native session config", async () => {
+    const session = await startCompressedSession(
+      {
+        compressionLevel: "max",
+        serverName: "alpha",
+        includeTools: ["echo", "add"],
+        excludeTools: ["add"],
+      },
+      [alphaBackend()],
+    );
+    const info = session.info();
+    const invokeTool = info.frontend_tools.find((tool) => tool.name.endsWith("invoke_tool"));
+    expect(info.frontend_tools.some((tool) => tool.name.endsWith("list_tools"))).toBe(true);
+    expect(invokeTool).toBeDefined();
+    await expect(
+      invokeProxy(info.bridge_url, info.token, invokeTool!.name, "echo", { message: "filtered" }),
+    ).resolves.toBe("alpha:filtered");
+    await expect(
+      invokeProxy(info.bridge_url, info.token, invokeTool!.name, "add", { a: 1, b: 2 }),
+    ).rejects.toThrow(/tool not found|unknown tool|not found/i);
+  });
+
+  it("starts a compressed session and invokes a real backend through the proxy", async () => {
+    const session = await startCompressedSession(
+      {
+        compressionLevel: "max",
+        serverName: "alpha",
+      },
+      [alphaBackend()],
+    );
+    const info = session.info();
+    expect(info.bridge_url).toMatch(/^http:\/\/127\.0\.0\.1:/);
+    const invokeTool = info.frontend_tools.find((tool) => tool.name.endsWith("invoke_tool"));
+    expect(invokeTool).toBeDefined();
+    await expect(
+      invokeProxy(info.bridge_url, info.token, invokeTool!.name, "echo", { message: "ts" }),
+    ).resolves.toBe("alpha:ts");
+  });
+
+  it("starts a compressed session from MCP config and routes multiple backends", async () => {
+    const fixtureDir = join(
+      process.cwd(),
+      "..",
+      "crates",
+      "mcp-compressor-core",
+      "tests",
+      "fixtures",
+    );
+    const python = process.env.PYTHON ?? "python3";
+    const session = await startCompressedSessionFromMcpConfig(
+      { compressionLevel: "max" },
+      JSON.stringify({
+        mcpServers: {
+          alpha: { command: python, args: [join(fixtureDir, "alpha_server.py")] },
+          beta: { command: python, args: [join(fixtureDir, "beta_server.py")] },
+        },
+      }),
+    );
+    const info = session.info();
+    expect(info.frontend_tools.some((tool) => tool.name === "alpha_invoke_tool")).toBe(true);
+    expect(info.frontend_tools.some((tool) => tool.name === "beta_invoke_tool")).toBe(true);
+    await expect(
+      invokeProxy(info.bridge_url, info.token, "alpha_invoke_tool", "add", { a: 2, b: 3 }),
+    ).resolves.toBe("5");
+    await expect(
+      invokeProxy(info.bridge_url, info.token, "beta_invoke_tool", "multiply", { a: 4, b: 5 }),
+    ).resolves.toBe("20");
+  });
+
+  it("starts a compressed session against a remote streamable HTTP backend", async () => {
+    const upstream = await startRemoteAlphaUpstream();
+    try {
+      const session = await startCompressedSession(
+        { compressionLevel: "max", serverName: "remote-alpha" },
+        [
+          {
+            name: "remote-alpha",
+            commandOrUrl: upstream.url,
+            args: ["--auth", "explicit-headers"],
+          },
+        ],
+      );
+      const info = session.info();
+      const invokeTool = info.frontend_tools.find((tool) => tool.name.endsWith("invoke_tool"));
+      expect(invokeTool).toBeDefined();
+      await expect(
+        invokeProxy(info.bridge_url, info.token, invokeTool!.name, "alpha_invoke_tool", {
+          tool_name: "echo",
+          tool_input: { message: "remote-ts" },
+        }),
+      ).resolves.toBe("alpha:remote-ts");
+    } finally {
+      await stopChild(upstream.child);
+    }
+  }, 90_000);
+
+  it("starts a CLI transform-mode session through the native addon", async () => {
+    const session = await startCompressedSession(
+      {
+        compressionLevel: "max",
+        serverName: "alpha",
+        transformMode: "cli",
+      },
+      [alphaBackend()],
+    );
+    const info = session.info();
+    expect(info.frontend_tools).toHaveLength(1);
+    expect(info.frontend_tools[0]!.name).toMatch(/alpha_help$/);
+  });
+
+  it("starts a Just Bash transform-mode session with typed provider metadata", async () => {
+    const session = await startCompressedSession(
+      {
+        compressionLevel: "max",
+        transformMode: "just-bash",
+      },
+      [alphaBackend(), betaBackend()],
+    );
+    const info = session.info();
+    expect(info.frontend_tools.some((tool) => tool.name === "bash_tool")).toBe(true);
+    expect(info.frontend_tools.some((tool) => tool.name === "alpha_help")).toBe(true);
+    expect(info.frontend_tools.some((tool) => tool.name === "beta_help")).toBe(true);
+    expect(info.just_bash_providers.map((provider) => provider.provider_name).sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+    const alphaProvider = info.just_bash_providers.find(
+      (provider) => provider.provider_name === "alpha",
+    );
+    expect(alphaProvider?.help_tool_name).toBe("alpha_help");
+    expect(alphaProvider?.tools.some((command) => command.command_name === "echo")).toBe(true);
+    expect(
+      alphaProvider?.tools.some((command) => command.invoke_tool_name === "alpha_invoke_tool"),
+    ).toBe(true);
+  });
+
+  it("lists and clears OAuth credentials through the native addon", () => {
+    const previousXdg = process.env.XDG_CONFIG_HOME;
+    const previousHome = process.env.HOME;
+    const configHome = mkdtempSync(join(tmpdir(), "mcp-compressor-oauth-"));
+    process.env.XDG_CONFIG_HOME = configHome;
+    process.env.HOME = configHome;
+    try {
+      expect(listOAuthCredentials()).toEqual([]);
+      const storeDir = join(configHome, "oauth-store");
+      mkdirSync(storeDir, { recursive: true });
+      rememberOAuthBackend("https://example.test/mcp", "example", storeDir);
+      expect(listOAuthCredentials()).toEqual([
+        {
+          backend_name: "example",
+          backend_uri: "https://example.test/mcp",
+          store_dir: storeDir,
+        },
+      ]);
+      expect(clearOAuthCredentials("missing")).toEqual([]);
+      expect(clearOAuthCredentials("example")).toEqual([storeDir]);
+      expect(listOAuthCredentials()).toEqual([]);
+    } finally {
+      if (previousXdg === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdg;
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    }
   });
 
   it("parses MCP config through the native addon", () => {

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compressToolListing,
+  formatToolSchemaResponse,
+  parseMcpConfig,
+  parseToolArgv,
+  type RustTool,
+} from "../src/rust_core.js";
+
+const sampleTool: RustTool = {
+  name: "echo",
+  description: "Echo a value.",
+  inputSchema: {
+    type: "object",
+    properties: { message: { type: "string" } },
+    required: ["message"],
+  },
+};
+
+describe("Rust native core wrapper", () => {
+  it("compresses tool listings through the native addon", () => {
+    expect(compressToolListing("high", [sampleTool])).toBe("<tool>echo(message)</tool>");
+  });
+
+  it("formats schema responses through the native addon", () => {
+    const response = formatToolSchemaResponse(sampleTool);
+    expect(response).toContain("Echo a value.");
+    expect(response).toContain('"message"');
+  });
+
+  it("parses generated CLI argv through the native addon", () => {
+    expect(parseToolArgv(sampleTool, ["--message", "hello"])).toEqual({ message: "hello" });
+  });
+
+  it("parses MCP config through the native addon", () => {
+    expect(
+      parseMcpConfig('{"mcpServers":{"my-server":{"command":"python","args":["server.py"]}}}'),
+    ).toEqual([
+      {
+        name: "my-server",
+        command: "python",
+        args: ["server.py"],
+        env: [],
+        cli_prefix: "my-server",
+      },
+    ]);
+  });
+});

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -93,14 +93,16 @@ async function startRemoteAlphaUpstream(): Promise<{
   url: string;
   child: ChildProcessWithoutNullStreams;
 }> {
+  const root = join(process.cwd(), "..");
+  const binary = join(
+    root,
+    "target",
+    "debug",
+    process.platform === "win32" ? "mcp-compressor-core.exe" : "mcp-compressor-core",
+  );
   const child = spawn(
-    "cargo",
+    binary,
     [
-      "run",
-      "-q",
-      "-p",
-      "mcp-compressor-core",
-      "--",
       "--compression",
       "max",
       "--server-name",
@@ -114,7 +116,7 @@ async function startRemoteAlphaUpstream(): Promise<{
       fixturePath("alpha_server.py"),
     ],
     {
-      cwd: join(process.cwd(), ".."),
+      cwd: root,
       env: {
         ...process.env,
         PYTHON: process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python"),
@@ -123,11 +125,22 @@ async function startRemoteAlphaUpstream(): Promise<{
   );
 
   const url = await new Promise<string>((resolve, reject) => {
+    let stderr = "";
+    let stdout = "";
     const timeout = setTimeout(() => {
-      reject(new Error("timed out waiting for streamable HTTP upstream URL"));
-    }, 30_000);
+      reject(
+        new Error(
+          `timed out waiting for streamable HTTP upstream URL\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    }, 60_000);
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
       const match = /listening on (http:\/\/127\.0\.0\.1:\d+\/mcp)/.exec(String(chunk));
       if (match) {
         clearTimeout(timeout);

--- a/typescript/tests/subpath_exports.test.ts
+++ b/typescript/tests/subpath_exports.test.ts
@@ -24,6 +24,7 @@ test("package.json exports declares the lightweight sub-paths", () => {
     "./bash",
     "./config",
     "./errors",
+    "./rust-core",
     "./types",
   ]);
 });


### PR DESCRIPTION
## Summary
- add dedicated `crates/mcp-compressor-node` napi-rs extension crate backed by `mcp-compressor-core`
- add `typescript/src/rust_core.ts` typed wrappers and `typescript/src/native.ts` native loader
- expose `./rust-core` TypeScript subpath
- add native addon tests for compression, schema formatting, argv parsing, and MCP config parsing
- add `bun run build:native` and CI coverage for building the native addon before TypeScript checks
- ignore generated napi loader and platform binaries while keeping `typescript/native/package.json` as CommonJS marker
- update Rust design doc with the new node addon architecture

## Validation
- `cargo check -p mcp-compressor-node`
- `cargo check -p mcp-compressor-core`
- `cargo check -p mcp-compressor-python`
- `cargo test -p mcp-compressor-core --tests --no-run`
- `cd typescript && bun run build:native && bun run check`
- `make check`