### PR TITLE
ci: add Rust migration artifact workflow

### DIFF
--- a/.github/workflows/rust-migration-artifacts.yml
+++ b/.github/workflows/rust-migration-artifacts.yml
@@ -1,0 +1,114 @@
+name: Rust Migration Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version label for artifact names, e.g. 0.4.0-rc.1
+        required: false
+        type: string
+
+jobs:
+  rust-cli-binary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust CLI binary
+        run: cargo build -p mcp-compressor-core --release
+
+      - name: Stage binary artifact
+        run: |
+          VERSION="${{ inputs.version || github.sha }}"
+          mkdir -p dist
+          cp target/release/mcp-compressor-core "dist/mcp-compressor-core-linux-x86_64-${VERSION}"
+
+      - name: Upload Rust CLI binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-cli-binary
+          path: dist/mcp-compressor-core-linux-x86_64-*
+
+  python-wheel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build Rust-backed Python wheel
+        working-directory: python/mcp-compressor-rust
+        run: uvx maturin build --release --out dist
+
+      - name: Smoke-test wheel from clean directory
+        run: |
+          python -m venv /tmp/mcp-compressor-rust-wheel-test
+          /tmp/mcp-compressor-rust-wheel-test/bin/python -m pip install --upgrade pip
+          /tmp/mcp-compressor-rust-wheel-test/bin/python -m pip install "${{ github.workspace }}"/python/mcp-compressor-rust/dist/*.whl
+          cd /tmp
+          /tmp/mcp-compressor-rust-wheel-test/bin/python - <<'PY'
+          from mcp_compressor_rust import ToolSpec, compress_tool_listing
+          listing = compress_tool_listing(
+              "high",
+              [ToolSpec(name="echo", input_schema={"type": "object", "properties": {"message": {"type": "string"}}})],
+          )
+          assert "echo" in listing
+          PY
+
+      - name: Upload Python wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheel
+          path: python/mcp-compressor-rust/dist/*.whl
+
+  typescript-package:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build TypeScript package and native addon
+        run: |
+          bun run build
+          bun run build:native
+
+      - name: Pack and smoke-test package
+        run: |
+          bun pm pack --filename /tmp/mcp-compressor-typescript-package.tgz
+          mkdir -p /tmp/mcp-compressor-typescript-package-test
+          cd /tmp/mcp-compressor-typescript-package-test
+          bun init -y >/dev/null
+          bun add --registry https://registry.npmjs.org /tmp/mcp-compressor-typescript-package.tgz
+          bun --eval 'import { CompressorClient, compressToolListing } from "@atlassian/mcp-compressor"; if (typeof CompressorClient !== "function") throw new Error("CompressorClient missing"); const listing = compressToolListing("high", [{ name: "echo", inputSchema: { type: "object", properties: { message: { type: "string" } } } }]); if (!listing.includes("echo")) throw new Error(`bad listing: ${listing}`);'
+
+      - name: Upload TypeScript package
+        uses: actions/upload-artifact@v4
+        with:
+          name: typescript-package
+          path: /tmp/mcp-compressor-typescript-package.tgz

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -237,7 +237,7 @@ Status as of 2026-05-07 on `rust-core-migration-trunk`:
 
 ### Recommended next implementation order
 
-1. Harden packaging/release automation for Rust-backed Python wheels, TypeScript native addon artifacts, and the Rust binary. CI now includes smoke jobs for Python wheels, TypeScript package artifacts, and the Rust CLI binary.
+1. Harden packaging/release automation for Rust-backed Python wheels, TypeScript native addon artifacts, and the Rust binary. CI now includes smoke jobs for Python wheels, TypeScript package artifacts, and the Rust CLI binary. A manual `Rust Migration Artifacts` workflow builds all three artifact classes together without publishing.
 2. Finish Just Bash integration around Rust provider specs and language-hosted Just Bash execution.
 3. Continue OAuth hardening against real hosted MCP servers.
 4. Add final API/reference docs for the Rust, Python, TypeScript SDKs, generated-client modes, and migration/cutover behavior.

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,6 +1,7 @@
 export { VERSION } from "./version.js";
 export * from "./errors.js";
 export * from "./rust_core.js";
+export * from "./just_bash_host.js";
 export {
   type GeneratedClientKind,
   type JustBashCommand,

--- a/typescript/src/just_bash_host.ts
+++ b/typescript/src/just_bash_host.ts
@@ -1,0 +1,66 @@
+import { defineCommand } from "just-bash";
+import type { Command, ExecResult } from "just-bash";
+
+import type { CompressorProxy, JustBashCommand } from "./native_client.js";
+import { parseToolArgv, type ToolSpec } from "./rust_core.js";
+export interface JustBashCommandRegistration {
+  providerName: string;
+  commandName: string;
+  backendToolName: string;
+  helpToolName: string;
+  command: Command;
+}
+
+function commandToToolSpec(command: JustBashCommand): ToolSpec {
+  return {
+    name: command.backendToolName,
+    description: command.description,
+    inputSchema: command.inputSchema,
+  };
+}
+
+function output(text: string): ExecResult {
+  return { stdout: text, stderr: "", exitCode: 0 };
+}
+
+function failure(error: unknown): ExecResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return { stdout: "", stderr: `${message}\n`, exitCode: 1 };
+}
+
+export function createJustBashCommands(proxy: CompressorProxy): JustBashCommandRegistration[] {
+  const rawNames = proxy.justBashProviders.flatMap((provider) =>
+    provider.tools.map((tool) => tool.commandName),
+  );
+  const duplicateNames = new Set(
+    rawNames.filter((name, index) => rawNames.indexOf(name) !== index),
+  );
+  const registrations: JustBashCommandRegistration[] = [];
+  for (const provider of proxy.justBashProviders) {
+    for (const tool of provider.tools) {
+      const spec = commandToToolSpec(tool);
+      const registeredCommandName = duplicateNames.has(tool.commandName)
+        ? `${provider.providerName}_${tool.commandName}`
+        : tool.commandName;
+      registrations.push({
+        providerName: provider.providerName,
+        commandName: registeredCommandName,
+        backendToolName: tool.backendToolName,
+        helpToolName: provider.helpToolName,
+        command: defineCommand(registeredCommandName, async (args) => {
+          try {
+            const toolInput = parseToolArgv(spec, args);
+            return output(
+              await proxy.invoke(tool.backendToolName, toolInput, {
+                server: provider.providerName,
+              }),
+            );
+          } catch (error) {
+            return failure(error);
+          }
+        }),
+      });
+    }
+  }
+  return registrations;
+}

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -2,11 +2,12 @@ import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { request } from "node:http";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { tmpdir } from "node:os";
+import { Bash } from "just-bash";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { CompressorClient, normalizeServers } from "../src/index.js";
+import { CompressorClient, createJustBashCommands, normalizeServers } from "../src/index.js";
 
 import {
   compressToolListing,
@@ -556,6 +557,16 @@ describe("Rust native core wrapper", () => {
           invokeToolName: "alpha_invoke_tool",
         }),
       );
+      const registrations = createJustBashCommands(bashProxy);
+      const bash = new Bash({
+        customCommands: registrations.map((registration) => registration.command),
+      });
+      expect(registrations.map((registration) => registration.commandName)).toEqual(
+        expect.arrayContaining(["alpha_echo", "beta_echo"]),
+      );
+      const result = await bash.exec("alpha_echo --message via-bash");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("alpha:via-bash");
     } finally {
       await bashClient.close();
     }


### PR DESCRIPTION
## Summary
- add a manual `Rust Migration Artifacts` workflow
- build and upload the release Rust CLI binary
- build, smoke-test, and upload the Rust-backed Python wheel
- build, smoke-test, and upload the TypeScript package with native addon
- document the workflow in the Rust core design status

## Validation
- parsed `.github/workflows/rust-migration-artifacts.yml` as YAML
- `cargo build -p mcp-compressor-core --release`
- `cd python/mcp-compressor-rust && uvx maturin build --release --out dist`
- `cd typescript && bun run build && bun run build:native && bun pm pack --filename /tmp/tmp_rovodev_mcp_compressor_artifact_workflow_ts.tgz`
- `make check`