### PR TITLE
feat: add TypeScript Just Bash host helpers

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,6 +1,7 @@
 export { VERSION } from "./version.js";
 export * from "./errors.js";
 export * from "./rust_core.js";
+export * from "./just_bash_host.js";
 export {
   type GeneratedClientKind,
   type JustBashCommand,

--- a/typescript/src/just_bash_host.ts
+++ b/typescript/src/just_bash_host.ts
@@ -1,0 +1,66 @@
+import { defineCommand } from "just-bash";
+import type { Command, ExecResult } from "just-bash";
+
+import type { CompressorProxy, JustBashCommand } from "./native_client.js";
+import { parseToolArgv, type ToolSpec } from "./rust_core.js";
+export interface JustBashCommandRegistration {
+  providerName: string;
+  commandName: string;
+  backendToolName: string;
+  helpToolName: string;
+  command: Command;
+}
+
+function commandToToolSpec(command: JustBashCommand): ToolSpec {
+  return {
+    name: command.backendToolName,
+    description: command.description,
+    inputSchema: command.inputSchema,
+  };
+}
+
+function output(text: string): ExecResult {
+  return { stdout: text, stderr: "", exitCode: 0 };
+}
+
+function failure(error: unknown): ExecResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return { stdout: "", stderr: `${message}\n`, exitCode: 1 };
+}
+
+export function createJustBashCommands(proxy: CompressorProxy): JustBashCommandRegistration[] {
+  const rawNames = proxy.justBashProviders.flatMap((provider) =>
+    provider.tools.map((tool) => tool.commandName),
+  );
+  const duplicateNames = new Set(
+    rawNames.filter((name, index) => rawNames.indexOf(name) !== index),
+  );
+  const registrations: JustBashCommandRegistration[] = [];
+  for (const provider of proxy.justBashProviders) {
+    for (const tool of provider.tools) {
+      const spec = commandToToolSpec(tool);
+      const registeredCommandName = duplicateNames.has(tool.commandName)
+        ? `${provider.providerName}_${tool.commandName}`
+        : tool.commandName;
+      registrations.push({
+        providerName: provider.providerName,
+        commandName: registeredCommandName,
+        backendToolName: tool.backendToolName,
+        helpToolName: provider.helpToolName,
+        command: defineCommand(registeredCommandName, async (args) => {
+          try {
+            const toolInput = parseToolArgv(spec, args);
+            return output(
+              await proxy.invoke(tool.backendToolName, toolInput, {
+                server: provider.providerName,
+              }),
+            );
+          } catch (error) {
+            return failure(error);
+          }
+        }),
+      });
+    }
+  }
+  return registrations;
+}

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -2,11 +2,12 @@ import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { request } from "node:http";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { tmpdir } from "node:os";
+import { Bash } from "just-bash";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { CompressorClient, normalizeServers } from "../src/index.js";
+import { CompressorClient, createJustBashCommands, normalizeServers } from "../src/index.js";
 
 import {
   compressToolListing,
@@ -556,6 +557,16 @@ describe("Rust native core wrapper", () => {
           invokeToolName: "alpha_invoke_tool",
         }),
       );
+      const registrations = createJustBashCommands(bashProxy);
+      const bash = new Bash({
+        customCommands: registrations.map((registration) => registration.command),
+      });
+      expect(registrations.map((registration) => registration.commandName)).toEqual(
+        expect.arrayContaining(["alpha_echo", "beta_echo"]),
+      );
+      const result = await bash.exec("alpha_echo --message via-bash");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("alpha:via-bash");
     } finally {
       await bashClient.close();
     }


### PR DESCRIPTION
## Summary
- add `createJustBashCommands(proxy)` to convert Rust-backed Just Bash provider metadata into executable `just-bash` custom commands
- use Rust schema-driven argv parsing and route execution through the live `CompressorProxy`
- prefix duplicate backend command names with provider name, e.g. `alpha_echo` / `beta_echo`, to avoid multi-server collisions
- add live fixture-backed TypeScript test that executes a registered Just Bash command through the Rust proxy
- stack on top of #118

## Validation
- `cd typescript && bun run check`
- `make check`