### PR TITLE
feat: add Rust CompressorClient SDK

### DIFF
--- a/crates/mcp-compressor-core/src/lib.rs
+++ b/crates/mcp-compressor-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod error;
 pub mod ffi;
 pub mod oauth;
 pub mod proxy;
+pub mod sdk;
 pub mod server;
 
 pub use error::Error;

--- a/crates/mcp-compressor-core/src/sdk.rs
+++ b/crates/mcp-compressor-core/src/sdk.rs
@@ -1,0 +1,411 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::client_gen::cli::CliGenerator;
+use crate::client_gen::generator::{ClientGenerator, GeneratorConfig};
+use crate::client_gen::python::PythonGenerator;
+use crate::client_gen::typescript::TypeScriptGenerator;
+use crate::compression::engine::Tool;
+use crate::compression::CompressionLevel;
+use crate::ffi::{normalize_sdk_servers, FfiSdkServerConfig, FfiSdkServersConfig};
+use crate::proxy::{RunningToolProxy, ToolProxyServer};
+use crate::server::{CompressedServer, CompressedServerConfig, ProxyTransformMode};
+use crate::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompressorMode {
+    CompressedTools,
+    Cli,
+    JustBash,
+}
+
+impl From<CompressorMode> for ProxyTransformMode {
+    fn from(value: CompressorMode) -> Self {
+        match value {
+            CompressorMode::CompressedTools => Self::CompressedTools,
+            CompressorMode::Cli => Self::Cli,
+            CompressorMode::JustBash => Self::JustBash,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerConfig {
+    inner: FfiSdkServerConfig,
+}
+
+impl ServerConfig {
+    pub fn command(command: impl Into<String>) -> Self {
+        Self {
+            inner: FfiSdkServerConfig::Structured {
+                command: Some(command.into()),
+                url: None,
+                args: Vec::new(),
+                headers: BTreeMap::new(),
+            },
+        }
+    }
+
+    pub fn url(url: impl Into<String>) -> Self {
+        Self {
+            inner: FfiSdkServerConfig::Structured {
+                command: None,
+                url: Some(url.into()),
+                args: Vec::new(),
+                headers: BTreeMap::new(),
+            },
+        }
+    }
+
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        if let FfiSdkServerConfig::Structured { args, .. } = &mut self.inner {
+            args.push(arg.into());
+        }
+        self
+    }
+
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        if let FfiSdkServerConfig::Structured { args: stored, .. } = &mut self.inner {
+            stored.extend(args.into_iter().map(Into::into));
+        }
+        self
+    }
+
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        if let FfiSdkServerConfig::Structured { headers, .. } = &mut self.inner {
+            headers.insert(name.into(), value.into());
+        }
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompressorClientBuilder {
+    servers: BTreeMap<String, FfiSdkServerConfig>,
+    compression_level: CompressionLevel,
+    server_name: Option<String>,
+    include_tools: Vec<String>,
+    exclude_tools: Vec<String>,
+    toonify: bool,
+    mode: CompressorMode,
+}
+
+impl Default for CompressorClientBuilder {
+    fn default() -> Self {
+        Self {
+            servers: BTreeMap::new(),
+            compression_level: CompressionLevel::Max,
+            server_name: None,
+            include_tools: Vec::new(),
+            exclude_tools: Vec::new(),
+            toonify: false,
+            mode: CompressorMode::CompressedTools,
+        }
+    }
+}
+
+impl CompressorClientBuilder {
+    pub fn server(mut self, name: impl Into<String>, config: ServerConfig) -> Self {
+        self.servers.insert(name.into(), config.inner);
+        self
+    }
+
+    pub fn compression_level(mut self, level: CompressionLevel) -> Self {
+        self.compression_level = level;
+        self
+    }
+
+    pub fn server_name(mut self, server_name: impl Into<String>) -> Self {
+        self.server_name = Some(server_name.into());
+        self
+    }
+
+    pub fn include_tools(mut self, tools: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.include_tools = tools.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn exclude_tools(mut self, tools: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.exclude_tools = tools.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn toonify(mut self, enabled: bool) -> Self {
+        self.toonify = enabled;
+        self
+    }
+
+    pub fn mode(mut self, mode: CompressorMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn build(self) -> CompressorClient {
+        CompressorClient { builder: self }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompressorClient {
+    builder: CompressorClientBuilder,
+}
+
+impl CompressorClient {
+    pub fn builder() -> CompressorClientBuilder {
+        CompressorClientBuilder::default()
+    }
+
+    pub async fn connect(&self) -> Result<CompressorProxy, Error> {
+        let backends = normalize_sdk_servers(FfiSdkServersConfig::from_iter(
+            self.builder.servers.clone(),
+        ))?;
+        let server = CompressedServer::connect_multi_stdio(
+            CompressedServerConfig {
+                level: self.builder.compression_level.clone(),
+                server_name: self.builder.server_name.clone(),
+                include_tools: self.builder.include_tools.clone(),
+                exclude_tools: self.builder.exclude_tools.clone(),
+                toonify: self.builder.toonify,
+                transform_mode: self.builder.mode.into(),
+                ..CompressedServerConfig::default()
+            },
+            backends.into_iter().map(Into::into).collect(),
+        )
+        .await?;
+        CompressorProxy::start(server).await
+    }
+}
+
+pub struct CompressorProxy {
+    default_server: Option<String>,
+    frontend_tools: Vec<Tool>,
+    backend_tools: Vec<Tool>,
+    proxy: RunningToolProxy,
+}
+
+impl CompressorProxy {
+    async fn start(server: CompressedServer) -> Result<Self, Error> {
+        let default_server = server.default_server_name().map(str::to_string);
+        let frontend_tools = server.list_frontend_tools().await?;
+        let backend_tools = server.backend_tools();
+        let proxy = ToolProxyServer::start(server).await?;
+        Ok(Self {
+            default_server,
+            frontend_tools,
+            backend_tools,
+            proxy,
+        })
+    }
+
+    pub fn bridge_url(&self) -> &str {
+        self.proxy.bridge_url()
+    }
+
+    pub fn token(&self) -> &str {
+        self.proxy.token_value()
+    }
+
+    pub fn tools(&self) -> &[Tool] {
+        &self.frontend_tools
+    }
+
+    pub fn backend_tools(&self) -> &[Tool] {
+        &self.backend_tools
+    }
+
+    pub async fn invoke(&self, tool_name: &str, input: Value) -> Result<String, Error> {
+        self.invoke_on(self.default_server.as_deref(), tool_name, input).await
+    }
+
+    pub async fn invoke_on(
+        &self,
+        server: Option<&str>,
+        tool_name: &str,
+        input: Value,
+    ) -> Result<String, Error> {
+        let wrapper = self.invoke_wrapper(server)?;
+        let client = reqwest::Client::new();
+        let response = client
+            .post(self.proxy.exec_url())
+            .header("Authorization", format!("Bearer {}", self.token()))
+            .json(&json!({
+                "tool": wrapper,
+                "input": {
+                    "tool_name": tool_name,
+                    "tool_input": input,
+                }
+            }))
+            .send()
+            .await
+            .map_err(|error| Error::Config(format!("proxy request failed: {error}")))?;
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .map_err(|error| Error::Config(format!("proxy response failed: {error}")))?;
+        if status.is_success() {
+            Ok(text)
+        } else {
+            Err(Error::Config(format!("proxy request failed with {status}: {text}")))
+        }
+    }
+
+    pub fn write_client(
+        &self,
+        kind: GeneratedClientKind,
+        output_dir: impl AsRef<Path>,
+        name: Option<&str>,
+    ) -> Result<Vec<PathBuf>, Error> {
+        let generator_config = GeneratorConfig {
+            cli_name: name
+                .or(self.default_server.as_deref())
+                .unwrap_or("mcp")
+                .to_string(),
+            bridge_url: self.bridge_url().to_string(),
+            token: self.token().to_string(),
+            tools: self.backend_tools.clone(),
+            session_pid: 0,
+            output_dir: output_dir.as_ref().to_path_buf(),
+        };
+        match kind {
+            GeneratedClientKind::Cli => CliGenerator.generate(&generator_config),
+            GeneratedClientKind::Python => PythonGenerator.generate(&generator_config),
+            GeneratedClientKind::TypeScript => TypeScriptGenerator.generate(&generator_config),
+        }
+    }
+
+    fn invoke_wrapper(&self, server: Option<&str>) -> Result<String, Error> {
+        let suffix = "_invoke_tool";
+        let matches = self
+            .frontend_tools
+            .iter()
+            .filter(|tool| tool.name.ends_with(suffix))
+            .filter(|tool| {
+                server
+                    .map(|name| tool.name == format!("{name}{suffix}"))
+                    .unwrap_or(true)
+            })
+            .map(|tool| tool.name.clone())
+            .collect::<Vec<_>>();
+        match matches.as_slice() {
+            [name] => Ok(name.clone()),
+            [] => Err(Error::Config(format!(
+                "No compressed invoke wrapper found for server {}",
+                server.unwrap_or("<default>")
+            ))),
+            _ => Err(Error::Config(
+                "Multiple compressed invoke wrappers found; specify a server".to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeneratedClientKind {
+    Cli,
+    Python,
+    TypeScript,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn fixture_path(name: &str) -> String {
+        format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    fn python_command() -> String {
+        std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+    }
+
+    #[tokio::test]
+    async fn compressor_client_invokes_single_server_without_compressor_subprocess() {
+        let client = CompressorClient::builder()
+            .server(
+                "alpha",
+                ServerConfig::command(python_command()).arg(fixture_path("alpha_server.py")),
+            )
+            .compression_level(CompressionLevel::Max)
+            .build();
+        let proxy = client.connect().await.unwrap();
+        assert!(proxy.tools().iter().any(|tool| tool.name == "alpha_invoke_tool"));
+        let result = proxy.invoke("echo", json!({ "message": "rust-sdk" })).await.unwrap();
+        assert_eq!(result, "alpha:rust-sdk");
+    }
+
+    #[tokio::test]
+    async fn compressor_client_routes_multiple_servers() {
+        let client = CompressorClient::builder()
+            .server(
+                "alpha",
+                ServerConfig::command(python_command()).arg(fixture_path("alpha_server.py")),
+            )
+            .server(
+                "beta",
+                ServerConfig::command(python_command()).arg(fixture_path("beta_server.py")),
+            )
+            .compression_level(CompressionLevel::Max)
+            .build();
+        let proxy = client.connect().await.unwrap();
+        let alpha = proxy
+            .invoke_on(Some("alpha"), "add", json!({ "a": 2, "b": 3 }))
+            .await
+            .unwrap();
+        let beta = proxy
+            .invoke_on(Some("beta"), "multiply", json!({ "a": 4, "b": 5 }))
+            .await
+            .unwrap();
+        assert_eq!(alpha, "5");
+        assert_eq!(beta, "20");
+    }
+
+    #[tokio::test]
+    async fn compressor_client_writes_generated_clients() {
+        let client = CompressorClient::builder()
+            .server(
+                "alpha",
+                ServerConfig::command(python_command()).arg(fixture_path("alpha_server.py")),
+            )
+            .compression_level(CompressionLevel::Max)
+            .build();
+        let proxy = client.connect().await.unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let paths = proxy
+            .write_client(GeneratedClientKind::Python, tempdir.path(), Some("alpha"))
+            .unwrap();
+        assert!(paths.iter().any(|path| path.ends_with("alpha.py")));
+    }
+
+    #[tokio::test]
+    async fn compressor_client_exposes_cli_and_just_bash_modes() {
+        let cli = CompressorClient::builder()
+            .server(
+                "alpha",
+                ServerConfig::command(python_command()).arg(fixture_path("alpha_server.py")),
+            )
+            .mode(CompressorMode::Cli)
+            .build()
+            .connect()
+            .await
+            .unwrap();
+        assert!(cli.tools().iter().any(|tool| tool.name == "alpha_help"));
+
+        let bash = CompressorClient::builder()
+            .server(
+                "alpha",
+                ServerConfig::command(python_command()).arg(fixture_path("alpha_server.py")),
+            )
+            .mode(CompressorMode::JustBash)
+            .build()
+            .connect()
+            .await
+            .unwrap();
+        assert!(bash.tools().iter().any(|tool| tool.name == "bash_tool"));
+        assert!(bash.tools().iter().any(|tool| tool.name == "alpha_help"));
+    }
+}

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -205,6 +205,17 @@ impl CompressedServer {
         Ok(tools)
     }
 
+    /// Return the default backend server name when a single unambiguous default exists.
+    pub fn default_server_name(&self) -> Option<&str> {
+        self.config.server_name.as_deref().or_else(|| {
+            if self.backends.len() == 1 {
+                Some(self.backends[0].public_name.as_str())
+            } else {
+                None
+            }
+        })
+    }
+
     /// Return backend tool metadata for client generation and language bindings.
     pub fn backend_tools(&self) -> Vec<Tool> {
         self.backends


### PR DESCRIPTION
## Summary
- add an ergonomic Rust `CompressorClient` / `CompressorProxy` SDK surface
- support fluent server configuration, compression level, include/exclude filters, toonify, and transform mode
- expose proxy invocation, frontend/backend tool metadata, and generated client artifact writing
- add Rust SDK tests for single-server invocation, multi-server routing, generated clients, and CLI/Just Bash transform surfaces

## Validation
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core sdk:: -- --nocapture`
- `cargo check -p mcp-compressor-core`
- `cargo check -p mcp-compressor-python`
- `cargo check -p mcp-compressor-node`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --tests --no-run`
- `make check`