### PR TITLE
fix: handle Ctrl-C in Python CLI wrapper

### DIFF
--- a/python/mcp-compressor-rust/mcp_compressor_rust/cli.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -19,14 +20,27 @@ def _candidate_binaries() -> list[str]:
     return candidates
 
 
+def _run_child(command: list[str]) -> int:
+    child = subprocess.Popen(command)  # noqa: S603 - controlled CLI delegation
+    try:
+        return int(child.wait())
+    except KeyboardInterrupt:
+        child.terminate()
+        try:
+            child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.wait()
+        return 128 + signal.SIGINT
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the Rust core CLI, preserving stdio and process semantics."""
     args = sys.argv[1:] if argv is None else argv
     last_error: OSError | None = None
     for binary in _candidate_binaries():
         try:
-            completed = subprocess.run([binary, *args], check=False)  # noqa: S603 - controlled CLI delegation
-            return int(completed.returncode)
+            return _run_child([binary, *args])
         except FileNotFoundError as exc:
             last_error = exc
             continue

--- a/python/mcp-compressor-rust/tests/test_cli.py
+++ b/python/mcp-compressor-rust/tests/test_cli.py
@@ -1,9 +1,42 @@
 from __future__ import annotations
 
 import os
+import signal
 from pathlib import Path
 
 from mcp_compressor_rust.cli import main
+
+
+class InterruptingProcess:
+    def __init__(self, command: list[str]) -> None:
+        self.command = command
+        self.terminated = False
+        self.killed = False
+        self.wait_calls = 0
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_calls += 1
+        if timeout is None and self.wait_calls == 1:
+            raise KeyboardInterrupt
+        return -signal.SIGTERM
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+class StubbornInterruptingProcess(InterruptingProcess):
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_calls += 1
+        if timeout is None and self.wait_calls == 1:
+            raise KeyboardInterrupt
+        if timeout is not None:
+            import subprocess
+
+            raise subprocess.TimeoutExpired(self.command, timeout)
+        return -signal.SIGKILL
 
 
 def test_python_cli_delegates_to_rust_core_binary(tmp_path: Path, monkeypatch) -> None:
@@ -22,3 +55,33 @@ def test_python_cli_reports_missing_rust_core_binary(monkeypatch) -> None:
     monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")
     assert main(["--help"]) == 127
+
+
+def test_python_cli_ctrl_c_terminates_child_without_traceback(monkeypatch) -> None:
+    process = InterruptingProcess(["mcp-compressor-core"])
+
+    def popen(command: list[str]) -> InterruptingProcess:
+        process.command = command
+        return process
+
+    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", "mcp-compressor-core")
+    monkeypatch.setattr("subprocess.Popen", popen)
+
+    assert main(["--cli-mode"]) == 128 + signal.SIGINT
+    assert process.terminated
+    assert not process.killed
+
+
+def test_python_cli_ctrl_c_kills_stubborn_child(monkeypatch) -> None:
+    process = StubbornInterruptingProcess(["mcp-compressor-core"])
+
+    def popen(command: list[str]) -> StubbornInterruptingProcess:
+        process.command = command
+        return process
+
+    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", "mcp-compressor-core")
+    monkeypatch.setattr("subprocess.Popen", popen)
+
+    assert main(["--cli-mode"]) == 128 + signal.SIGINT
+    assert process.terminated
+    assert process.killed


### PR DESCRIPTION
## Summary
- replace `subprocess.run` in the Python Rust-backed CLI wrapper with explicit child process management
- on Ctrl-C, terminate the Rust child, kill it if it does not exit promptly, and return the conventional SIGINT exit code instead of showing a Python traceback
- add focused tests for normal delegation, graceful terminate, and stubborn-child kill behavior

## Validation
- `cd python/mcp-compressor-rust && uv run pytest -q tests`
- `cd python/mcp-compressor-rust && uv run ruff check mcp_compressor_rust tests`
- `cd python/mcp-compressor-rust && uv run ruff format --check mcp_compressor_rust tests`
- `cd python/mcp-compressor-rust && uv run ty check --project . --python .venv mcp_compressor_rust tests`
- `make check`