### PR TITLE
fix: order generated client required params first

### DIFF
--- a/crates/mcp-compressor-core/src/client_gen/python.rs
+++ b/crates/mcp-compressor-core/src/client_gen/python.rs
@@ -75,16 +75,17 @@ def {name}({params}) -> str:
 }
 
 fn python_params(tool: &crate::compression::engine::Tool) -> String {
-    let required = required_params(tool);
-    let mut parts = Vec::new();
-    for name in tool.param_names() {
-        if required.contains(&name) {
-            parts.push(name);
-        } else {
-            parts.push(format!("{name}=None"));
-        }
-    }
-    parts.join(", ")
+    ordered_param_names(tool)
+        .into_iter()
+        .map(|(name, required)| {
+            if required {
+                name
+            } else {
+                format!("{name}=None")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn python_input_dict(tool: &crate::compression::engine::Tool) -> String {
@@ -95,6 +96,20 @@ fn python_input_dict(tool: &crate::compression::engine::Tool) -> String {
         .collect::<Vec<_>>()
         .join(", ");
     format!("{{{pairs}}}")
+}
+
+fn ordered_param_names(tool: &crate::compression::engine::Tool) -> Vec<(String, bool)> {
+    let required = required_params(tool);
+    let mut params = tool
+        .param_names()
+        .into_iter()
+        .map(|name| {
+            let is_required = required.contains(&name);
+            (name, is_required)
+        })
+        .collect::<Vec<_>>();
+    params.sort_by_key(|(_name, is_required)| !*is_required);
+    params
 }
 
 fn required_params(tool: &crate::compression::engine::Tool) -> Vec<String> {
@@ -113,7 +128,8 @@ fn required_params(tool: &crate::compression::engine::Tool) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::client_gen::generator::test_helpers::{make_config, make_config_multiword_tool};
-    use crate::client_gen::ClientGenerator;
+    use crate::client_gen::{ClientGenerator, GeneratorConfig};
+    use crate::compression::engine::Tool;
     use std::ffi::OsStr;
     use std::fs;
 
@@ -263,6 +279,44 @@ mod tests {
         // "url" is required → no "= None" for url
         // (this test verifies the function signature handles optionality)
         assert!(content.contains("url"), "'url' param not found in generated file");
+    }
+
+    #[test]
+    fn required_params_are_ordered_before_optional_params() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GeneratorConfig {
+            cli_name: "real".to_string(),
+            bridge_url: "http://127.0.0.1:1".to_string(),
+            token: "token".to_string(),
+            tools: vec![Tool::new(
+                "real_tool",
+                Some("Real schema".to_string()),
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "optional_first": {"type": "string"},
+                        "required_second": {"type": "string"},
+                        "optional_third": {"type": "string"}
+                    },
+                    "required": ["required_second"]
+                }),
+            )],
+            session_pid: 1,
+            output_dir: dir.path().to_path_buf(),
+        };
+        let paths = PythonGenerator.generate(&config).unwrap();
+        let content = fs::read_to_string(&paths[0]).unwrap();
+        assert!(content.contains("def real_tool(required_second, optional_first=None, optional_third=None) -> str:"));
+        assert!(content.contains("{\"optional_first\": optional_first, \"required_second\": required_second, \"optional_third\": optional_third}"));
+        std::process::Command::new("python3")
+            .arg("-m")
+            .arg("py_compile")
+            .arg(&paths[0])
+            .status()
+            .expect("python3 should run")
+            .success()
+            .then_some(())
+            .expect("generated Python should compile");
     }
 
     // ------------------------------------------------------------------

--- a/crates/mcp-compressor-core/src/client_gen/typescript.rs
+++ b/crates/mcp-compressor-core/src/client_gen/typescript.rs
@@ -104,11 +104,10 @@ fn snake_to_camel(name: &str) -> String {
 }
 
 fn ts_params(tool: &crate::compression::engine::Tool) -> String {
-    let required = required_params(tool);
-    tool.param_names()
+    ordered_param_names(tool)
         .into_iter()
-        .map(|name| {
-            if required.contains(&name) {
+        .map(|(name, required)| {
+            if required {
                 format!("{name}: string")
             } else {
                 format!("{name}?: string")
@@ -126,6 +125,20 @@ fn ts_input_object(tool: &crate::compression::engine::Tool) -> String {
         .collect::<Vec<_>>()
         .join(", ");
     format!("{{ {pairs} }}")
+}
+
+fn ordered_param_names(tool: &crate::compression::engine::Tool) -> Vec<(String, bool)> {
+    let required = required_params(tool);
+    let mut params = tool
+        .param_names()
+        .into_iter()
+        .map(|name| {
+            let is_required = required.contains(&name);
+            (name, is_required)
+        })
+        .collect::<Vec<_>>();
+    params.sort_by_key(|(_name, is_required)| !*is_required);
+    params
 }
 
 fn required_params(tool: &crate::compression::engine::Tool) -> Vec<String> {
@@ -150,7 +163,8 @@ fn required_params(tool: &crate::compression::engine::Tool) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::client_gen::generator::test_helpers::{make_config, make_config_multiword_tool};
-    use crate::client_gen::ClientGenerator;
+    use crate::client_gen::{ClientGenerator, GeneratorConfig};
+    use crate::compression::engine::Tool;
     use std::ffi::OsStr;
     use std::fs;
 
@@ -319,6 +333,39 @@ mod tests {
             content.contains("Promise<string>"),
             "Promise<string> return type not found"
         );
+    }
+
+    #[test]
+    fn required_params_are_ordered_before_optional_params() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GeneratorConfig {
+            cli_name: "real".to_string(),
+            bridge_url: "http://127.0.0.1:1".to_string(),
+            token: "token".to_string(),
+            tools: vec![Tool::new(
+                "real_tool",
+                Some("Real schema".to_string()),
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "optional_first": {"type": "string"},
+                        "required_second": {"type": "string"},
+                        "optional_third": {"type": "string"}
+                    },
+                    "required": ["required_second"]
+                }),
+            )],
+            session_pid: 1,
+            output_dir: dir.path().to_path_buf(),
+        };
+        let paths = TypeScriptGenerator.generate(&config).unwrap();
+        let ts = find_ts(&paths);
+        let dts = find_dts(&paths);
+        let content = fs::read_to_string(ts).unwrap();
+        let declarations = fs::read_to_string(dts).unwrap();
+        assert!(content.contains("export async function realTool(required_second: string, optional_first?: string, optional_third?: string): Promise<string>"));
+        assert!(content.contains("{ optional_first: optional_first, required_second: required_second, optional_third: optional_third }"));
+        assert!(declarations.contains("export function realTool(required_second: string, optional_first?: string, optional_third?: string): Promise<string>;"));
     }
 
     /// A multi-word snake_case tool name is exported as camelCase.

--- a/tests/test_atlassian_mcp_real_world.py
+++ b/tests/test_atlassian_mcp_real_world.py
@@ -201,10 +201,31 @@ def test_atlassian_code_modes_generate_clients(flag: str, expected: str) -> None
     child, _script_dir, _bridge, _token_value = _start_proxy_mode(flag, "--output-dir", output_dir, script_name=None)
     try:
         assert any(path.suffix == expected for path in Path(output_dir).iterdir())
-        # The generated artifacts are intentionally smoke-tested here for real-world
-        # schema generation and proxy startup. Deeper generated-client invocation is
-        # covered by fixture-backed e2e; Atlassian schemas include optional-before-required
-        # patterns that need a dedicated generator hardening PR.
+        if flag == "--python-mode":
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import sys; sys.path.insert(0, {output_dir!r}); import atlassian; print(atlassian.getAccessibleAtlassianResources())",
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+                timeout=30,
+            )
+        else:
+            result = subprocess.run(
+                [
+                    "bun",
+                    "--eval",
+                    f"import {{ getAccessibleAtlassianResources }} from {json.dumps(str(Path(output_dir) / 'atlassian.ts'))}; console.log(await getAccessibleAtlassianResources());",
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+                timeout=30,
+            )
+        assert result.stdout.strip()
     finally:
         _stop(child)
 


### PR DESCRIPTION
## Summary
- order generated Python and TypeScript function parameters with required arguments before optional arguments
- preserve original schema property order in generated request payloads
- add regression tests for optional-before-required schemas, including Python compile validation
- re-enable real-world Atlassian Python/TypeScript code-mode invocation now that generated Python compiles for Atlassian schemas

## Validation
- `cargo test -p mcp-compressor-core client_gen:: -- --nocapture`
- `cargo check -p mcp-compressor-core`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --tests --no-run`
- `ATLASSIAN_MCP_BASIC_TOKEN=... uv run pytest -q tests/test_atlassian_mcp_real_world.py`
- `make check`