### PR TITLE
feat: expose native typescript oauth store updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "pyo3",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -6,7 +6,8 @@ use serde_json::Value;
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
     clear_oauth_credentials, compress_tool_listing, format_tool_schema_response, generate_client_artifacts,
-    list_oauth_credentials, parse_mcp_config, parse_tool_argv, start_compressed_session,
+    list_oauth_credentials, parse_mcp_config, parse_tool_argv, remember_oauth_backend,
+    start_compressed_session,
     start_compressed_session_from_mcp_config, FfiBackendConfig, FfiClientArtifactKind,
     FfiCompressedSession, FfiCompressedSessionConfig, FfiGeneratorConfig, FfiTool,
 };
@@ -61,6 +62,15 @@ pub fn generate_client_artifacts_json(kind: String, config_json: String) -> napi
 pub fn parse_mcp_config_json(config_json: String) -> napi::Result<String> {
     let parsed = parse_mcp_config(&config_json).map_err(napi_error)?;
     serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn remember_oauth_backend_json(
+    backend_uri: String,
+    backend_name: String,
+    store_dir: String,
+) -> napi::Result<()> {
+    remember_oauth_backend(&backend_uri, &backend_name, store_dir.into()).map_err(napi_error)
 }
 
 #[napi]

--- a/crates/mcp-compressor-python/Cargo.toml
+++ b/crates/mcp-compressor-python/Cargo.toml
@@ -12,3 +12,4 @@ mcp-compressor-core = { path = "../mcp-compressor-core" }
 pyo3 = { version = "0.28.3", features = ["extension-module"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/crates/mcp-compressor-python/src/lib.rs
+++ b/crates/mcp-compressor-python/src/lib.rs
@@ -6,7 +6,9 @@ use serde_json::Value;
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
     clear_oauth_credentials, compress_tool_listing, format_tool_schema_response, list_oauth_credentials,
-    parse_mcp_config, parse_tool_argv, FfiTool,
+    parse_mcp_config, parse_tool_argv, start_compressed_session,
+    start_compressed_session_from_mcp_config, FfiBackendConfig, FfiCompressedSession,
+    FfiCompressedSessionConfig, FfiTool,
 };
 
 fn py_value_error(error: impl std::fmt::Display) -> PyErr {
@@ -50,6 +52,47 @@ fn list_oauth_credentials_json() -> PyResult<String> {
     serde_json::to_string(&entries).map_err(py_value_error)
 }
 
+#[pyclass]
+struct PyCompressedSession {
+    inner: FfiCompressedSession,
+    #[allow(dead_code)]
+    runtime: tokio::runtime::Runtime,
+}
+
+#[pymethods]
+impl PyCompressedSession {
+    fn info_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner.info()).map_err(py_value_error)
+    }
+}
+
+#[pyfunction]
+fn start_compressed_session_json(
+    config_json: &str,
+    backends_json: &str,
+) -> PyResult<PyCompressedSession> {
+    let config = parse_json::<FfiCompressedSessionConfig>(config_json)?;
+    let backends = parse_json::<Vec<FfiBackendConfig>>(backends_json)?;
+    let runtime = tokio::runtime::Runtime::new().map_err(py_value_error)?;
+    let inner = runtime
+        .block_on(start_compressed_session(config, backends))
+        .map_err(py_value_error)?;
+    Ok(PyCompressedSession { inner, runtime })
+}
+
+#[pyfunction]
+fn start_compressed_session_from_mcp_config_json(
+    config_json: &str,
+    mcp_config_json: &str,
+) -> PyResult<PyCompressedSession> {
+    let config = parse_json::<FfiCompressedSessionConfig>(config_json)?;
+    let runtime = tokio::runtime::Runtime::new().map_err(py_value_error)?;
+    let inner = runtime
+        .block_on(start_compressed_session_from_mcp_config(config, mcp_config_json))
+        .map_err(py_value_error)?;
+    Ok(PyCompressedSession { inner, runtime })
+}
+
 #[pyfunction]
 fn clear_oauth_credentials_json(target: Option<&str>) -> PyResult<String> {
     let paths = clear_oauth_credentials(target).map_err(py_value_error)?;
@@ -62,10 +105,13 @@ fn clear_oauth_credentials_json(target: Option<&str>) -> PyResult<String> {
 
 #[pymodule]
 fn _mcp_compressor_core(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PyCompressedSession>()?;
     module.add_function(wrap_pyfunction!(compress_tool_listing_json, module)?)?;
     module.add_function(wrap_pyfunction!(format_tool_schema_response_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_tool_argv_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_mcp_config_json, module)?)?;
+    module.add_function(wrap_pyfunction!(start_compressed_session_json, module)?)?;
+    module.add_function(wrap_pyfunction!(start_compressed_session_from_mcp_config_json, module)?)?;
     module.add_function(wrap_pyfunction!(list_oauth_credentials_json, module)?)?;
     module.add_function(wrap_pyfunction!(clear_oauth_credentials_json, module)?)?;
     Ok(())

--- a/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
@@ -1,6 +1,9 @@
 """Rust-backed experimental Python API for mcp-compressor."""
 
 from mcp_compressor_rust.core import (
+    BackendConfig,
+    CompressedSession,
+    CompressedSessionConfig,
     RustTool,
     clear_oauth_credentials,
     compress_tool_listing,
@@ -8,9 +11,14 @@ from mcp_compressor_rust.core import (
     list_oauth_credentials,
     parse_mcp_config,
     parse_tool_argv,
+    start_compressed_session,
+    start_compressed_session_from_mcp_config,
 )
 
 __all__ = [
+    "BackendConfig",
+    "CompressedSession",
+    "CompressedSessionConfig",
     "RustTool",
     "clear_oauth_credentials",
     "compress_tool_listing",
@@ -18,4 +26,6 @@ __all__ = [
     "list_oauth_credentials",
     "parse_mcp_config",
     "parse_tool_argv",
+    "start_compressed_session",
+    "start_compressed_session_from_mcp_config",
 ]

--- a/python/mcp-compressor-rust/mcp_compressor_rust/core.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/core.py
@@ -11,6 +11,58 @@ _mcp_compressor_core = importlib.import_module("mcp_compressor_rust._mcp_compres
 
 
 @dataclass(frozen=True)
+class BackendConfig:
+    """Runtime backend configuration accepted by the Rust core extension."""
+
+    name: str
+    command_or_url: str
+    args: list[str] | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "command_or_url": self.command_or_url,
+            "args": self.args or [],
+        }
+
+
+@dataclass(frozen=True)
+class CompressedSessionConfig:
+    """Runtime session configuration accepted by the Rust core extension."""
+
+    compression_level: str = "max"
+    server_name: str | None = None
+    include_tools: list[str] | None = None
+    exclude_tools: list[str] | None = None
+    toonify: bool = False
+    transform_mode: str | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "compression_level": self.compression_level,
+            "server_name": self.server_name,
+            "include_tools": self.include_tools or [],
+            "exclude_tools": self.exclude_tools or [],
+            "toonify": self.toonify,
+            "transform_mode": self.transform_mode,
+        }
+
+
+class CompressedSession:
+    """Python wrapper around a Rust-backed compressed session handle."""
+
+    def __init__(self, native_session: Any) -> None:
+        self._native_session = native_session
+
+    def info(self) -> dict[str, Any]:
+        value = json.loads(self._native_session.info_json())
+        if not isinstance(value, dict):
+            msg = "Rust core session info_json returned non-object JSON"
+            raise TypeError(msg)
+        return value
+
+
+@dataclass(frozen=True)
 class RustTool:
     """JSON-serializable tool DTO accepted by the Rust core extension."""
 
@@ -55,6 +107,30 @@ def parse_tool_argv(tool: RustTool, argv: list[str]) -> dict[str, Any]:
         msg = "Rust core parse_tool_argv_json returned non-object JSON"
         raise TypeError(msg)
     return value
+
+
+def start_compressed_session(
+    config: CompressedSessionConfig,
+    backends: list[BackendConfig],
+) -> CompressedSession:
+    """Start a Rust-backed compressed session and local proxy."""
+    native_session = _mcp_compressor_core.start_compressed_session_json(
+        _json_dumps(config.to_json_dict()),
+        _json_dumps([backend.to_json_dict() for backend in backends]),
+    )
+    return CompressedSession(native_session)
+
+
+def start_compressed_session_from_mcp_config(
+    config: CompressedSessionConfig,
+    mcp_config_json: str,
+) -> CompressedSession:
+    """Start a Rust-backed compressed session from MCP config JSON."""
+    native_session = _mcp_compressor_core.start_compressed_session_from_mcp_config_json(
+        _json_dumps(config.to_json_dict()),
+        mcp_config_json,
+    )
+    return CompressedSession(native_session)
 
 
 def parse_mcp_config(config_json: str) -> list[dict[str, Any]]:

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -1,12 +1,37 @@
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+from urllib import error, request
+
 from mcp_compressor_rust import (
+    BackendConfig,
+    CompressedSessionConfig,
     RustTool,
     compress_tool_listing,
     format_tool_schema_response,
     parse_mcp_config,
     parse_tool_argv,
+    start_compressed_session,
+    start_compressed_session_from_mcp_config,
 )
+
+ROOT = Path(__file__).resolve().parents[2].parent
+FIXTURES = ROOT / "crates" / "mcp-compressor-core" / "tests" / "fixtures"
+PYTHON = os.environ.get("PYTHON") or str(ROOT / ".venv" / "bin" / "python3")
+
+
+def invoke_proxy(bridge_url: str, token: str, tool: str, tool_name: str, tool_input: dict[str, object]) -> str:
+    body = json.dumps({"tool": tool, "input": {"tool_name": tool_name, "tool_input": tool_input}}).encode()
+    req = request.Request(  # noqa: S310 - local Rust test proxy
+        f"{bridge_url}/exec",
+        data=body,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as response:  # noqa: S310 - local Rust test proxy
+        return response.read().decode()
 
 
 def sample_tool() -> RustTool:
@@ -33,6 +58,109 @@ def test_native_extension_formats_schema_response() -> None:
 
 def test_native_extension_parses_tool_argv() -> None:
     assert parse_tool_argv(sample_tool(), ["--message", "hello"]) == {"message": "hello"}
+
+
+def test_native_extension_starts_session_and_invokes_backend() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", server_name="alpha"),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")])],
+    )
+    info = session.info()
+    assert str(info["bridge_url"]).startswith("http://127.0.0.1:")
+    invoke_tool = next(tool for tool in info["frontend_tools"] if tool["name"].endswith("invoke_tool"))
+    assert (
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "echo", {"message": "py"})
+        == "alpha:py"
+    )
+
+
+def test_native_extension_starts_session_from_mcp_config_and_routes() -> None:
+    session = start_compressed_session_from_mcp_config(
+        CompressedSessionConfig(compression_level="max"),
+        json.dumps(
+            {
+                "mcpServers": {
+                    "alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]},
+                    "beta": {"command": PYTHON, "args": [str(FIXTURES / "beta_server.py")]},
+                }
+            }
+        ),
+    )
+    info = session.info()
+    tool_names = {tool["name"] for tool in info["frontend_tools"]}
+    assert "alpha_invoke_tool" in tool_names
+    assert "beta_invoke_tool" in tool_names
+    assert (
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), "alpha_invoke_tool", "add", {"a": 2, "b": 3}) == "5"
+    )
+    assert (
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), "beta_invoke_tool", "multiply", {"a": 4, "b": 5})
+        == "20"
+    )
+
+
+def test_native_extension_toonifies_json_outputs() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", server_name="alpha", toonify=True),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")])],
+    )
+    info = session.info()
+    invoke_tool = next(tool for tool in info["frontend_tools"] if tool["name"].endswith("invoke_tool"))
+    output = invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "structured_data", {})
+    assert "server: alpha" in output
+    assert "values" in output
+    assert not output.strip().startswith("{")
+
+
+def test_native_extension_applies_include_exclude_filters() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(
+            compression_level="max",
+            server_name="alpha",
+            include_tools=["echo", "add"],
+            exclude_tools=["add"],
+        ),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")])],
+    )
+    info = session.info()
+    invoke_tool = next(tool for tool in info["frontend_tools"] if tool["name"].endswith("invoke_tool"))
+    assert (
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "echo", {"message": "filtered"})
+        == "alpha:filtered"
+    )
+    try:
+        invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "add", {"a": 1, "b": 2})
+    except error.HTTPError as exc:
+        assert exc.code == 400
+        assert "not found" in exc.read().decode().lower()
+    else:  # pragma: no cover - defensive assertion for filter enforcement
+        raise AssertionError("excluded add tool unexpectedly invoked")
+
+
+def test_native_extension_supports_cli_transform_mode() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", server_name="alpha", transform_mode="cli"),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")])],
+    )
+    info = session.info()
+    assert [tool["name"] for tool in info["frontend_tools"]] == ["alpha_alpha_help"]
+
+
+def test_native_extension_supports_just_bash_transform_mode() -> None:
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", transform_mode="just-bash"),
+        [
+            BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURES / "alpha_server.py")]),
+            BackendConfig(name="beta", command_or_url=PYTHON, args=[str(FIXTURES / "beta_server.py")]),
+        ],
+    )
+    info = session.info()
+    tool_names = {tool["name"] for tool in info["frontend_tools"]}
+    assert {"bash_tool", "alpha_help", "beta_help"}.issubset(tool_names)
+    providers = {provider["provider_name"]: provider for provider in info["just_bash_providers"]}
+    assert set(providers) == {"alpha", "beta"}
+    assert providers["alpha"]["help_tool_name"] == "alpha_help"
+    assert any(command["command_name"] == "echo" for command in providers["alpha"]["tools"])
 
 
 def test_native_extension_parses_mcp_config() -> None:

