### PR TITLE
test: cover high-level SDK against Atlassian MCP

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/dto.rs
+++ b/crates/mcp-compressor-core/src/ffi/dto.rs
@@ -95,6 +95,7 @@ pub struct FfiCompressedSessionInfo {
     pub bridge_url: String,
     pub token: String,
     pub frontend_tools: Vec<FfiTool>,
+    pub backend_tools: Vec<FfiTool>,
     pub just_bash_providers: Vec<FfiJustBashProviderSpec>,
 }
 

--- a/crates/mcp-compressor-core/src/ffi/session.rs
+++ b/crates/mcp-compressor-core/src/ffi/session.rs
@@ -94,6 +94,7 @@ async fn compressed_session_from_server(
         .into_iter()
         .map(FfiTool::from)
         .collect();
+    let backend_tools = server.backend_tools().into_iter().map(FfiTool::from).collect();
     let just_bash_providers = server
         .just_bash_provider_specs()
         .into_iter()
@@ -105,6 +106,7 @@ async fn compressed_session_from_server(
             bridge_url: proxy.bridge_url().to_string(),
             token: proxy.token_value().to_string(),
             frontend_tools,
+            backend_tools,
             just_bash_providers,
         },
         _proxy: proxy,

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -205,6 +205,14 @@ impl CompressedServer {
         Ok(tools)
     }
 
+    /// Return backend tool metadata for client generation and language bindings.
+    pub fn backend_tools(&self) -> Vec<Tool> {
+        self.backends
+            .iter()
+            .flat_map(|backend| backend.tools.iter().cloned())
+            .collect()
+    }
+
     /// Return the full backend schema for a tool via the compressed wrapper API.
     pub async fn get_tool_schema(
         &self,

--- a/crates/mcp-compressor-python/src/lib.rs
+++ b/crates/mcp-compressor-python/src/lib.rs
@@ -5,10 +5,11 @@ use serde_json::Value;
 
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
-    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response, list_oauth_credentials,
-    normalize_sdk_servers, parse_mcp_config, parse_tool_argv, start_compressed_session,
-    start_compressed_session_from_mcp_config, FfiBackendConfig, FfiCompressedSession,
-    FfiCompressedSessionConfig, FfiSdkServersConfig, FfiTool,
+    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response,
+    generate_client_artifacts, list_oauth_credentials, normalize_sdk_servers, parse_mcp_config,
+    parse_tool_argv, start_compressed_session, start_compressed_session_from_mcp_config,
+    FfiBackendConfig, FfiClientArtifactKind, FfiCompressedSession, FfiCompressedSessionConfig,
+    FfiGeneratorConfig, FfiSdkServersConfig, FfiTool,
 };
 
 fn py_value_error(error: impl std::fmt::Display) -> PyErr {
@@ -38,6 +39,20 @@ fn parse_tool_argv_json(tool_json: &str, argv_json: &str) -> PyResult<String> {
     let argv = parse_json::<Vec<String>>(argv_json)?;
     let parsed = parse_tool_argv(tool, argv).map_err(py_value_error)?;
     serde_json::to_string(&parsed).map_err(py_value_error)
+}
+
+#[pyfunction]
+fn generate_client_artifacts_json(kind: &str, config_json: &str) -> PyResult<String> {
+    let kind = match kind {
+        "cli" => FfiClientArtifactKind::Cli,
+        "python" => FfiClientArtifactKind::Python,
+        "typescript" => FfiClientArtifactKind::TypeScript,
+        other => return Err(py_value_error(format!("unsupported client artifact kind: {other}"))),
+    };
+    let config = parse_json::<FfiGeneratorConfig>(config_json)?;
+    let paths = generate_client_artifacts(kind, config).map_err(py_value_error)?;
+    serde_json::to_string(&paths.iter().map(|path| path.to_string_lossy().to_string()).collect::<Vec<_>>())
+        .map_err(py_value_error)
 }
 
 #[pyfunction]
@@ -120,6 +135,7 @@ fn _mcp_compressor_core(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(compress_tool_listing_json, module)?)?;
     module.add_function(wrap_pyfunction!(format_tool_schema_response_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_tool_argv_json, module)?)?;
+    module.add_function(wrap_pyfunction!(generate_client_artifacts_json, module)?)?;
     module.add_function(wrap_pyfunction!(normalize_servers_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_mcp_config_json, module)?)?;
     module.add_function(wrap_pyfunction!(start_compressed_session_json, module)?)?;

--- a/python/mcp-compressor-rust/mcp_compressor_rust/client.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/client.py
@@ -105,7 +105,7 @@ class CompressorProxy:
             cli_name=name or self._default_server or "mcp",
             bridge_url=str(info["bridge_url"]),
             token=str(info["token"]),
-            tools=list(info["frontend_tools"]),
+            tools=list(info.get("backend_tools", info["frontend_tools"])),
             output_dir=output_dir,
         )
 

--- a/python/mcp-compressor-rust/mcp_compressor_rust/client.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/client.py
@@ -71,6 +71,7 @@ class CompressorProxy:
     def __init__(self, session: CompressedSession, default_server: str | None = None) -> None:
         self._session = session
         self._default_server = default_server
+        self._closed = False
 
     @property
     def bridge_url(self) -> str:
@@ -91,7 +92,14 @@ class CompressorProxy:
             for tool in self._session.info()["frontend_tools"]
         ]
 
