### PR TITLE
refactor: extract cli output path selection

### DIFF
--- a/crates/mcp-compressor-core/src/app/mod.rs
+++ b/crates/mcp-compressor-core/src/app/mod.rs
@@ -1,0 +1,1 @@
+pub mod paths;

--- a/crates/mcp-compressor-core/src/app/paths.rs
+++ b/crates/mcp-compressor-core/src/app/paths.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+/// Select where generated CLI scripts should be written.
+///
+/// Returns `(directory, on_path)` where `on_path` indicates whether the
+/// directory is already on the user's `PATH`.
+pub fn cli_output_dir() -> std::io::Result<(PathBuf, bool)> {
+    if let Some(path) = std::env::var_os("MCP_COMPRESSOR_CLI_OUTPUT_DIR") {
+        return Ok((PathBuf::from(path), true));
+    }
+
+    let path_dirs = path_dirs();
+    for candidate in candidate_script_dirs() {
+        let resolved = candidate.canonicalize().unwrap_or(candidate.clone());
+        if resolved.is_dir() && path_dirs.iter().any(|path_dir| path_dir == &resolved) {
+            return Ok((resolved, true));
+        }
+    }
+
+    Ok((std::env::current_dir()?, false))
+}
+
+fn candidate_script_dirs() -> Vec<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let mut candidates = Vec::new();
+    if cfg!(windows) {
+        if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {
+            candidates.push(
+                PathBuf::from(local_app_data)
+                    .join("Microsoft")
+                    .join("WindowsApps"),
+            );
+        }
+        if let Some(home) = &home {
+            candidates.push(home.join(".local").join("bin"));
+        }
+    } else {
+        if let Some(home) = &home {
+            candidates.push(home.join(".local").join("bin"));
+            candidates.push(home.join("bin"));
+        }
+        candidates.push(PathBuf::from("/usr/local/bin"));
+        candidates.push(PathBuf::from("/opt/homebrew/bin"));
+    }
+    candidates
+}
+
+fn path_dirs() -> Vec<PathBuf> {
+    std::env::var_os("PATH")
+        .map(|path| {
+            std::env::split_paths(&path)
+                .map(|entry| entry.canonicalize().unwrap_or(entry))
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/crates/mcp-compressor-core/src/lib.rs
+++ b/crates/mcp-compressor-core/src/lib.rs
@@ -12,6 +12,7 @@
 //! | [`server`] | `CompressedServer`, `ToolCache`, tool registration |
 //! | [`ffi`] | FFI-safe surface for PyO3 / napi-rs language bindings |
 
+pub mod app;
 pub mod cli;
 pub mod client_gen;
 pub mod compression;

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use mcp_compressor_core::app::paths::cli_output_dir;
 use mcp_compressor_core::client_gen::cli::CliGenerator;
 use mcp_compressor_core::client_gen::{ClientGenerator, GeneratorConfig};
 use mcp_compressor_core::compression::CompressionLevel;
@@ -183,7 +184,8 @@ async fn run_cli_mode(cli: CliOptions, server: CompressedServer) -> Result<(), C
     let proxy = ToolProxyServer::start(server)
         .await
         .map_err(|error| CliError::Runtime(error.to_string()))?;
-    let (output_dir, on_path) = cli_output_dir(&cli)?;
+    let (output_dir, on_path) = cli_output_dir()
+        .map_err(|error| CliError::Runtime(error.to_string()))?;
     let cli_name = cli.server_name.clone().unwrap_or_else(|| "mcp".to_string());
     let config = GeneratorConfig {
         cli_name: cli_name.clone(),
@@ -224,60 +226,6 @@ async fn run_cli_mode(cli: CliOptions, server: CompressedServer) -> Result<(), C
 
     std::future::pending::<()>().await;
     Ok(())
-}
-
-fn cli_output_dir(_cli: &CliOptions) -> Result<(PathBuf, bool), CliError> {
-    if let Some(path) = std::env::var_os("MCP_COMPRESSOR_CLI_OUTPUT_DIR") {
-        return Ok((PathBuf::from(path), true));
-    }
-
-    let path_dirs = path_dirs();
-    for candidate in candidate_script_dirs() {
-        let resolved = candidate.canonicalize().unwrap_or(candidate.clone());
-        if resolved.is_dir() && path_dirs.iter().any(|path_dir| path_dir == &resolved) {
-            return Ok((resolved, true));
-        }
-    }
-
-    Ok((
-        std::env::current_dir().map_err(|error| CliError::Runtime(error.to_string()))?,
-        false,
-    ))
-}
-
-fn candidate_script_dirs() -> Vec<PathBuf> {
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    let mut candidates = Vec::new();
-    if cfg!(windows) {
-        if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {
-            candidates.push(
-                PathBuf::from(local_app_data)
-                    .join("Microsoft")
-                    .join("WindowsApps"),
-            );
-        }
-        if let Some(home) = &home {
-            candidates.push(home.join(".local").join("bin"));
-        }
-    } else {
-        if let Some(home) = &home {
-            candidates.push(home.join(".local").join("bin"));
-            candidates.push(home.join("bin"));
-        }
-        candidates.push(PathBuf::from("/usr/local/bin"));
-        candidates.push(PathBuf::from("/opt/homebrew/bin"));
-    }
-    candidates
-}
-
-fn path_dirs() -> Vec<PathBuf> {
-    std::env::var_os("PATH")
-        .map(|path| {
-            std::env::split_paths(&path)
-                .map(|entry| entry.canonicalize().unwrap_or(entry))
-                .collect()
-        })
-        .unwrap_or_default()
 }
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
## Summary
- move generated CLI output directory selection out of the binary entrypoint into `app::paths`
- keep `main.rs` focused on command parsing and mode dispatch
- preserve existing PATH candidate and `MCP_COMPRESSOR_CLI_OUTPUT_DIR` behavior

## Validation
- `cargo check -p mcp-compressor-core`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary -- --nocapture`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --lib -- --nocapture`