### PR TITLE
feat: add high-level TypeScript native client

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -244,6 +244,39 @@ for (const runtime of client.runtimes) {
 }
 ```
 
+## Rust-backed native client
+
+The Rust-core migration exposes a high-level native client for applications that want to start compressed MCP proxy sessions in-process, without spawning the `mcp-compressor` CLI as a stdio subprocess.
+
+```ts
+import { NativeCompressorClient } from "@atlassian/mcp-compressor";
+
+const client = new NativeCompressorClient({
+  servers: {
+    atlassian: {
+      url: "https://mcp.atlassian.com/v1/mcp",
+      headers: {
+        Authorization: `Basic ${token}`,
+      },
+    },
+  },
+  compressionLevel: "medium",
+  includeTools: ["getConfluencePage", "updateConfluencePage"],
+  toonify: true,
+});
+
+const proxy = await client.connect();
+try {
+  console.log(proxy.tools.map((tool) => tool.name));
+  const output = await proxy.invoke("getAccessibleAtlassianResources", {}, { server: "atlassian" });
+  console.log(output);
+} finally {
+  await client.close();
+}
+```
+
+The existing `CompressorClient` remains available for compatibility while this native implementation is validated.
+
 ## Development
 
 ### Setup

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -10,6 +10,7 @@ import { FastMCP } from "fastmcp";
 import { z } from "zod";
 
 export * from "./backend-client.js";
+export * from "./native_client.js";
 export * from "./client.js";
 export * from "./config.js";
 export * from "./errors.js";

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -1,0 +1,212 @@
+import { startCompressedSession, startCompressedSessionFromMcpConfig } from "./rust_core.js";
+import type { BackendConfig as LegacyBackendConfig, JsonConfigServerEntry } from "./types.js";
+import type { CompressedSession, CompressedSessionInfo } from "./rust_core.js";
+
+export type NativeCompressorMode = "compressed" | "cli" | "bash" | "python" | "typescript";
+export type NativeServerConfig = LegacyBackendConfig | JsonConfigServerEntry | string;
+export type NativeServersInput = Record<string, NativeServerConfig> | LegacyBackendConfig | string;
+
+export interface NativeCompressorClientOptions {
+  servers: NativeServersInput;
+  mode?: NativeCompressorMode;
+  compressionLevel?: string;
+  serverName?: string | null;
+  includeTools?: string[];
+  excludeTools?: string[];
+  toonify?: boolean;
+}
+
+export interface ProxyTool {
+  name: string;
+  description?: string | null;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface ProxyResponse {
+  text: string;
+}
+
+export interface NormalizedBackendConfig {
+  name: string;
+  commandOrUrl: string;
+  args?: string[];
+}
+
+export function normalizeServers(servers: NativeServersInput): NormalizedBackendConfig[] | string {
+  if (typeof servers === "string") {
+    const trimmed = servers.trim();
+    if (trimmed.startsWith("{")) {
+      return servers;
+    }
+    return [{ name: "default", commandOrUrl: servers }];
+  }
+  if (isLegacyBackendConfig(servers)) {
+    return [legacyBackendToNative("default", servers)];
+  }
+  return Object.entries(servers).map(([name, config]) => normalizeServer(name, config));
+}
+
+function isLegacyBackendConfig(value: unknown): value is LegacyBackendConfig {
+  return (
+    typeof value === "object" && value !== null && "type" in value && typeof value.type === "string"
+  );
+}
+
+function normalizeServer(name: string, config: NativeServerConfig): NormalizedBackendConfig {
+  if (typeof config === "string") {
+    return { name, commandOrUrl: config };
+  }
+  if ("type" in config && typeof config.type === "string") {
+    return legacyBackendToNative(name, config);
+  }
+  if ("url" in config && config.url !== undefined) {
+    const args: string[] = [];
+    if (config.headers) {
+      for (const [key, value] of Object.entries(config.headers)) {
+        args.push("-H", `${key}=${value}`);
+      }
+      if (!config.args?.includes("--auth")) {
+        args.push("--auth", "explicit-headers");
+      }
+    }
+    args.push(...(config.args ?? []));
+    return { name, commandOrUrl: String(config.url), args };
+  }
+  if ("command" in config && config.command !== undefined) {
+    return { name, commandOrUrl: config.command, args: config.args ?? [] };
+  }
+  throw new Error(`Unsupported server config for ${name}`);
+}
+
+function legacyBackendToNative(
+  name: string,
+  backend: LegacyBackendConfig,
+): NormalizedBackendConfig {
+  if (backend.type === "stdio") {
+    return { name, commandOrUrl: backend.command, args: backend.args ?? [] };
+  }
+  const args: string[] = [];
+  if (backend.headers) {
+    for (const [key, value] of Object.entries(backend.headers)) {
+      args.push("-H", `${key}=${value}`);
+    }
+    args.push("--auth", "explicit-headers");
+  }
+  return { name, commandOrUrl: backend.url, args };
+}
+
+function transformMode(mode: NativeCompressorMode): string | null {
+  if (mode === "compressed") return null;
+  if (mode === "bash") return "just-bash";
+  if (mode === "python" || mode === "typescript") return "cli";
+  return mode;
+}
+
+export class NativeCompressorProxy {
+  constructor(
+    private readonly session: CompressedSession,
+    private readonly defaultServer: string | null,
+  ) {}
+
+  info(): CompressedSessionInfo {
+    return this.session.info();
+  }
+
+  get bridgeUrl(): string {
+    return this.info().bridge_url;
+  }
+
+  get token(): string {
+    return this.info().token;
+  }
+
+  get tools(): ProxyTool[] {
+    return this.info().frontend_tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.input_schema,
+    }));
+  }
+
+  async invokeWrapper(
+    wrapperTool: string,
+    toolInput: Record<string, unknown>,
+  ): Promise<ProxyResponse> {
+    const response = await fetch(`${this.bridgeUrl}/exec`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ tool: wrapperTool, input: toolInput }),
+    });
+    if (!response.ok) {
+      throw new Error(`Proxy invocation failed: ${response.status} ${await response.text()}`);
+    }
+    return { text: await response.text() };
+  }
+
+  schema(_tool: string, options: { server?: string } = {}): Record<string, unknown> {
+    const server = options.server ?? this.defaultServer;
+    const invokeTool = `${server ? `${server}_` : ""}invoke_tool`;
+    const wrapper = this.tools.find((tool) => tool.name === invokeTool);
+    if (!wrapper) {
+      throw new Error(`No compressed invoke wrapper found for ${server ?? "default"}`);
+    }
+    return wrapper.inputSchema;
+  }
+
+  async invoke(
+    tool: string,
+    toolInput: Record<string, unknown> = {},
+    options: { server?: string } = {},
+  ): Promise<string> {
+    const server = options.server ?? this.defaultServer;
+    const wrapper = `${server ? `${server}_` : ""}invoke_tool`;
+    return (await this.invokeWrapper(wrapper, { tool_name: tool, tool_input: toolInput })).text;
+  }
+
+  close(): void {
+    this.session.close();
+  }
+}
+
+export class NativeCompressorClient {
+  private session: CompressedSession | null = null;
+  private readonly mode: NativeCompressorMode;
+
+  constructor(private readonly options: NativeCompressorClientOptions) {
+    this.mode = options.mode ?? "compressed";
+  }
+
+  async connect(): Promise<NativeCompressorProxy> {
+    if (this.session) {
+      return new NativeCompressorProxy(this.session, this.defaultServer());
+    }
+    const normalized = normalizeServers(this.options.servers);
+    const config = {
+      compressionLevel: this.options.compressionLevel ?? "medium",
+      serverName: this.options.serverName ?? null,
+      includeTools: this.options.includeTools ?? [],
+      excludeTools: this.options.excludeTools ?? [],
+      toonify: this.options.toonify ?? false,
+      transformMode: transformMode(this.mode),
+    };
+    this.session =
+      typeof normalized === "string"
+        ? await startCompressedSessionFromMcpConfig(config, normalized)
+        : await startCompressedSession(config, normalized);
+    return new NativeCompressorProxy(this.session, this.defaultServer());
+  }
+
+  async close(): Promise<void> {
+    this.session?.close();
+    this.session = null;
+  }
+
+  private defaultServer(): string | null {
+    const normalized = normalizeServers(this.options.servers);
+    if (typeof normalized === "string") return null;
+    return normalized.length === 1 ? normalized[0]!.name : null;
+  }
+}

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -6,6 +6,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { NativeCompressorClient, normalizeServers } from "../src/native_client.js";
+
 import {
   compressToolListing,
   formatToolSchemaResponse,
@@ -298,6 +300,72 @@ describe("Rust native core wrapper", () => {
     await expect(
       invokeProxy(info.bridge_url, info.token, invokeTool!.name, "echo", { message: "ts" }),
     ).resolves.toBe("alpha:ts");
+  });
+
+  it("provides a high-level native CompressorClient for compressed tools", async () => {
+    const previousPath = process.env.PATH;
+    const previousBinary = process.env.MCP_COMPRESSOR_CORE_BINARY;
+    process.env.PATH = "";
+    process.env.MCP_COMPRESSOR_CORE_BINARY = "definitely-missing-mcp-compressor-core";
+    try {
+      const fixtureDir = join(
+        process.cwd(),
+        "..",
+        "crates",
+        "mcp-compressor-core",
+        "tests",
+        "fixtures",
+      );
+      const python = process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python");
+      const client = new NativeCompressorClient({
+        servers: {
+          alpha: { command: python, args: [join(fixtureDir, "alpha_server.py")] },
+          beta: { command: python, args: [join(fixtureDir, "beta_server.py")] },
+        },
+        compressionLevel: "max",
+      });
+      const proxy = await client.connect();
+      try {
+        expect(proxy.tools.map((tool) => tool.name)).toContain("alpha_invoke_tool");
+        expect(proxy.schema("echo", { server: "alpha" })).toBeDefined();
+        await expect(proxy.invoke("echo", { message: "sdk" }, { server: "alpha" })).resolves.toBe(
+          "alpha:sdk",
+        );
+        await expect(proxy.invoke("multiply", { a: 6, b: 7 }, { server: "beta" })).resolves.toBe(
+          "42",
+        );
+      } finally {
+        await client.close();
+      }
+    } finally {
+      if (previousPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = previousPath;
+      }
+      if (previousBinary === undefined) {
+        delete process.env.MCP_COMPRESSOR_CORE_BINARY;
+      } else {
+        process.env.MCP_COMPRESSOR_CORE_BINARY = previousBinary;
+      }
+    }
+  });
+
+  it("normalizes high-level native server config", () => {
+    const normalized = normalizeServers({
+      remote: {
+        url: "https://example.test/mcp",
+        headers: { Authorization: "Bearer token" },
+        args: ["--auth", "explicit-headers"],
+      },
+    });
+    expect(normalized).toEqual([
+      {
+        name: "remote",
+        commandOrUrl: "https://example.test/mcp",
+        args: ["-H", "Authorization=Bearer token", "--auth", "explicit-headers"],
+      },
+    ]);
   });
 
   it("lets a TypeScript agent start a compressed multi-server proxy without a compressor subprocess", async () => {


### PR DESCRIPTION
## Summary
- add `NativeCompressorClient` and `NativeCompressorProxy` as high-level TypeScript SDK wrappers over the Rust native session APIs
- support SDK-style server config maps for stdio and remote URL backends with headers
- export the native client from the package root while keeping the existing legacy `CompressorClient` available for compatibility
- add e2e coverage proving a TypeScript app can start a multi-server compressed proxy via imports without using the compressor CLI subprocess
- document the Rust-backed native client in the TypeScript README

## Validation
- `cd typescript && bun run format && bun run build:native && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts && bun run check`
- `make check`
- `cargo check -p mcp-compressor-core`
- `cargo check -p mcp-compressor-node`