### PR TITLE
ci: smoke test Rust CLI binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,44 @@ jobs:
           uv run ruff check mcp_compressor_rust tests
           uv run ty check --project . --python .venv mcp_compressor_rust tests
 
+  rust-binary-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python environment for fixture server
+        uses: ./.github/actions/setup-python-env
+
+      - name: Build Rust CLI binary
+        run: cargo build -p mcp-compressor-core --release
+
+      - name: Smoke-test Rust CLI binary
+        env:
+          PYTHON: ${{ github.workspace }}/.venv/bin/python
+        run: |
+          BIN=target/release/mcp-compressor-core
+          "$BIN" --help
+          if "$BIN" --compression invalid -- "$PYTHON" crates/mcp-compressor-core/tests/fixtures/alpha_server.py; then
+            echo "Expected invalid compression level to fail" >&2
+            exit 1
+          fi
+          MCP_COMPRESSOR_EXIT_AFTER_READY=1 "$BIN" \
+            --cli-mode \
+            --server-name alpha \
+            --output-dir /tmp/mcp-compressor-rust-bin-smoke \
+            -- "$PYTHON" crates/mcp-compressor-core/tests/fixtures/alpha_server.py
+          test -x /tmp/mcp-compressor-rust-bin-smoke/alpha
+
+      - name: Upload Rust CLI binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-compressor-core-linux-x86_64
+          path: target/release/mcp-compressor-core
+
   python-rust-wheel:
     runs-on: ubuntu-latest
     steps:

--- a/crates/mcp-compressor-core/src/app/runtime.rs
+++ b/crates/mcp-compressor-core/src/app/runtime.rs
@@ -84,7 +84,14 @@ pub async fn run_cli_mode(cli: CliOptions, server: CompressedServer) -> Result<(
     let proxy = ToolProxyServer::start(server)
         .await
         .map_err(|error| error.to_string())?;
-    let (output_dir, on_path) = cli_output_dir().map_err(|error| error.to_string())?;
+    let (output_dir, on_path) = if let Some(output_dir) = cli.output_dir.clone() {
+        let on_path = std::env::var_os("PATH")
+            .map(|paths| std::env::split_paths(&paths).any(|path| path == output_dir))
+            .unwrap_or(false);
+        (output_dir, on_path)
+    } else {
+        cli_output_dir().map_err(|error| error.to_string())?
+    };
     let cli_name = cli.server_name.clone().unwrap_or_else(|| "mcp".to_string());
     let config = GeneratorConfig {
         cli_name: cli_name.clone(),

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -186,6 +186,34 @@ fn rust_cli_mode_installs_generated_script_in_path_candidate_by_default() {
 }
 
 #[test]
+fn rust_cli_mode_honors_explicit_output_dir() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let output_dir = tempdir.path().join("custom-bin");
+    let expected_script = output_dir.join("alpha");
+
+    let mut cmd = core_cmd();
+    cmd.env("MCP_COMPRESSOR_EXIT_AFTER_READY", "1")
+        .args([
+            "--cli-mode",
+            "--server-name",
+            "alpha",
+            "--output-dir",
+            output_dir.to_str().unwrap(),
+            "--",
+            &common::python_command(),
+            common::fixture_path("alpha_server.py").to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Generated CLI: {}",
+            expected_script.display()
+        )));
+
+    assert!(expected_script.exists());
+}
+
+#[test]
 fn rust_cli_mode_manual_flow_generates_script_that_invokes_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let output_dir = tempdir.path().join("generated");

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -237,7 +237,7 @@ Status as of 2026-05-07 on `rust-core-migration-trunk`:
 
 ### Recommended next implementation order
 
-1. Harden packaging/release automation for Rust-backed Python wheels, TypeScript native addon artifacts, and the Rust binary.
+1. Harden packaging/release automation for Rust-backed Python wheels, TypeScript native addon artifacts, and the Rust binary. CI now includes smoke jobs for Python wheels, TypeScript package artifacts, and the Rust CLI binary.
 2. Finish Just Bash integration around Rust provider specs and language-hosted Just Bash execution.
 3. Continue OAuth hardening against real hosted MCP servers.
 4. Add final API/reference docs for the Rust, Python, TypeScript SDKs, generated-client modes, and migration/cutover behavior.
@@ -817,6 +817,18 @@ The Rust `CompressorProxy` exposes the same concepts as the language SDKs: compr
 #### Rust CLI binary
 
 The Rust core crate should also ship a directly usable CLI executable. This binary is not just a development harness; it is a supported entrypoint for users who want the Rust implementation without the Python or TypeScript wrappers.
+
+A local packaging smoke test is:
+
+```bash
+cargo build -p mcp-compressor-core --release
+MCP_COMPRESSOR_EXIT_AFTER_READY=1 target/release/mcp-compressor-core \
+  --cli-mode \
+  --server-name alpha \
+  --output-dir /tmp/mcp-compressor-rust-bin-smoke \
+  -- python3 crates/mcp-compressor-core/tests/fixtures/alpha_server.py
+test -x /tmp/mcp-compressor-rust-bin-smoke/alpha
+```
 
 The Rust CLI should support the same high-level modes as the wrappers:
 


### PR DESCRIPTION
## Summary
- add CI job that builds the Rust CLI binary in release mode
- smoke-test `--help`, invalid compression-level handling, and CLI-mode startup with fixture backend
- upload the release binary as a GitHub Actions artifact
- fix `--output-dir` so CLI mode honors the explicit output directory instead of always selecting a PATH candidate
- add regression test for explicit `--output-dir`
- document a local Rust binary smoke-test flow in the design doc

## Validation
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary rust_cli_mode_honors_explicit_output_dir -- --nocapture`
- `cargo build -p mcp-compressor-core --release`
- `MCP_COMPRESSOR_EXIT_AFTER_READY=1 target/release/mcp-compressor-core --cli-mode --server-name alpha --output-dir /tmp/mcp-compressor-rust-bin-smoke -- "/Users/tesler/Repos/mcp-compressor/.venv/bin/python" crates/mcp-compressor-core/tests/fixtures/alpha_server.py && test -x /tmp/mcp-compressor-rust-bin-smoke/alpha`
- `make check`
- `cargo check -p mcp-compressor-core`