### PR TITLE
refactor: make ffi session own proxy handle

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/session.rs
+++ b/crates/mcp-compressor-core/src/ffi/session.rs
@@ -1,4 +1,4 @@
-use crate::proxy::ToolProxyServer;
+use crate::proxy::{RunningToolProxy, ToolProxyServer};
 use crate::server::{CompressedServer, CompressedServerConfig, ProxyTransformMode};
 use crate::Error;
 
@@ -8,6 +8,7 @@ use super::dto::{
 
 pub struct FfiCompressedSession {
     info: FfiCompressedSessionInfo,
+    _proxy: RunningToolProxy,
 }
 
 impl FfiCompressedSession {
@@ -22,6 +23,8 @@ impl FfiCompressedSession {
     pub fn info(&self) -> FfiCompressedSessionInfo {
         self.info.clone()
     }
+
+    pub fn close(self) {}
 }
 
 fn parse_ffi_transform_mode(value: Option<&str>) -> Result<ProxyTransformMode, Error> {
@@ -55,6 +58,7 @@ async fn compressed_session_from_server(
             frontend_tools,
             just_bash_providers,
         },
+        _proxy: proxy,
     })
 }
 

--- a/crates/mcp-compressor-core/src/proxy/server.rs
+++ b/crates/mcp-compressor-core/src/proxy/server.rs
@@ -22,10 +22,11 @@ use crate::Error;
 #[derive(Debug)]
 pub struct ToolProxyServer;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RunningToolProxy {
     bridge_url: String,
     token: SessionToken,
+    task: tokio::task::JoinHandle<()>,
 }
 
 #[derive(Clone)]
@@ -63,7 +64,7 @@ impl ToolProxyServer {
 
         let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
         let addr = listener.local_addr()?;
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             if let Err(error) = axum::serve(listener, app).await {
                 eprintln!("mcp-compressor proxy server error: {error}");
             }
@@ -72,6 +73,7 @@ impl ToolProxyServer {
         Ok(RunningToolProxy {
             bridge_url: format!("http://{addr}"),
             token,
+            task,
         })
     }
 }
@@ -121,6 +123,12 @@ fn authorized(token: &SessionToken, headers: &HeaderMap) -> bool {
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .is_some_and(|header| token.verify(header))
+}
+
+impl Drop for RunningToolProxy {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
 }
 
 impl RunningToolProxy {

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -6,10 +6,10 @@ use mcp_compressor_core::client_gen::cli::CliGenerator;
 use mcp_compressor_core::client_gen::python::PythonGenerator;
 use mcp_compressor_core::client_gen::typescript::TypeScriptGenerator;
 use mcp_compressor_core::client_gen::{ClientGenerator, GeneratorConfig};
-use mcp_compressor_core::proxy::ToolProxyServer;
+use mcp_compressor_core::proxy::{RunningToolProxy, ToolProxyServer};
 use mcp_compressor_core::server::CompressedServer;
 
-async fn running_proxy_config(output_dir: &std::path::Path) -> GeneratorConfig {
+async fn running_proxy_config(output_dir: &std::path::Path) -> (GeneratorConfig, RunningToolProxy) {
     let compressed = CompressedServer::connect_stdio(
         common::max_config(Some("alpha")),
         common::backend("alpha", "alpha_server.py"),
@@ -18,7 +18,7 @@ async fn running_proxy_config(output_dir: &std::path::Path) -> GeneratorConfig {
     .unwrap();
     let proxy = ToolProxyServer::start(compressed).await.unwrap();
 
-    GeneratorConfig {
+    let config = GeneratorConfig {
         cli_name: "alpha".to_string(),
         bridge_url: proxy.bridge_url().to_string(),
         token: proxy.token_value().to_string(),
@@ -33,13 +33,14 @@ async fn running_proxy_config(output_dir: &std::path::Path) -> GeneratorConfig {
         )],
         session_pid: std::process::id(),
         output_dir: output_dir.to_path_buf(),
-    }
+    };
+    (config, proxy)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_cli_script_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
-    let config = running_proxy_config(tempdir.path()).await;
+    let (config, _proxy) = running_proxy_config(tempdir.path()).await;
     let paths = CliGenerator.generate(&config).unwrap();
     let script = paths
         .iter()
@@ -65,7 +66,7 @@ async fn generated_cli_script_invokes_real_proxy_and_backend() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_python_module_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
-    let config = running_proxy_config(tempdir.path()).await;
+    let (config, _proxy) = running_proxy_config(tempdir.path()).await;
     PythonGenerator.generate(&config).unwrap();
 
     let code = "import alpha; print(alpha.echo('hello'))";
@@ -89,7 +90,7 @@ async fn generated_python_module_invokes_real_proxy_and_backend() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_typescript_module_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
-    let config = running_proxy_config(tempdir.path()).await;
+    let (config, _proxy) = running_proxy_config(tempdir.path()).await;
     TypeScriptGenerator.generate(&config).unwrap();
 
     let module_path = tempdir.path().join("alpha.ts");

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -100,6 +100,9 @@ impl NativeCompressedSession {
     pub fn info_json(&self) -> napi::Result<String> {
         serde_json::to_string(&self.inner.info()).map_err(napi_error)
     }
+
+    #[napi]
+    pub fn close(&mut self) {}
 }
 
 #[napi]

--- a/crates/mcp-compressor-python/src/lib.rs
+++ b/crates/mcp-compressor-python/src/lib.rs
@@ -64,6 +64,10 @@ impl PyCompressedSession {
     fn info_json(&self) -> PyResult<String> {
         serde_json::to_string(&self.inner.info()).map_err(py_value_error)
     }
+
+    fn close(&mut self) {
+        // The Rust session/proxy shuts down when the Python object is dropped.
+    }
 }
 
 #[pyfunction]

--- a/python/mcp-compressor-rust/mcp_compressor_rust/core.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/core.py
@@ -61,6 +61,9 @@ class CompressedSession:
             raise TypeError(msg)
         return value
 
+    def close(self) -> None:
+        self._native_session.close()
+
 
 @dataclass(frozen=True)
 class RustTool:

--- a/typescript/src/native.ts
+++ b/typescript/src/native.ts
@@ -27,6 +27,7 @@ export interface NativeCore {
 
 export interface NativeCompressedSession {
   infoJson(): string;
+  close(): void;
 }
 
 const require = createRequire(import.meta.url);

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -109,6 +109,10 @@ export class CompressedSession {
   info(): CompressedSessionInfo {
     return JSON.parse(this.nativeSession.infoJson()) as CompressedSessionInfo;
   }
+
+  close(): void {
+    this.nativeSession.close();
+  }
 }
 
 function toNativeSessionConfig(config: CompressedSessionConfig): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- make `RunningToolProxy` retain the spawned proxy task and abort it on drop
- make `FfiCompressedSession` explicitly own the running proxy handle instead of only copying session info
- expose no-op close methods through Rust/PyO3/napi wrapper surfaces so language bindings have a lifecycle hook
- add Python and TypeScript wrapper `close()` methods

## Validation
- `cargo check -p mcp-compressor-core`
- `cargo check -p mcp-compressor-python`
- `cargo check -p mcp-compressor-node`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core ffi:: -- --nocapture`
- `cd python/mcp-compressor-rust && uv run maturin develop && uv run pytest -q tests && uv run ruff check mcp_compressor_rust tests && uv run ty check --project . --python .venv mcp_compressor_rust tests`
- `cd typescript && bun run build:native && bun run vitest run tests/rust_core.test.ts && bun run typecheck && bun run lint`
- `make check`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --lib -- --nocapture`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --tests --no-run`