### PR TITLE
ci: smoke test TypeScript native package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,6 +194,44 @@ jobs:
           name: mcp-compressor-rust-wheel
           path: python/mcp-compressor-rust/dist/*.whl
 
+  typescript-native-package:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build TypeScript package and native addon
+        run: |
+          bun run build
+          bun run build:native
+
+      - name: Pack and smoke-test package in clean project
+        run: |
+          PACKAGE_TGZ=$(bun pm pack --filename /tmp/mcp-compressor-ts-package.tgz)
+          mkdir -p /tmp/mcp-compressor-ts-package-test
+          cd /tmp/mcp-compressor-ts-package-test
+          bun init -y >/dev/null
+          bun add --registry https://registry.npmjs.org /tmp/mcp-compressor-ts-package.tgz
+          bun --eval 'import { CompressorClient, compressToolListing } from "@atlassian/mcp-compressor"; if (typeof CompressorClient !== "function") throw new Error("CompressorClient missing"); const listing = compressToolListing("high", [{ name: "echo", description: "Echo", inputSchema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] } }]); if (!listing.includes("echo") || !listing.includes("message")) throw new Error(`bad listing: ${listing}`); console.log("Rust-backed TypeScript package smoke test passed");'
+
+      - name: Upload npm package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-compressor-typescript-package
+          path: /tmp/mcp-compressor-ts-package.tgz
+
   check-docs:
     runs-on: ubuntu-latest
     steps:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -311,6 +311,24 @@ bun run build         # compile to dist/
 bun cli               # run the CLI directly from source
 ```
 
+### Packaging smoke test
+
+Build and test the npm package from a clean temporary project:
+
+```bash
+bun install
+bun run build
+bun run build:native
+bun pm pack --filename /tmp/mcp-compressor-ts-package.tgz
+mkdir -p /tmp/mcp-compressor-ts-package-test
+cd /tmp/mcp-compressor-ts-package-test
+bun init -y
+bun add --registry https://registry.npmjs.org /tmp/mcp-compressor-ts-package.tgz
+bun --eval 'import { CompressorClient, compressToolListing } from "@atlassian/mcp-compressor"; console.log(typeof CompressorClient, compressToolListing("high", [{ name: "echo", inputSchema: { type: "object", properties: {} } }]))'
+```
+
+CI runs the same package smoke test and uploads the packed tarball as an artifact.
+
 ### Toolchain
 
 | Tool | Purpose |

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -46,7 +46,7 @@
     "atlassian-mcp-compressor": "dist/cli.js"
   },
   "scripts": {
-    "build": "bun run tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun run tsc -p tsconfig.build.json",
     "build:core": "cargo build -p mcp-compressor-core",
     "build:native": "napi build --manifest-path ../crates/mcp-compressor-node/Cargo.toml --platform --release --output-dir native",
     "cli": "bun src/cli.ts",


### PR DESCRIPTION
## Summary
- add a CI job that builds the TypeScript package and napi native addon
- pack the npm package and install it into a clean temporary project
- smoke-test importing the Rust-backed root API from the packed package
- upload the packed tarball as a GitHub Actions artifact
- document the local npm pack smoke-test flow
- clean `dist` before TypeScript package builds so stale removed legacy files cannot be packed

## Validation
- `cd typescript && bun install && bun run build && bun run build:native && bun pm pack --filename /tmp/tmp_rovodev_mcp_compressor_ts_package.tgz && mkdir -p /tmp/tmp_rovodev_mcp_compressor_ts_package_test_2 && cd /tmp/tmp_rovodev_mcp_compressor_ts_package_test_2 && bun init -y && bun add --registry https://registry.npmjs.org /tmp/tmp_rovodev_mcp_compressor_ts_package.tgz && bun --eval 'import { CompressorClient, compressToolListing } from "@atlassian/mcp-compressor"; if (typeof CompressorClient !== "function") throw new Error("CompressorClient missing"); const listing = compressToolListing("high", [{ name: "echo", description: "Echo", inputSchema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] } }]); if (!listing.includes("echo") || !listing.includes("message")) throw new Error();'`
- `cd typescript && bun run check && bun run build`
- `make check`