### PR TITLE
feat: expose Just Bash provider metadata in SDKs

### DIFF
--- a/crates/mcp-compressor-core/src/sdk.rs
+++ b/crates/mcp-compressor-core/src/sdk.rs
@@ -182,6 +182,7 @@ pub struct CompressorProxy {
     default_server: Option<String>,
     frontend_tools: Vec<Tool>,
     backend_tools: Vec<Tool>,
+    just_bash_providers: Vec<crate::server::JustBashProviderSpec>,
     proxy: RunningToolProxy,
 }
 
@@ -190,11 +191,13 @@ impl CompressorProxy {
         let default_server = server.default_server_name().map(str::to_string);
         let frontend_tools = server.list_frontend_tools().await?;
         let backend_tools = server.backend_tools();
+        let just_bash_providers = server.just_bash_provider_specs();
         let proxy = ToolProxyServer::start(server).await?;
         Ok(Self {
             default_server,
             frontend_tools,
             backend_tools,
+            just_bash_providers,
             proxy,
         })
     }
@@ -213,6 +216,10 @@ impl CompressorProxy {
 
     pub fn backend_tools(&self) -> &[Tool] {
         &self.backend_tools
+    }
+
+    pub fn just_bash_providers(&self) -> &[crate::server::JustBashProviderSpec] {
+        &self.just_bash_providers
     }
 
     pub async fn invoke(&self, tool_name: &str, input: Value) -> Result<String, Error> {
@@ -407,5 +414,16 @@ mod tests {
             .unwrap();
         assert!(bash.tools().iter().any(|tool| tool.name == "bash_tool"));
         assert!(bash.tools().iter().any(|tool| tool.name == "alpha_help"));
+        let provider = bash
+            .just_bash_providers()
+            .iter()
+            .find(|provider| provider.provider_name == "alpha")
+            .unwrap();
+        assert_eq!(provider.help_tool_name, "alpha_help");
+        assert!(provider.tools.iter().any(|command| {
+            command.command_name == "echo"
+                && command.backend_tool_name == "echo"
+                && command.invoke_tool_name == "alpha_invoke_tool"
+        }));
     }
 }

--- a/python/mcp-compressor-rust/README.md
+++ b/python/mcp-compressor-rust/README.md
@@ -50,6 +50,18 @@ with CompressorClient(
 - `bash` — expose Just Bash provider metadata through the Rust core session.
 Generated Python and TypeScript clients are produced with `proxy.write_client(...)` rather than by selecting a long-lived session mode.
 
+## Just Bash metadata
+
+Just Bash mode exposes the compressed proxy bridge plus typed provider metadata. Language hosts can use this metadata to register backend MCP tools as Just Bash commands without the Rust core executing shell commands itself:
+
+```python
+with CompressorClient(servers=servers, mode="bash") as proxy:
+    for provider in proxy.just_bash_providers:
+        print(provider.provider_name, provider.help_tool_name)
+        for command in provider.tools:
+            print(command.command_name, command.backend_tool_name, command.invoke_tool_name)
+```
+
 ## Generated clients
 
 A connected proxy can write shell, Python, or TypeScript clients that call the live Rust proxy:

--- a/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
@@ -1,6 +1,14 @@
-"""Rust-backed experimental Python API for mcp-compressor."""
+"""Rust-backed Python API for mcp-compressor."""
 
-from mcp_compressor_rust.client import CompressorClient, CompressorProxy, ProxyResponse, ProxyTool, normalize_servers
+from mcp_compressor_rust.client import (
+    CompressorClient,
+    CompressorProxy,
+    JustBashCommand,
+    JustBashProvider,
+    ProxyResponse,
+    ProxyTool,
+    normalize_servers,
+)
 from mcp_compressor_rust.core import (
     BackendConfig,
     CompressedSession,
@@ -22,6 +30,8 @@ __all__ = [
     "CompressedSessionConfig",
     "CompressorClient",
     "CompressorProxy",
+    "JustBashCommand",
+    "JustBashProvider",
     "ProxyResponse",
     "ProxyTool",
     "ToolSpec",

--- a/python/mcp-compressor-rust/mcp_compressor_rust/client.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/client.py
@@ -33,6 +33,22 @@ class ProxyResponse:
     text: str
 
 
+@dataclass(frozen=True)
+class JustBashCommand:
+    command_name: str
+    backend_tool_name: str
+    description: str | None
+    input_schema: dict[str, Any]
+    invoke_tool_name: str
+
+
+@dataclass(frozen=True)
+class JustBashProvider:
+    provider_name: str
+    help_tool_name: str
+    tools: list[JustBashCommand]
+
+
 def _backend_from_value(name: str, value: ServerConfig) -> BackendConfig:
     if isinstance(value, BackendConfig):
         return value
@@ -82,6 +98,27 @@ class CompressorProxy:
     @property
     def token(self) -> str:
         return str(self._session.info()["token"])
+
+    @property
+    def just_bash_providers(self) -> list[JustBashProvider]:
+        providers = self._session.info().get("just_bash_providers", [])
+        return [
+            JustBashProvider(
+                provider_name=str(provider["provider_name"]),
+                help_tool_name=str(provider["help_tool_name"]),
+                tools=[
+                    JustBashCommand(
+                        command_name=str(command["command_name"]),
+                        backend_tool_name=str(command["backend_tool_name"]),
+                        description=command.get("description"),
+                        input_schema=dict(command["input_schema"]),
+                        invoke_tool_name=str(command["invoke_tool_name"]),
+                    )
+                    for command in provider["tools"]
+                ],
+            )
+            for provider in providers
+        ]
 
     @property
     def tools(self) -> list[ProxyTool]:

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -210,6 +210,15 @@ def test_high_level_compressor_client_exposes_cli_and_bash_modes(monkeypatch) ->
         compression_level="max",
     ) as proxy:
         assert {"bash_tool", "alpha_help", "beta_help"}.issubset({tool.name for tool in proxy.tools})
+        providers = {provider.provider_name: provider for provider in proxy.just_bash_providers}
+        assert set(providers) == {"alpha", "beta"}
+        assert providers["alpha"].help_tool_name == "alpha_help"
+        assert any(
+            command.command_name == "echo"
+            and command.backend_tool_name == "echo"
+            and command.invoke_tool_name == "alpha_invoke_tool"
+            for command in providers["alpha"].tools
+        )
 
 
 def test_high_level_compressor_client_supports_remote_config_shape() -> None:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -277,6 +277,22 @@ try {
 
 The package root now exposes the Rust-backed `CompressorClient` as the primary SDK surface on the migration trunk.
 
+Just Bash mode exposes typed provider metadata so language hosts can register backend MCP tools as Just Bash commands while Rust owns compression/proxy routing:
+
+```ts
+const proxy = await new CompressorClient({ servers, mode: "bash" }).connect();
+try {
+  for (const provider of proxy.justBashProviders) {
+    console.log(provider.providerName, provider.helpToolName);
+    for (const command of provider.tools) {
+      console.log(command.commandName, command.backendToolName, command.invokeToolName);
+    }
+  }
+} finally {
+  proxy.close();
+}
+```
+
 Connected proxies can also write shell, Python, or TypeScript clients that call the live Rust proxy:
 
 ```ts

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -3,6 +3,8 @@ export * from "./errors.js";
 export * from "./rust_core.js";
 export {
   type GeneratedClientKind,
+  type JustBashCommand,
+  type JustBashProvider,
   type CompressorClientOptions,
   type NativeCompressorMode as CompressorMode,
   type NativeServersInput as ServersInput,

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -31,6 +31,20 @@ export interface ProxyResponse {
   text: string;
 }
 
+export interface JustBashCommand {
+  commandName: string;
+  backendToolName: string;
+  description?: string | null;
+  inputSchema: Record<string, unknown>;
+  invokeToolName: string;
+}
+
+export interface JustBashProvider {
+  providerName: string;
+  helpToolName: string;
+  tools: JustBashCommand[];
+}
+
 export type GeneratedClientKind = "cli" | "python" | "typescript";
 
 export interface NormalizedBackendConfig {
@@ -108,6 +122,24 @@ export class CompressorProxy {
       name: tool.name,
       description: tool.description,
       inputSchema: tool.input_schema,
+    }));
+  }
+
+  get justBashProviders(): JustBashProvider[] {
+    return this.info().just_bash_providers.map((provider) => ({
+      providerName: provider.provider_name,
+      helpToolName: provider.help_tool_name,
+      tools: provider.tools.map((command) => ({
+        commandName: command.command_name,
+        backendToolName:
+          command.backendToolName ??
+          command.backend_tool_name ??
+          command.tool_name ??
+          command.command_name,
+        description: command.description,
+        inputSchema: command.input_schema,
+        invokeToolName: command.invoke_tool_name,
+      })),
     }));
   }
 

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -80,7 +80,9 @@ export interface CompressedSessionConfig {
 
 export interface JustBashCommandSpec {
   command_name: string;
-  tool_name: string;
+  tool_name?: string;
+  backend_tool_name?: string;
+  backendToolName?: string;
   description?: string | null;
   input_schema: Record<string, unknown>;
   invoke_tool_name: string;

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -545,6 +545,17 @@ describe("Rust native core wrapper", () => {
       expect(bashProxy.tools.map((tool) => tool.name)).toEqual(
         expect.arrayContaining(["bash_tool", "alpha_help", "beta_help"]),
       );
+      const alphaProvider = bashProxy.justBashProviders.find(
+        (provider) => provider.providerName === "alpha",
+      );
+      expect(alphaProvider?.helpToolName).toBe("alpha_help");
+      expect(alphaProvider?.tools).toContainEqual(
+        expect.objectContaining({
+          commandName: "echo",
+          backendToolName: "echo",
+          invokeToolName: "alpha_invoke_tool",
+        }),
+      );
     } finally {
       await bashClient.close();
     }


### PR DESCRIPTION
## Summary
- expose typed Just Bash provider/command metadata on Python, TypeScript, and Rust high-level proxy objects
- export Python `JustBashProvider` / `JustBashCommand` and TypeScript `JustBashProvider` / `JustBashCommand` types
- harden Python, TypeScript, and Rust tests around Just Bash provider metadata shape
- document the current Just Bash contract: Rust owns compression/proxy routing and language hosts consume provider metadata to register commands

## Validation
- `cd typescript && bun run check`
- `cd python/mcp-compressor-rust && uv run maturin develop && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests/test_core.py::test_high_level_compressor_client_exposes_cli_and_bash_modes && uv run ruff check mcp_compressor_rust tests && uv run ty check --project . --python .venv mcp_compressor_rust tests`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core sdk::tests::compressor_client_exposes_cli_and_just_bash_modes -- --nocapture`
- `cargo check -p mcp-compressor-core`
- `make check`