### PR TITLE
feat: add high-level Python CompressorClient

### DIFF
--- a/python/mcp-compressor-rust/README.md
+++ b/python/mcp-compressor-rust/README.md
@@ -2,4 +2,49 @@
 
 Experimental Rust-backed Python package for `mcp-compressor`.
 
-This package is intentionally separate from the legacy `mcp_compressor` package while the Rust core migration is validated. It exposes thin Python wrappers around the `_mcp_compressor_core` native extension built from the Rust workspace.
+The package name is temporary while the Rust-core migration is validated. The public API should be treated as the future Python SDK shape: users create a `CompressorClient` around one or more MCP server configs and use the resulting proxy/tools. The fact that the implementation is Rust-backed is not part of the user-facing programming model.
+
+## Quick start
+
+```python
+from mcp_compressor_rust import CompressorClient
+
+servers = {
+    "alpha": {
+        "command": "python",
+        "args": ["alpha_server.py"],
+    },
+    "atlassian": {
+        "url": "https://mcp.atlassian.com/v1/mcp",
+        "headers": {
+            "Authorization": f"Basic {token}",
+        },
+    },
+}
+
+with CompressorClient(
+    servers=servers,
+    mode="compressed",
+    compression_level="medium",
+    include_tools=["getConfluencePage", "updateConfluencePage"],
+    toonify=True,
+) as proxy:
+    print([tool.name for tool in proxy.tools])
+    result = proxy.invoke(
+        "getAccessibleAtlassianResources",
+        {},
+        server="atlassian",
+    )
+    print(result)
+```
+
+## Modes
+
+`CompressorClient` accepts these modes:
+
+- `compressed` — expose compressed wrapper tools such as `<server>_get_tool_schema` and `<server>_invoke_tool`.
+- `cli` — expose CLI/help transform metadata through the Rust core session.
+- `bash` — expose Just Bash provider metadata through the Rust core session.
+- `python` / `typescript` — reserved for generated-code workflows.
+
+Low-level helpers such as `compress_tool_listing` and `parse_tool_argv` remain available for tests and advanced integrations, but the primary SDK entry point is `CompressorClient`.

--- a/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
@@ -1,5 +1,6 @@
 """Rust-backed experimental Python API for mcp-compressor."""
 
