### PR TITLE
refactor: extract cli option parsing

### DIFF
--- a/crates/mcp-compressor-core/src/app/mod.rs
+++ b/crates/mcp-compressor-core/src/app/mod.rs
@@ -1,1 +1,2 @@
+pub mod options;
 pub mod paths;

--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -1,0 +1,196 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+
+use crate::compression::CompressionLevel;
+use crate::server::{BackendServerConfig, ProxyTransformMode};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "mcp-compressor-core",
+    about = "Standalone Rust MCP compressor core binary",
+    disable_help_subcommand = true
+)]
+pub struct CliOptions {
+    #[command(subcommand)]
+    pub command_kind: Option<CliCommand>,
+
+    /// Compression level: low, medium, high, or max.
+    #[arg(long, value_enum, default_value = "medium")]
+    compression: CompressionLevelArg,
+
+    /// MCP config JSON file.
+    #[arg(long = "config")]
+    pub config_path: Option<PathBuf>,
+
+    /// Frontend server name/prefix.
+    #[arg(long)]
+    pub server_name: Option<String>,
+
+    /// Frontend transform mode.
+    #[arg(long, value_enum, default_value = "compressed-tools")]
+    transform_mode: TransformModeArg,
+
+    /// Alias for --transform-mode cli.
+    #[arg(long, action = ArgAction::SetTrue)]
+    cli_mode: bool,
+
+    /// Alias for --transform-mode just-bash.
+    #[arg(long, action = ArgAction::SetTrue)]
+    just_bash: bool,
+
+    /// Multi-server backend spec: name=command [args...]. Repeat for each backend.
+    #[arg(long = "multi-server", value_name = "NAME=COMMAND [ARGS...]", action = ArgAction::Append)]
+    pub multi_server: Vec<MultiServerArg>,
+
+    /// Frontend transport.
+    #[arg(long, value_enum, default_value = "stdio")]
+    pub transport: FrontendTransport,
+
+    /// Port for streamable-http frontend; 0 chooses an available port.
+    #[arg(long, default_value_t = 8000)]
+    pub port: u16,
+
+    /// Backend command, URL, and arguments. All backend server arguments belong after `--`.
+    #[arg(value_name = "COMMAND", allow_hyphen_values = true, last = true)]
+    pub command: Vec<String>,
+}
+
+impl CliOptions {
+    pub fn compression(&self) -> CompressionLevel {
+        self.compression.into()
+    }
+
+    pub fn transform_mode(&self) -> ProxyTransformMode {
+        if self.just_bash {
+            ProxyTransformMode::JustBash
+        } else if self.cli_mode {
+            ProxyTransformMode::Cli
+        } else {
+            self.transform_mode.into()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum CliCommand {
+    /// Clear stored OAuth credentials.
+    ClearOauth {
+        /// Backend server name or URL to clear. If omitted, all Rust OAuth state is removed.
+        target: Option<String>,
+    },
+}
+
+impl CliCommand {
+    pub fn clear_oauth_target(&self) -> Option<&str> {
+        match self {
+            Self::ClearOauth { target } => target.as_deref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MultiServerArg {
+    name: String,
+    command: String,
+    args: Vec<String>,
+}
+
+impl FromStr for MultiServerArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut parts = value.split_whitespace();
+        let spec = parts
+            .next()
+            .ok_or_else(|| "expected name=command".to_string())?;
+        let (name, command) = spec
+            .split_once('=')
+            .filter(|(name, command)| !name.is_empty() && !command.is_empty())
+            .ok_or_else(|| "expected name=command".to_string())?;
+        Ok(Self {
+            name: name.to_string(),
+            command: command.to_string(),
+            args: parts.map(ToString::to_string).collect(),
+        })
+    }
+}
+
+impl From<MultiServerArg> for BackendServerConfig {
+    fn from(value: MultiServerArg) -> Self {
+        BackendServerConfig::new(value.name, value.command, value.args)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CompressionLevelArg {
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+impl std::fmt::Display for CompressionLevelArg {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Max => "max",
+        })
+    }
+}
+
+impl From<CompressionLevelArg> for CompressionLevel {
+    fn from(value: CompressionLevelArg) -> Self {
+        match value {
+            CompressionLevelArg::Low => CompressionLevel::Low,
+            CompressionLevelArg::Medium => CompressionLevel::Medium,
+            CompressionLevelArg::High => CompressionLevel::High,
+            CompressionLevelArg::Max => CompressionLevel::Max,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum TransformModeArg {
+    CompressedTools,
+    Cli,
+    JustBash,
+}
+
+impl std::fmt::Display for TransformModeArg {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::CompressedTools => "compressed-tools",
+            Self::Cli => "cli",
+            Self::JustBash => "just-bash",
+        })
+    }
+}
+
+impl From<TransformModeArg> for ProxyTransformMode {
+    fn from(value: TransformModeArg) -> Self {
+        match value {
+            TransformModeArg::CompressedTools => ProxyTransformMode::CompressedTools,
+            TransformModeArg::Cli => ProxyTransformMode::Cli,
+            TransformModeArg::JustBash => ProxyTransformMode::JustBash,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FrontendTransport {
+    Stdio,
+    StreamableHttp,
+}
+
+impl std::fmt::Display for FrontendTransport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Stdio => "stdio",
+            Self::StreamableHttp => "streamable-http",
+        })
+    }
+}

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -1,16 +1,14 @@
 //! CLI entrypoint for the standalone Rust mcp-compressor core binary.
 
 use std::net::{Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
 use std::process::ExitCode;
-use std::str::FromStr;
 use std::sync::Arc;
 
-use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use clap::Parser;
+use mcp_compressor_core::app::options::{CliCommand, CliOptions, FrontendTransport};
 use mcp_compressor_core::app::paths::cli_output_dir;
 use mcp_compressor_core::client_gen::cli::CliGenerator;
 use mcp_compressor_core::client_gen::{ClientGenerator, GeneratorConfig};
-use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::oauth::clear_oauth_store;
 use mcp_compressor_core::proxy::ToolProxyServer;
 use mcp_compressor_core::server::registration::FrontendServer;
@@ -228,204 +226,19 @@ async fn run_cli_mode(cli: CliOptions, server: CompressedServer) -> Result<(), C
     Ok(())
 }
 
-#[derive(Debug, Parser)]
-#[command(
-    name = "mcp-compressor-core",
-    about = "Standalone Rust MCP compressor core binary",
-    disable_help_subcommand = true
-)]
-struct CliOptions {
-    #[command(subcommand)]
-    command_kind: Option<CliCommand>,
-
-    /// Compression level: low, medium, high, or max.
-    #[arg(long, value_enum, default_value = "medium")]
-    compression: CompressionLevelArg,
-
-    /// MCP config JSON file.
-    #[arg(long = "config")]
-    config_path: Option<PathBuf>,
-
-    /// Frontend server name/prefix.
-    #[arg(long)]
-    server_name: Option<String>,
-
-    /// Frontend transform mode.
-    #[arg(long, value_enum, default_value = "compressed-tools")]
-    transform_mode: TransformModeArg,
-
-    /// Alias for --transform-mode cli.
-    #[arg(long, action = ArgAction::SetTrue)]
-    cli_mode: bool,
-
-    /// Alias for --transform-mode just-bash.
-    #[arg(long, action = ArgAction::SetTrue)]
-    just_bash: bool,
-
-    /// Multi-server backend spec: name=command [args...]. Repeat for each backend.
-    #[arg(long = "multi-server", value_name = "NAME=COMMAND [ARGS...]", action = ArgAction::Append)]
-    multi_server: Vec<MultiServerArg>,
-
-    /// Frontend transport.
-    #[arg(long, value_enum, default_value = "stdio")]
-    transport: FrontendTransport,
-
-    /// Port for streamable-http frontend; 0 chooses an available port.
-    #[arg(long, default_value_t = 8000)]
-    port: u16,
-
-    /// Backend command, URL, and arguments. All backend server arguments belong after `--`.
-    #[arg(value_name = "COMMAND", allow_hyphen_values = true, last = true)]
-    command: Vec<String>,
-}
-
-#[derive(Debug, Clone, Subcommand)]
-enum CliCommand {
-    /// Clear stored OAuth credentials.
-    ClearOauth {
-        /// Backend server name or URL to clear. If omitted, all Rust OAuth state is removed.
-        target: Option<String>,
-    },
-}
-
 fn run_command(command: &CliCommand) -> Result<(), CliError> {
-    match command {
-        CliCommand::ClearOauth { target } => {
-            let removed = clear_oauth_store(target.as_deref())
-                .map_err(|error| CliError::Runtime(error.to_string()))?;
-            if removed.is_empty() {
-                println!("No stored OAuth credentials found.");
-            } else {
-                println!(
-                    "Removed {} OAuth store entr{}.",
-                    removed.len(),
-                    if removed.len() == 1 { "y" } else { "ies" }
-                );
-            }
-            Ok(())
-        }
+    let removed = clear_oauth_store(command.clear_oauth_target())
+        .map_err(|error| CliError::Runtime(error.to_string()))?;
+    if removed.is_empty() {
+        println!("No stored OAuth credentials found.");
+    } else {
+        println!(
+            "Removed {} OAuth store entr{}.",
+            removed.len(),
+            if removed.len() == 1 { "y" } else { "ies" }
+        );
     }
-}
-
-impl CliOptions {
-    fn compression(&self) -> CompressionLevel {
-        self.compression.into()
-    }
-
-    fn transform_mode(&self) -> ProxyTransformMode {
-        if self.just_bash {
-            ProxyTransformMode::JustBash
-        } else if self.cli_mode {
-            ProxyTransformMode::Cli
-        } else {
-            self.transform_mode.into()
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct MultiServerArg {
-    name: String,
-    command: String,
-    args: Vec<String>,
-}
-
-impl FromStr for MultiServerArg {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let mut parts = value.split_whitespace();
-        let spec = parts
-            .next()
-            .ok_or_else(|| "expected name=command".to_string())?;
-        let (name, command) = spec
-            .split_once('=')
-            .filter(|(name, command)| !name.is_empty() && !command.is_empty())
-            .ok_or_else(|| "expected name=command".to_string())?;
-        Ok(Self {
-            name: name.to_string(),
-            command: command.to_string(),
-            args: parts.map(ToString::to_string).collect(),
-        })
-    }
-}
-
-impl From<MultiServerArg> for BackendServerConfig {
-    fn from(value: MultiServerArg) -> Self {
-        BackendServerConfig::new(value.name, value.command, value.args)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum CompressionLevelArg {
-    Low,
-    Medium,
-    High,
-    Max,
-}
-
-impl std::fmt::Display for CompressionLevelArg {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(match self {
-            Self::Low => "low",
-            Self::Medium => "medium",
-            Self::High => "high",
-            Self::Max => "max",
-        })
-    }
-}
-
-impl From<CompressionLevelArg> for CompressionLevel {
-    fn from(value: CompressionLevelArg) -> Self {
-        match value {
-            CompressionLevelArg::Low => CompressionLevel::Low,
-            CompressionLevelArg::Medium => CompressionLevel::Medium,
-            CompressionLevelArg::High => CompressionLevel::High,
-            CompressionLevelArg::Max => CompressionLevel::Max,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum TransformModeArg {
-    CompressedTools,
-    Cli,
-    JustBash,
-}
-
-impl std::fmt::Display for TransformModeArg {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(match self {
-            Self::CompressedTools => "compressed-tools",
-            Self::Cli => "cli",
-            Self::JustBash => "just-bash",
-        })
-    }
-}
-
-impl From<TransformModeArg> for ProxyTransformMode {
-    fn from(value: TransformModeArg) -> Self {
-        match value {
-            TransformModeArg::CompressedTools => ProxyTransformMode::CompressedTools,
-            TransformModeArg::Cli => ProxyTransformMode::Cli,
-            TransformModeArg::JustBash => ProxyTransformMode::JustBash,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum FrontendTransport {
-    Stdio,
-    StreamableHttp,
-}
-
-impl std::fmt::Display for FrontendTransport {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(match self {
-            Self::Stdio => "stdio",
-            Self::StreamableHttp => "streamable-http",
-        })
-    }
+    Ok(())
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- move Clap option/value/subcommand types from the binary entrypoint into `app::options`
- keep `main.rs` focused on runtime construction, mode dispatch, and command execution
- preserve existing CLI behavior and help output through the same Clap derives

## Validation
- `cargo check -p mcp-compressor-core`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary -- --nocapture`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --lib -- --nocapture`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --tests --no-run`