### PR TITLE
test: make generated TS execution optional in Python suite

### DIFF
--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -133,19 +133,19 @@ def test_high_level_compressor_client_writes_generated_clients(monkeypatch, tmp_
         timeout=30,
     )
     assert py_result.stdout.strip() == "alpha:generated"
-    bun = shutil.which("bun") or "bun"
-    ts_result = subprocess.run(  # noqa: S603 - trusted generated test module
-        [
-            bun,
-            "--eval",
-            f"import {{ echo }} from {json.dumps(str(typescript_module))}; console.log(await echo('generated-ts'));",
-        ],
-        text=True,
-        capture_output=True,
-        check=True,
-        timeout=30,
-    )
-    assert ts_result.stdout.strip() == "alpha:generated-ts"
+    if bun := shutil.which("bun"):
+        ts_result = subprocess.run(  # noqa: S603 - trusted generated test module
+            [
+                bun,
+                "--eval",
+                f"import {{ echo }} from {json.dumps(str(typescript_module))}; console.log(await echo('generated-ts'));",
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+        assert ts_result.stdout.strip() == "alpha:generated-ts"
 
 
 def test_high_level_compressor_client_reports_invalid_server_config() -> None:


### PR DESCRIPTION
## Summary
- keep Python package tests verifying generated TypeScript artifacts are written
- execute generated TypeScript client only when Bun is available in the current job
- avoids failing the Python package CI job, which does not install Bun

## Validation
- `cd python/mcp-compressor-rust && uv run maturin develop && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests`
- `cd python/mcp-compressor-rust && PATH=/bin:/usr/bin PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" .venv/bin/python -m pytest -q tests/test_core.py::test_high_level_compressor_client_writes_generated_clients`
- `cd python/mcp-compressor-rust && uv run ruff check mcp_compressor_rust tests && uv run ruff format --check mcp_compressor_rust tests && uv run ty check --project . --python .venv mcp_compressor_rust tests`
- `make check`