### PR TITLE
ci: build Rust-backed Python wheel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,61 @@ jobs:
           uv run ruff check mcp_compressor_rust tests
           uv run ty check --project . --python .venv mcp_compressor_rust tests
 
+  python-rust-wheel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build Rust-backed Python wheel
+        working-directory: python/mcp-compressor-rust
+        run: uvx maturin build --release --out dist
+
+      - name: Install wheel into clean venv and smoke test
+        run: |
+          python -m venv /tmp/mcp-compressor-rust-wheel-test
+          /tmp/mcp-compressor-rust-wheel-test/bin/python -m pip install --upgrade pip
+          /tmp/mcp-compressor-rust-wheel-test/bin/python -m pip install "${{ github.workspace }}"/python/mcp-compressor-rust/dist/*.whl
+          cd /tmp
+          /tmp/mcp-compressor-rust-wheel-test/bin/python - <<'PY'
+          from mcp_compressor_rust import ToolSpec, compress_tool_listing
+
+          listing = compress_tool_listing(
+              "high",
+              [
+                  ToolSpec(
+                      name="echo",
+                      description="Echo a message.",
+                      input_schema={
+                          "type": "object",
+                          "properties": {"message": {"type": "string"}},
+                          "required": ["message"],
+                      },
+                  )
+              ],
+          )
+          assert "echo" in listing
+          assert "message" in listing
+          print("Rust-backed Python wheel import smoke test passed")
+          PY
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-compressor-rust-wheel
+          path: python/mcp-compressor-rust/dist/*.whl
+
   check-docs:
     runs-on: ubuntu-latest
     steps:

--- a/python/mcp-compressor-rust/README.md
+++ b/python/mcp-compressor-rust/README.md
@@ -61,6 +61,20 @@ with CompressorClient(servers=servers, compression_level="max") as proxy:
     proxy.write_client("typescript", "./generated-ts", name="atlassian")
 ```
 
+## Packaging smoke test
+
+Build a local wheel and verify it imports from a clean virtualenv:
+
+```bash
+uvx maturin build --release --out dist
+python -m venv /tmp/mcp-compressor-rust-wheel-test
+/tmp/mcp-compressor-rust-wheel-test/bin/python -m pip install "$PWD"/dist/*.whl
+cd /tmp
+/tmp/mcp-compressor-rust-wheel-test/bin/python -c "from mcp_compressor_rust import CompressorClient, ToolSpec"
+```
+
+CI runs the same kind of wheel smoke test before uploading the built wheel as an artifact.
+
 ## Advanced helpers
 
 Low-level helpers such as `compress_tool_listing`, `parse_tool_argv`, and `ToolSpec` remain available for tests and advanced integrations, but the primary SDK entry point is `CompressorClient`.


### PR DESCRIPTION
## Summary
- add a CI job that builds the `mcp-compressor-rust` wheel with maturin
- install the wheel into a clean virtualenv and smoke-test importing/using the native extension
- upload the wheel as a GitHub Actions artifact
- document the local wheel smoke-test flow in the Rust-backed Python README

## Validation
- `cd python/mcp-compressor-rust && uvx maturin build --release --out dist`
- `cd python/mcp-compressor-rust && uv run python -m venv /tmp/tmp_rovodev_mcp_compressor_wheel_test && /tmp/tmp_rovodev_mcp_compressor_wheel_test/bin/python -m pip install dist/*.whl && /tmp/tmp_rovodev_mcp_compressor_wheel_test/bin/python -c "from mcp_compressor_rust import ToolSpec, compress_tool_listing"`
- `make check`