+    def close(self) -> None:
+        self._closed = True
+        self._session.close()
+
     def invoke_wrapper(self, wrapper_tool: str, tool_input: dict[str, Any]) -> ProxyResponse:
+        if self._closed:
+            msg = "Compressor proxy is closed"
+            raise RuntimeError(msg)
         body = json.dumps({"tool": wrapper_tool, "input": tool_input}).encode()
         req = request.Request(  # noqa: S310 - local Rust proxy URL
             f"{self.bridge_url}/exec",

--- a/python/mcp-compressor-rust/mcp_compressor_rust/client.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal
 from urllib import request
 
@@ -9,6 +10,7 @@ from mcp_compressor_rust.core import (
     BackendConfig,
     CompressedSession,
     CompressedSessionConfig,
+    generate_client_artifacts,
     normalize_sdk_servers,
     start_compressed_session,
     start_compressed_session_from_mcp_config,
@@ -95,6 +97,17 @@ class CompressorProxy:
     def close(self) -> None:
         self._closed = True
         self._session.close()
+
+    def write_client(self, kind: str, output_dir: str | Path, *, name: str | None = None) -> list[Path]:
+        info = self._session.info()
+        return generate_client_artifacts(
+            kind,
+            cli_name=name or self._default_server or "mcp",
+            bridge_url=str(info["bridge_url"]),
+            token=str(info["token"]),
+            tools=list(info["frontend_tools"]),
+            output_dir=output_dir,
+        )
 
     def invoke_wrapper(self, wrapper_tool: str, tool_input: dict[str, Any]) -> ProxyResponse:
         if self._closed:

--- a/python/mcp-compressor-rust/mcp_compressor_rust/core.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 _mcp_compressor_core = importlib.import_module("mcp_compressor_rust._mcp_compressor_core")
@@ -134,6 +135,31 @@ def start_compressed_session_from_mcp_config(
         mcp_config_json,
     )
     return CompressedSession(native_session)
+
+
+def generate_client_artifacts(
+    kind: str,
+    *,
+    cli_name: str,
+    bridge_url: str,
+    token: str,
+    tools: list[dict[str, Any]],
+    output_dir: str | Path,
+    session_pid: int = 0,
+) -> list[Path]:
+    config = {
+        "cli_name": cli_name,
+        "bridge_url": bridge_url,
+        "token": token,
+        "tools": tools,
+        "output_dir": str(output_dir),
+        "session_pid": session_pid,
+    }
+    raw = json.loads(_mcp_compressor_core.generate_client_artifacts_json(kind, _json_dumps(config)))
+    if not isinstance(raw, list):
+        msg = "Rust core generate_client_artifacts_json returned non-list JSON"
+        raise TypeError(msg)
+    return [Path(str(path)) for path in raw]
 
 
 def normalize_sdk_servers(servers: dict[str, Any]) -> list[BackendConfig]:

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -106,8 +106,18 @@ def test_high_level_compressor_client_writes_generated_clients(monkeypatch, tmp_
         servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
         compression_level="max",
     ) as proxy:
+        cli_paths = proxy.write_client("cli", tmp_path / "bin", name="alpha")
         python_paths = proxy.write_client("python", tmp_path / "py", name="alpha")
         ts_paths = proxy.write_client("typescript", tmp_path / "ts", name="alpha")
+    cli_script = next(path for path in cli_paths if path.name == "alpha")
+    cli_result = subprocess.run(  # noqa: S603 - trusted generated test CLI
+        [str(cli_script), "echo", "--message", "generated-cli"],
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    assert cli_result.stdout.strip() == "alpha:generated-cli"
     python_module = next(path for path in python_paths if path.name == "alpha.py")
     typescript_module = next(path for path in ts_paths if path.name == "alpha.ts")
     assert any(path.name == "alpha.d.ts" for path in ts_paths)

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -97,6 +97,24 @@ def test_high_level_compressor_client_exposes_compressed_tools_and_invocation(mo
         assert proxy.invoke("multiply", {"a": 6, "b": 7}, server="beta") == "42"
 
 
+def test_high_level_compressor_client_reports_invalid_server_config() -> None:
+    with pytest.raises(ValueError, match="must define command or url"):
+        CompressorClient(servers={"bad": {"args": ["unused"]}}).connect()
+
+
+def test_high_level_compressor_client_reports_missing_wrapper(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("PATH", "")
+    with (
+        CompressorClient(
+            servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
+            compression_level="max",
+        ) as proxy,
+        pytest.raises(KeyError, match="No compressed invoke wrapper"),
+    ):
+        proxy.schema("echo", server="missing")
+
+
 def test_high_level_compressor_client_lifecycle_is_explicit(monkeypatch) -> None:
     monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from urllib import error, request
 
+import pytest
+
 from mcp_compressor_rust import (
     BackendConfig,
     CompressedSessionConfig,
@@ -93,6 +95,21 @@ def test_high_level_compressor_client_exposes_compressed_tools_and_invocation(mo
         assert proxy.schema("echo", server="alpha")
         assert proxy.invoke("echo", {"message": "sdk"}, server="alpha") == "alpha:sdk"
         assert proxy.invoke("multiply", {"a": 6, "b": 7}, server="beta") == "42"
+
+
+def test_high_level_compressor_client_lifecycle_is_explicit(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("PATH", "")
+    client = CompressorClient(
+        servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
+        compression_level="max",
+    )
+    proxy = client.connect()
+    assert proxy.invoke("echo", {"message": "before-close"}) == "alpha:before-close"
+    proxy.close()
+    proxy.close()
+    with pytest.raises(RuntimeError):
+        proxy.invoke("echo", {"message": "after-close"})
 
 
 def test_high_level_compressor_client_defaults_single_server_wrapper(monkeypatch) -> None:

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 from urllib import error, request
 
@@ -99,16 +102,40 @@ def test_high_level_compressor_client_exposes_compressed_tools_and_invocation(mo
 
 def test_high_level_compressor_client_writes_generated_clients(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
-    monkeypatch.setenv("PATH", "")
     with CompressorClient(
         servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
         compression_level="max",
     ) as proxy:
         python_paths = proxy.write_client("python", tmp_path / "py", name="alpha")
         ts_paths = proxy.write_client("typescript", tmp_path / "ts", name="alpha")
-    assert any(path.name == "alpha.py" for path in python_paths)
-    assert any(path.name == "alpha.ts" for path in ts_paths)
+    python_module = next(path for path in python_paths if path.name == "alpha.py")
+    typescript_module = next(path for path in ts_paths if path.name == "alpha.ts")
     assert any(path.name == "alpha.d.ts" for path in ts_paths)
+    py_result = subprocess.run(  # noqa: S603 - trusted generated test module
+        [
+            sys.executable,
+            "-c",
+            f"import sys; sys.path.insert(0, {str(python_module.parent)!r}); import alpha; print(alpha.echo('generated'))",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    assert py_result.stdout.strip() == "alpha:generated"
+    bun = shutil.which("bun") or "bun"
+    ts_result = subprocess.run(  # noqa: S603 - trusted generated test module
+        [
+            bun,
+            "--eval",
+            f"import {{ echo }} from {json.dumps(str(typescript_module))}; console.log(await echo('generated-ts'));",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    assert ts_result.stdout.strip() == "alpha:generated-ts"
 
 
 def test_high_level_compressor_client_reports_invalid_server_config() -> None:

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -97,6 +97,20 @@ def test_high_level_compressor_client_exposes_compressed_tools_and_invocation(mo
         assert proxy.invoke("multiply", {"a": 6, "b": 7}, server="beta") == "42"
 
 
+def test_high_level_compressor_client_writes_generated_clients(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("PATH", "")
+    with CompressorClient(
+        servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
+        compression_level="max",
+    ) as proxy:
+        python_paths = proxy.write_client("python", tmp_path / "py", name="alpha")
+        ts_paths = proxy.write_client("typescript", tmp_path / "ts", name="alpha")
+    assert any(path.name == "alpha.py" for path in python_paths)
+    assert any(path.name == "alpha.ts" for path in ts_paths)
+    assert any(path.name == "alpha.d.ts" for path in ts_paths)
+
+
 def test_high_level_compressor_client_reports_invalid_server_config() -> None:
     with pytest.raises(ValueError, match="must define command or url"):
         CompressorClient(servers={"bad": {"args": ["unused"]}}).connect()

--- a/tests/test_atlassian_mcp_real_world.py
+++ b/tests/test_atlassian_mcp_real_world.py
@@ -332,6 +332,52 @@ def test_atlassian_python_high_level_compressor_client() -> None:
         assert proxy.invoke(SAFE_TOOL, {}, server="atlassian_atlassian")
 
 
+def test_atlassian_python_high_level_generated_clients(tmp_path) -> None:
+    sys.path.insert(0, str(ROOT / "python" / "mcp-compressor-rust"))
+    rust_package = cast("Any", importlib.import_module("mcp_compressor_rust"))
+
+    client = rust_package.CompressorClient(
+        servers={
+            "atlassian": {
+                "url": ATLASSIAN_URL,
+                "headers": {"Authorization": f"Basic {_token()}"},
+            }
+        },
+        compression_level="medium",
+        server_name="atlassian",
+        include_tools=[SAFE_TOOL],
+    )
+    with client as proxy:
+        python_paths = proxy.write_client("python", tmp_path / "py", name="atlassian")
+        ts_paths = proxy.write_client("typescript", tmp_path / "ts", name="atlassian")
+        python_module = next(path for path in python_paths if path.name == "atlassian.py")
+        typescript_module = next(path for path in ts_paths if path.name == "atlassian.ts")
+        py_result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                f"import sys; sys.path.insert(0, {str(python_module.parent)!r}); import atlassian; print(atlassian.getAccessibleAtlassianResources())",
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+            timeout=60,
+        )
+        assert py_result.stdout.strip()
+        ts_result = subprocess.run(
+            [
+                "bun",
+                "--eval",
+                f"import {{ getAccessibleAtlassianResources }} from {json.dumps(str(typescript_module))}; console.log(await getAccessibleAtlassianResources());",
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+            timeout=60,
+        )
+        assert ts_result.stdout.strip()
+
+
 def test_atlassian_python_native_session() -> None:
     sys.path.insert(0, str(ROOT / "python" / "mcp-compressor-rust"))
     rust_package = cast("Any", importlib.import_module("mcp_compressor_rust"))

--- a/tests/test_atlassian_mcp_real_world.py
+++ b/tests/test_atlassian_mcp_real_world.py
@@ -309,6 +309,29 @@ async def test_atlassian_mcp_config_multi_server_and_streamable_http_port() -> N
         _stop(child)
 
 
+def test_atlassian_python_high_level_compressor_client() -> None:
+    sys.path.insert(0, str(ROOT / "python" / "mcp-compressor-rust"))
+    rust_package = cast("Any", importlib.import_module("mcp_compressor_rust"))
+
+    client = rust_package.CompressorClient(
+        servers={
+            "atlassian": {
+                "url": ATLASSIAN_URL,
+                "headers": {"Authorization": f"Basic {_token()}"},
+            }
+        },
+        compression_level="medium",
+        server_name="atlassian",
+        include_tools=[SAFE_TOOL],
+    )
+    with client as proxy:
+        assert {tool.name for tool in proxy.tools} == {
+            "atlassian_atlassian_get_tool_schema",
+            "atlassian_atlassian_invoke_tool",
+        }
+        assert proxy.invoke(SAFE_TOOL, {}, server="atlassian_atlassian")
+
+
 def test_atlassian_python_native_session() -> None:
     sys.path.insert(0, str(ROOT / "python" / "mcp-compressor-rust"))
     rust_package = cast("Any", importlib.import_module("mcp_compressor_rust"))
@@ -334,6 +357,46 @@ def test_atlassian_python_native_session() -> None:
         }
     finally:
         session.close()
+
+
+def test_atlassian_typescript_high_level_compressor_client() -> None:
+    subprocess.run(["bun", "run", "build"], cwd=ROOT / "typescript", check=True)
+    script = textwrap.dedent(
+        f"""
+        import {{ NativeCompressorClient }} from './dist/index.js';
+        const client = new NativeCompressorClient({{
+          servers: {{
+            atlassian: {{
+              url: '{ATLASSIAN_URL}',
+              headers: {{ Authorization: `Basic ${{process.env.{TOKEN_ENV}}}` }},
+            }},
+          }},
+          compressionLevel: 'medium',
+          serverName: 'atlassian',
+          includeTools: ['{SAFE_TOOL}'],
+        }});
+        const proxy = await client.connect();
+        try {{
+          const tools = proxy.tools.map((tool) => tool.name).sort();
+          const output = await proxy.invoke('{SAFE_TOOL}', {{}}, {{ server: 'atlassian_atlassian' }});
+          console.log(JSON.stringify({{ tools, output }}));
+        }} finally {{
+          await client.close();
+        }}
+        """
+    )
+    result = subprocess.run(
+        ["bun", "--eval", script],
+        cwd=ROOT / "typescript",
+        env={**os.environ, TOKEN_ENV: _token()},
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=60,
+    )
+    payload: dict[str, Any] = json.loads(result.stdout)
+    assert payload["tools"] == ["atlassian_atlassian_get_tool_schema", "atlassian_atlassian_invoke_tool"]
+    assert payload["output"]
 
 
 def test_atlassian_typescript_native_session() -> None:

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -81,6 +81,8 @@ function transformMode(mode: NativeCompressorMode): string | null {
 }
 
 export class NativeCompressorProxy {
+  private closed = false;
+
   constructor(
     private readonly session: CompressedSession,
     private readonly defaultServer: string | null,
@@ -110,6 +112,9 @@ export class NativeCompressorProxy {
     wrapperTool: string,
     toolInput: Record<string, unknown>,
   ): Promise<ProxyResponse> {
+    if (this.closed) {
+      throw new Error("Compressor proxy is closed");
+    }
     const response = await fetch(`${this.bridgeUrl}/exec`, {
       method: "POST",
       headers: {
@@ -145,6 +150,7 @@ export class NativeCompressorProxy {
   }
 
   close(): void {
+    this.closed = true;
     this.session.close();
   }
 }

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -167,7 +167,7 @@ export class NativeCompressorProxy {
       cliName: options.name ?? this.defaultServer ?? "mcp",
       bridgeUrl: info.bridge_url,
       token: info.token,
-      tools: info.frontend_tools.map((tool) => ({
+      tools: info.backend_tools.map((tool) => ({
         name: tool.name,
         description: tool.description,
         inputSchema: tool.input_schema,

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -1,4 +1,5 @@
 import {
+  generateClientArtifacts,
   normalizeSdkServers,
   startCompressedSession,
   startCompressedSessionFromMcpConfig,
@@ -29,6 +30,8 @@ export interface ProxyTool {
 export interface ProxyResponse {
   text: string;
 }
+
+export type GeneratedClientKind = "cli" | "python" | "typescript";
 
 export interface NormalizedBackendConfig {
   name: string;
@@ -152,6 +155,26 @@ export class NativeCompressorProxy {
   close(): void {
     this.closed = true;
     this.session.close();
+  }
+
+  writeClient(
+    kind: GeneratedClientKind,
+    outputDir: string,
+    options: { name?: string } = {},
+  ): string[] {
+    const info = this.info();
+    return generateClientArtifacts(kind, {
+      cliName: options.name ?? this.defaultServer ?? "mcp",
+      bridgeUrl: info.bridge_url,
+      token: info.token,
+      tools: info.frontend_tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.input_schema,
+      })),
+      outputDir,
+      sessionPid: 0,
+    });
   }
 }
 

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -100,6 +100,11 @@ export interface CompressedSessionInfo {
     description?: string | null;
     input_schema: Record<string, unknown>;
   }>;
+  backend_tools: Array<{
+    name: string;
+    description?: string | null;
+    input_schema: Record<string, unknown>;
+  }>;
   just_bash_providers: JustBashProviderSpec[];
 }
 

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -368,12 +368,32 @@ describe("Rust native core wrapper", () => {
     });
     const proxy = await client.connect();
     try {
+      const cliPaths = proxy.writeClient("cli", join(outputDir, "bin"), { name: "alpha" });
       const pythonPaths = proxy.writeClient("python", join(outputDir, "py"), { name: "alpha" });
       const tsPaths = proxy.writeClient("typescript", join(outputDir, "ts"), { name: "alpha" });
+      const cliPath = cliPaths.find((path) => path.endsWith("alpha"));
       const pythonPath = pythonPaths.find((path) => path.endsWith("alpha.py"));
       const tsPath = tsPaths.find((path) => path.endsWith("alpha.ts"));
+      expect(cliPath).toBeDefined();
       expect(pythonPath).toBeDefined();
       expect(tsPath).toBeDefined();
+      const cliResult = await new Promise<string>((resolve, reject) => {
+        const child = spawn(cliPath!, ["echo", "--message", "generated-cli"]);
+        let stdout = "";
+        let stderr = "";
+        child.stdout.on("data", (chunk) => {
+          stdout += String(chunk);
+        });
+        child.stderr.on("data", (chunk) => {
+          stderr += String(chunk);
+        });
+        child.on("error", reject);
+        child.on("exit", (code) => {
+          if (code === 0) resolve(stdout.trim());
+          else reject(new Error(stderr));
+        });
+      });
+      expect(cliResult).toBe("alpha:generated-cli");
       expect(tsPaths.some((path) => path.endsWith("alpha.d.ts"))).toBe(true);
       const pyResult = await new Promise<string>((resolve, reject) => {
         const child = spawn(python, [

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -370,9 +370,33 @@ describe("Rust native core wrapper", () => {
     try {
       const pythonPaths = proxy.writeClient("python", join(outputDir, "py"), { name: "alpha" });
       const tsPaths = proxy.writeClient("typescript", join(outputDir, "ts"), { name: "alpha" });
-      expect(pythonPaths.some((path) => path.endsWith("alpha.py"))).toBe(true);
-      expect(tsPaths.some((path) => path.endsWith("alpha.ts"))).toBe(true);
+      const pythonPath = pythonPaths.find((path) => path.endsWith("alpha.py"));
+      const tsPath = tsPaths.find((path) => path.endsWith("alpha.ts"));
+      expect(pythonPath).toBeDefined();
+      expect(tsPath).toBeDefined();
       expect(tsPaths.some((path) => path.endsWith("alpha.d.ts"))).toBe(true);
+      const pyResult = await new Promise<string>((resolve, reject) => {
+        const child = spawn(python, [
+          "-c",
+          `import sys; sys.path.insert(0, ${JSON.stringify(pythonPath!.replace(/\/alpha\.py$/, ""))}); import alpha; print(alpha.echo('generated'))`,
+        ]);
+        let stdout = "";
+        let stderr = "";
+        child.stdout.on("data", (chunk) => {
+          stdout += String(chunk);
+        });
+        child.stderr.on("data", (chunk) => {
+          stderr += String(chunk);
+        });
+        child.on("error", reject);
+        child.on("exit", (code) => {
+          if (code === 0) resolve(stdout.trim());
+          else reject(new Error(stderr));
+        });
+      });
+      expect(pyResult).toBe("alpha:generated");
+      const tsResult = await import(tsPath!);
+      await expect(tsResult.echo("generated-ts")).resolves.toBe("alpha:generated-ts");
     } finally {
       proxy.close();
     }

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -351,6 +351,37 @@ describe("Rust native core wrapper", () => {
     }
   });
 
+  it("reports invalid high-level native server configs", async () => {
+    const client = new NativeCompressorClient({
+      servers: { bad: { args: ["unused"] } as unknown as { command: string } },
+    });
+    await expect(client.connect()).rejects.toThrow(/must define command or url/);
+  });
+
+  it("reports missing high-level native wrappers", async () => {
+    const fixtureDir = join(
+      process.cwd(),
+      "..",
+      "crates",
+      "mcp-compressor-core",
+      "tests",
+      "fixtures",
+    );
+    const python = process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python");
+    const client = new NativeCompressorClient({
+      servers: { alpha: { command: python, args: [join(fixtureDir, "alpha_server.py")] } },
+      compressionLevel: "max",
+    });
+    const proxy = await client.connect();
+    try {
+      expect(() => proxy.schema("echo", { server: "missing" })).toThrow(
+        /No compressed invoke wrapper/,
+      );
+    } finally {
+      proxy.close();
+    }
+  });
+
   it("makes high-level native CompressorClient lifecycle explicit", async () => {
     const fixtureDir = join(
       process.cwd(),

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -351,6 +351,33 @@ describe("Rust native core wrapper", () => {
     }
   });
 
+  it("writes generated clients from the high-level native proxy", async () => {
+    const fixtureDir = join(
+      process.cwd(),
+      "..",
+      "crates",
+      "mcp-compressor-core",
+      "tests",
+      "fixtures",
+    );
+    const python = process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python");
+    const outputDir = mkdtempSync(join(tmpdir(), "mcp-compressor-generated-"));
+    const client = new NativeCompressorClient({
+      servers: { alpha: { command: python, args: [join(fixtureDir, "alpha_server.py")] } },
+      compressionLevel: "max",
+    });
+    const proxy = await client.connect();
+    try {
+      const pythonPaths = proxy.writeClient("python", join(outputDir, "py"), { name: "alpha" });
+      const tsPaths = proxy.writeClient("typescript", join(outputDir, "ts"), { name: "alpha" });
+      expect(pythonPaths.some((path) => path.endsWith("alpha.py"))).toBe(true);
+      expect(tsPaths.some((path) => path.endsWith("alpha.ts"))).toBe(true);
+      expect(tsPaths.some((path) => path.endsWith("alpha.d.ts"))).toBe(true);
+    } finally {
+      proxy.close();
+    }
+  });
+
   it("reports invalid high-level native server configs", async () => {
     const client = new NativeCompressorClient({
       servers: { bad: { args: ["unused"] } as unknown as { command: string } },

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -351,6 +351,29 @@ describe("Rust native core wrapper", () => {
     }
   });
 
+  it("makes high-level native CompressorClient lifecycle explicit", async () => {
+    const fixtureDir = join(
+      process.cwd(),
+      "..",
+      "crates",
+      "mcp-compressor-core",
+      "tests",
+      "fixtures",
+    );
+    const python = process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python");
+    const client = new NativeCompressorClient({
+      servers: { alpha: { command: python, args: [join(fixtureDir, "alpha_server.py")] } },
+      compressionLevel: "max",
+    });
+    const proxy = await client.connect();
+    await expect(proxy.invoke("echo", { message: "before-close" })).resolves.toBe(
+      "alpha:before-close",
+    );
+    proxy.close();
+    proxy.close();
+    await expect(proxy.invoke("echo", { message: "after-close" })).rejects.toThrow();
+  });
+
   it("defaults single-server native CompressorClient invocation to that server", async () => {
     const previousPath = process.env.PATH;
     const previousBinary = process.env.MCP_COMPRESSOR_CORE_BINARY;


### PR DESCRIPTION
## Summary
- add real-world Atlassian MCP coverage for Python high-level `CompressorClient`
- add real-world Atlassian MCP coverage for TypeScript high-level `NativeCompressorClient`
- both tests use explicit Basic auth headers, compressed mode, include filters, and invoke `getAccessibleAtlassianResources` through the high-level SDK proxy
- stacked on top of #101

## Validation
- `ATLASSIAN_MCP_BASIC_TOKEN=... uv run pytest -q tests/test_atlassian_mcp_real_world.py::test_atlassian_python_high_level_compressor_client tests/test_atlassian_mcp_real_world.py::test_atlassian_typescript_high_level_compressor_client -s`
- `uv run ruff check tests/test_atlassian_mcp_real_world.py`
- `uv run ty check tests/test_atlassian_mcp_real_world.py`
- `make check`