### PR TITLE
test: cover native sessions without compressor subprocess

### DIFF
--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -74,6 +74,38 @@ def test_native_extension_starts_session_and_invokes_backend() -> None:
     )
 
 
+def test_python_agent_can_start_compressed_multi_server_proxy_without_compressor_subprocess(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("PATH", "")
+    session = start_compressed_session_from_mcp_config(
+        CompressedSessionConfig(compression_level="max"),
+        json.dumps(
+            {
+                "mcpServers": {
+                    "alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]},
+                    "beta": {"command": PYTHON, "args": [str(FIXTURES / "beta_server.py")]},
+                }
+            }
+        ),
+    )
+    try:
+        info = session.info()
+        tool_names = {tool["name"] for tool in info["frontend_tools"]}
+        assert {"alpha_get_tool_schema", "alpha_invoke_tool", "beta_get_tool_schema", "beta_invoke_tool"}.issubset(
+            tool_names
+        )
+        assert (
+            invoke_proxy(str(info["bridge_url"]), str(info["token"]), "alpha_invoke_tool", "echo", {"message": "agent"})
+            == "alpha:agent"
+        )
+        assert (
+            invoke_proxy(str(info["bridge_url"]), str(info["token"]), "beta_invoke_tool", "multiply", {"a": 6, "b": 7})
+            == "42"
+        )
+    finally:
+        session.close()
+
+
 def test_native_extension_starts_session_from_mcp_config_and_routes() -> None:
     session = start_compressed_session_from_mcp_config(
         CompressedSessionConfig(compression_level="max"),

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -300,6 +300,57 @@ describe("Rust native core wrapper", () => {
     ).resolves.toBe("alpha:ts");
   });
 
+  it("lets a TypeScript agent start a compressed multi-server proxy without a compressor subprocess", async () => {
+    const previousPath = process.env.PATH;
+    const previousBinary = process.env.MCP_COMPRESSOR_CORE_BINARY;
+    process.env.PATH = "";
+    process.env.MCP_COMPRESSOR_CORE_BINARY = "definitely-missing-mcp-compressor-core";
+    try {
+      const fixtureDir = join(
+        process.cwd(),
+        "..",
+        "crates",
+        "mcp-compressor-core",
+        "tests",
+        "fixtures",
+      );
+      const python = process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python");
+      const session = await startCompressedSessionFromMcpConfig(
+        { compressionLevel: "max" },
+        JSON.stringify({
+          mcpServers: {
+            alpha: { command: python, args: [join(fixtureDir, "alpha_server.py")] },
+            beta: { command: python, args: [join(fixtureDir, "beta_server.py")] },
+          },
+        }),
+      );
+      try {
+        const info = session.info();
+        expect(info.frontend_tools.map((tool) => tool.name)).toContain("alpha_invoke_tool");
+        expect(info.frontend_tools.map((tool) => tool.name)).toContain("beta_invoke_tool");
+        await expect(
+          invokeProxy(info.bridge_url, info.token, "alpha_invoke_tool", "echo", { message: "agent" }),
+        ).resolves.toBe("alpha:agent");
+        await expect(
+          invokeProxy(info.bridge_url, info.token, "beta_invoke_tool", "multiply", { a: 6, b: 7 }),
+        ).resolves.toBe("42");
+      } finally {
+        session.close();
+      }
+    } finally {
+      if (previousPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = previousPath;
+      }
+      if (previousBinary === undefined) {
+        delete process.env.MCP_COMPRESSOR_CORE_BINARY;
+      } else {
+        process.env.MCP_COMPRESSOR_CORE_BINARY = previousBinary;
+      }
+    }
+  });
+
   it("starts a compressed session from MCP config and routes multiple backends", async () => {
     const fixtureDir = join(
       process.cwd(),

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -329,7 +329,9 @@ describe("Rust native core wrapper", () => {
         expect(info.frontend_tools.map((tool) => tool.name)).toContain("alpha_invoke_tool");
         expect(info.frontend_tools.map((tool) => tool.name)).toContain("beta_invoke_tool");
         await expect(
-          invokeProxy(info.bridge_url, info.token, "alpha_invoke_tool", "echo", { message: "agent" }),
+          invokeProxy(info.bridge_url, info.token, "alpha_invoke_tool", "echo", {
+            message: "agent",
+          }),
         ).resolves.toBe("alpha:agent");
         await expect(
           invokeProxy(info.bridge_url, info.token, "beta_invoke_tool", "multiply", { a: 6, b: 7 }),


### PR DESCRIPTION
## Summary
- add Python native e2e coverage for a coding-agent style app starting a multi-server compressed proxy through imports only
- add TypeScript native e2e coverage for the same no-`mcp-compressor`-subprocess workflow
- poison `MCP_COMPRESSOR_CORE_BINARY` and `PATH` in the tests to prove the compressor CLI/binary is not used while backend MCP fixture servers still start normally

## Validation
- `cd python/mcp-compressor-rust && uv run maturin develop && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests/test_core.py && uv run ruff check mcp_compressor_rust tests && uv run ruff format --check mcp_compressor_rust tests && uv run ty check --project . --python .venv mcp_compressor_rust tests`
- `cd typescript && bun run build:native && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts && bun run typecheck && bun run lint`
- `make check`
- `cargo check -p mcp-compressor-core`
- `cargo check -p mcp-compressor-python`
- `cargo check -p mcp-compressor-node`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --tests --no-run`