--- a/typescript/src/native.ts
+++ b/typescript/src/native.ts
@@ -12,6 +12,7 @@ export interface NativeCore {
   parseToolArgvJson(toolJson: string, argvJson: string): string;
   generateClientArtifactsJson(kind: string, configJson: string): string;
   parseMcpConfigJson(configJson: string): string;
+  rememberOauthBackendJson(backendUri: string, backendName: string, storeDir: string): void;
   listOauthCredentialsJson(): string;
   clearOauthCredentialsJson(target?: string | null): string;
   startCompressedSessionJson(

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -164,6 +164,14 @@ export function parseMcpConfig(configJson: string): ParsedMcpServer[] {
   return JSON.parse(loadNativeCore().parseMcpConfigJson(configJson)) as ParsedMcpServer[];
 }
 
+export function rememberOAuthBackend(
+  backendUri: string,
+  backendName: string,
+  storeDir: string,
+): void {
+  loadNativeCore().rememberOauthBackendJson(backendUri, backendName, storeDir);
+}
+
 export interface OAuthStoreEntry {
   backend_name: string;
   backend_uri: string;

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -12,6 +12,7 @@ import {
   clearOAuthCredentials,
   generateClientArtifacts,
   listOAuthCredentials,
+  rememberOAuthBackend,
   startCompressedSession,
   startCompressedSessionFromMcpConfig,
   parseMcpConfig,
@@ -388,8 +389,19 @@ describe("Rust native core wrapper", () => {
     process.env.HOME = configHome;
     try {
       expect(listOAuthCredentials()).toEqual([]);
-      expect(clearOAuthCredentials()).toEqual([]);
+      const storeDir = join(configHome, "oauth-store");
+      mkdirSync(storeDir, { recursive: true });
+      rememberOAuthBackend("https://example.test/mcp", "example", storeDir);
+      expect(listOAuthCredentials()).toEqual([
+        {
+          backend_name: "example",
+          backend_uri: "https://example.test/mcp",
+          store_dir: storeDir,
+        },
+      ]);
       expect(clearOAuthCredentials("missing")).toEqual([]);
+      expect(clearOAuthCredentials("example")).toEqual([storeDir]);
+      expect(listOAuthCredentials()).toEqual([]);
     } finally {
       if (previousXdg === undefined) {
         delete process.env.XDG_CONFIG_HOME;


### PR DESCRIPTION
## Summary
- expose Rust OAuth store remembering through the napi-rs native addon
- add TypeScript `rememberOAuthBackend` wrapper
- extend native TypeScript OAuth helper test to remember, list, targeted-clear, and re-list stored OAuth metadata in an isolated config dir

## Validation
- `cargo check -p mcp-compressor-node`
- `cargo check -p mcp-compressor-core`
- `cd typescript && bun run format && bun run build:native && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python3" bun run vitest run tests/rust_core.test.ts -t "OAuth" && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python3" bun run vitest run tests/rust_core.test.ts && bun run typecheck && bun run format:check && bun run lint`

Stacked on #81 / `rust-node-toon-session-e2e`.