+from mcp_compressor_rust.client import CompressorClient, CompressorProxy, ProxyResponse, ProxyTool, normalize_servers
 from mcp_compressor_rust.core import (
     BackendConfig,
     CompressedSession,
@@ -19,11 +20,16 @@ __all__ = [
     "BackendConfig",
     "CompressedSession",
     "CompressedSessionConfig",
+    "CompressorClient",
+    "CompressorProxy",
+    "ProxyResponse",
+    "ProxyTool",
     "RustTool",
     "clear_oauth_credentials",
     "compress_tool_listing",
     "format_tool_schema_response",
     "list_oauth_credentials",
+    "normalize_servers",
     "parse_mcp_config",
     "parse_tool_argv",
     "start_compressed_session",

--- a/python/mcp-compressor-rust/mcp_compressor_rust/client.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/client.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+from urllib import request
+
+from mcp_compressor_rust.core import (
+    BackendConfig,
+    CompressedSession,
+    CompressedSessionConfig,
+    start_compressed_session,
+    start_compressed_session_from_mcp_config,
+)
+
+CompressorMode = Literal["compressed", "cli", "bash", "python", "typescript"]
+ServerConfig = dict[str, Any] | str | BackendConfig
+ServersInput = dict[str, ServerConfig] | ServerConfig | str
+
+
+@dataclass(frozen=True)
+class ProxyTool:
+    name: str
+    description: str | None
+    input_schema: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ProxyResponse:
+    text: str
+
+
+def _backend_from_value(name: str, value: ServerConfig) -> BackendConfig:
+    if isinstance(value, BackendConfig):
+        return value
+    if isinstance(value, str):
+        return BackendConfig(name=name, command_or_url=value)
+    if "url" in value:
+        args: list[str] = []
+        headers = value.get("headers")
+        if isinstance(headers, dict):
+            for key, header_value in headers.items():
+                args.extend(["-H", f"{key}={header_value}"])
+            if "--auth" not in value.get("args", []):
+                args.extend(["--auth", "explicit-headers"])
+        args.extend(str(arg) for arg in value.get("args", []))
+        return BackendConfig(name=name, command_or_url=str(value["url"]), args=args)
+    if "command" in value:
+        return BackendConfig(
+            name=name,
+            command_or_url=str(value["command"]),
+            args=[str(arg) for arg in value.get("args", [])],
+        )
+    msg = f"Unsupported server config for {name!r}"
+    raise ValueError(msg)
+
+
+def _resolve_backends(servers: ServersInput) -> tuple[list[BackendConfig] | None, str | None]:
+    if isinstance(servers, str):
+        stripped = servers.strip()
+        if stripped.startswith("{"):
+            return None, servers
+        return [BackendConfig(name="default", command_or_url=servers)], None
+    if isinstance(servers, BackendConfig):
+        return [servers], None
+    return [_backend_from_value(name, value) for name, value in servers.items()], None
+
+
+class CompressorProxy:
+    def __init__(self, session: CompressedSession, default_server: str | None = None) -> None:
+        self._session = session
+        self._default_server = default_server
+
+    @property
+    def bridge_url(self) -> str:
+        return str(self._session.info()["bridge_url"])
+
+    @property
+    def token(self) -> str:
+        return str(self._session.info()["token"])
+
+    @property
+    def tools(self) -> list[ProxyTool]:
+        return [
+            ProxyTool(
+                name=str(tool["name"]),
+                description=tool.get("description"),
+                input_schema=dict(tool["input_schema"]),
+            )
+            for tool in self._session.info()["frontend_tools"]
+        ]
+
+    def invoke_wrapper(self, wrapper_tool: str, tool_input: dict[str, Any]) -> ProxyResponse:
+        body = json.dumps({"tool": wrapper_tool, "input": tool_input}).encode()
+        req = request.Request(  # noqa: S310 - local Rust proxy URL
+            f"{self.bridge_url}/exec",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with request.urlopen(req, timeout=30) as response:  # noqa: S310 - local Rust proxy
+            return ProxyResponse(response.read().decode())
+
+    def schema(self, tool: str, *, server: str | None = None) -> dict[str, Any]:
+        prefix = f"{server or self._default_server}_" if server or self._default_server else ""
+        invoke_name = f"{prefix}invoke_tool"
+        for frontend_tool in self.tools:
+            if frontend_tool.name == invoke_name:
+                return frontend_tool.input_schema
+        msg = f"No compressed invoke wrapper found for {server or self._default_server or 'default'}"
+        raise KeyError(msg)
+
+    def invoke(self, tool: str, tool_input: dict[str, Any] | None = None, *, server: str | None = None) -> str:
+        wrapper = _wrapper_name(server or self._default_server, "invoke_tool")
+        return self.invoke_wrapper(wrapper, {"tool_name": tool, "tool_input": tool_input or {}}).text
+
+
+def _wrapper_name(server: str | None, suffix: str) -> str:
+    return f"{server}_{suffix}" if server else suffix
+
+
+def normalize_servers(servers: ServersInput) -> list[BackendConfig] | None:
+    """Normalize SDK server config into backend configs.
+
+    Returns ``None`` when the input is raw MCP config JSON, which is passed through
+    to the Rust core unchanged.
+    """
+    backends, mcp_config_json = _resolve_backends(servers)
+    if mcp_config_json is not None:
+        return None
+    return backends
+
+
+class CompressorClient:
+    def __init__(
+        self,
+        *,
+        servers: ServersInput,
+        mode: CompressorMode = "compressed",
+        compression_level: str = "medium",
+        server_name: str | None = None,
+        include_tools: list[str] | None = None,
+        exclude_tools: list[str] | None = None,
+        toonify: bool = False,
+    ) -> None:
+        self._servers = servers
+        self._mode = mode
+        self._config = CompressedSessionConfig(
+            compression_level=compression_level,
+            server_name=server_name,
+            include_tools=include_tools,
+            exclude_tools=exclude_tools,
+            toonify=toonify,
+            transform_mode=_transform_mode(mode),
+        )
+        self._session: CompressedSession | None = None
+
+    def connect(self) -> CompressorProxy:
+        if self._session is not None:
+            return CompressorProxy(self._session, self._default_server())
+        backends, mcp_config_json = _resolve_backends(self._servers)
+        if mcp_config_json is not None:
+            self._session = start_compressed_session_from_mcp_config(self._config, mcp_config_json)
+        else:
+            self._session = start_compressed_session(self._config, backends or [])
+        return CompressorProxy(self._session, self._default_server())
+
+    def _default_server(self) -> str | None:
+        backends, mcp_config_json = _resolve_backends(self._servers)
+        if mcp_config_json is not None:
+            return None
+        if backends is not None and len(backends) == 1:
+            return backends[0].name
+        return None
+
+    def close(self) -> None:
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+
+    def __enter__(self) -> CompressorProxy:
+        return self.connect()
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
+
+
+def _transform_mode(mode: CompressorMode) -> str | None:
+    if mode == "compressed":
+        return None
+    if mode == "bash":
+        return "just-bash"
+    if mode == "python" or mode == "typescript":
+        return "cli"
+    return mode

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -8,6 +8,7 @@ from urllib import error, request
 from mcp_compressor_rust import (
     BackendConfig,
     CompressedSessionConfig,
+    CompressorClient,
     RustTool,
     compress_tool_listing,
     format_tool_schema_response,
@@ -72,6 +73,43 @@ def test_native_extension_starts_session_and_invokes_backend() -> None:
         invoke_proxy(str(info["bridge_url"]), str(info["token"]), invoke_tool["name"], "echo", {"message": "py"})
         == "alpha:py"
     )
+
+
+def test_high_level_compressor_client_exposes_compressed_tools_and_invocation(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("PATH", "")
+    with CompressorClient(
+        servers={
+            "alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]},
+            "beta": {"command": PYTHON, "args": [str(FIXTURES / "beta_server.py")]},
+        },
+        mode="compressed",
+        compression_level="max",
+    ) as proxy:
+        tool_names = {tool.name for tool in proxy.tools}
+        assert {"alpha_get_tool_schema", "alpha_invoke_tool", "beta_get_tool_schema", "beta_invoke_tool"}.issubset(
+            tool_names
+        )
+        assert proxy.schema("echo", server="alpha")
+        assert proxy.invoke("echo", {"message": "sdk"}, server="alpha") == "alpha:sdk"
+        assert proxy.invoke("multiply", {"a": 6, "b": 7}, server="beta") == "42"
+
+
+def test_high_level_compressor_client_supports_remote_config_shape() -> None:
+    from mcp_compressor_rust import normalize_servers
+
+    backends = normalize_servers(
+        {
+            "remote": {
+                "url": "https://example.test/mcp",
+                "headers": {"Authorization": "Bearer token"},
+                "args": ["--auth", "explicit-headers"],
+            }
+        }
+    )
+    assert backends is not None
+    assert backends[0].command_or_url == "https://example.test/mcp"
+    assert backends[0].args == ["-H", "Authorization=Bearer token", "--auth", "explicit-headers"]
 
 
 def test_python_agent_can_start_compressed_multi_server_proxy_without_compressor_subprocess(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add a high-level Python `CompressorClient` API so users work with compressor concepts instead of Rust/FFI details
- add `CompressorProxy`, `ProxyTool`, and `ProxyResponse` wrappers over the Rust-backed session/proxy
- support SDK-style server config maps for stdio and remote URL backends with headers
- document the public Python quick-start around `CompressorClient`
- add e2e tests for multi-server compressed tools and invocation without using the compressor CLI subprocess

## Notes
- low-level helpers remain available for advanced/test usage, but the public happy path should be `CompressorClient`
- this is the first step toward a shared language SDK model; TS should follow by moving the top-level `CompressorClient` to the Rust-backed session implementation while preserving alta-compatible semantics

## Validation
- `cd python/mcp-compressor-rust && uv run maturin develop && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests && uv run ruff check mcp_compressor_rust tests && uv run ruff format --check mcp_compressor_rust tests && uv run ty check --project . --python .venv mcp_compressor_rust tests`
- `make check`