### PR TITLE
feat: add Python Just Bash host helpers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,9 +260,9 @@ jobs:
           PACKAGE_TGZ=$(bun pm pack --filename /tmp/mcp-compressor-ts-package.tgz)
           mkdir -p /tmp/mcp-compressor-ts-package-test
           cd /tmp/mcp-compressor-ts-package-test
-          bun init -y >/dev/null
-          bun add --registry https://registry.npmjs.org /tmp/mcp-compressor-ts-package.tgz
-          bun --eval 'import { CompressorClient, compressToolListing } from "@atlassian/mcp-compressor"; if (typeof CompressorClient !== "function") throw new Error("CompressorClient missing"); const listing = compressToolListing("high", [{ name: "echo", description: "Echo", inputSchema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] } }]); if (!listing.includes("echo") || !listing.includes("message")) throw new Error(`bad listing: ${listing}`); console.log("Rust-backed TypeScript package smoke test passed");'
+          printf '{"type":"module"}\n' > package.json
+          npm install --registry https://registry.npmjs.org /tmp/mcp-compressor-ts-package.tgz
+          node --input-type=module -e 'import { CompressorClient, compressToolListing } from "@atlassian/mcp-compressor"; if (typeof CompressorClient !== "function") throw new Error("CompressorClient missing"); const listing = compressToolListing("high", [{ name: "echo", description: "Echo", inputSchema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] } }]); if (!listing.includes("echo") || !listing.includes("message")) throw new Error(`bad listing: ${listing}`); console.log("Rust-backed TypeScript package smoke test passed");'
 
       - name: Upload npm package artifact
         uses: actions/upload-artifact@v4

--- a/python/mcp-compressor-rust/README.md
+++ b/python/mcp-compressor-rust/README.md
@@ -60,7 +60,13 @@ with CompressorClient(servers=servers, mode="bash") as proxy:
         print(provider.provider_name, provider.help_tool_name)
         for command in provider.tools:
             print(command.command_name, command.backend_tool_name, command.invoke_tool_name)
+
+    # Python hosts can also create callable command objects from the metadata.
+    commands = {cmd.command_name: cmd for cmd in create_just_bash_commands(proxy)}
+    print(commands["atlassian_get-accessible-atlassian-resources"]([]))
 ```
+
+Duplicate backend command names are prefixed with the provider name, for example `alpha_echo` and `beta_echo`.
 
 ## Generated clients
 

--- a/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/__init__.py
@@ -23,6 +23,7 @@ from mcp_compressor_rust.core import (
     start_compressed_session,
     start_compressed_session_from_mcp_config,
 )
+from mcp_compressor_rust.just_bash_host import JustBashCallableCommand, create_just_bash_commands
 
 __all__ = [
     "BackendConfig",
@@ -30,6 +31,7 @@ __all__ = [
     "CompressedSessionConfig",
     "CompressorClient",
     "CompressorProxy",
+    "JustBashCallableCommand",
     "JustBashCommand",
     "JustBashProvider",
     "ProxyResponse",
@@ -37,6 +39,7 @@ __all__ = [
     "ToolSpec",
     "clear_oauth_credentials",
     "compress_tool_listing",
+    "create_just_bash_commands",
     "format_tool_schema_response",
     "list_oauth_credentials",
     "normalize_servers",

--- a/python/mcp-compressor-rust/mcp_compressor_rust/just_bash_host.py
+++ b/python/mcp-compressor-rust/mcp_compressor_rust/just_bash_host.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcp_compressor_rust.client import CompressorProxy, JustBashCommand
+from mcp_compressor_rust.core import ToolSpec, parse_tool_argv
+
+
+@dataclass(frozen=True)
+class JustBashCallableCommand:
+    """Python-hosted callable equivalent of a Just Bash custom command."""
+
+    provider_name: str
+    command_name: str
+    backend_tool_name: str
+    help_tool_name: str
+    command: JustBashCommand
+    proxy: CompressorProxy
+
+    def parse(self, args: list[str]) -> dict[str, Any]:
+        return parse_tool_argv(
+            ToolSpec(
+                name=self.backend_tool_name,
+                description=self.command.description,
+                input_schema=self.command.input_schema,
+            ),
+            args,
+        )
+
+    def __call__(self, args: list[str] | None = None) -> str:
+        return self.proxy.invoke(
+            self.backend_tool_name,
+            self.parse(args or []),
+            server=self.provider_name,
+        )
+
+
+def create_just_bash_commands(proxy: CompressorProxy) -> list[JustBashCallableCommand]:
+    """Create Python-hosted Just Bash command callables from a compressor proxy.
+
+    This mirrors the TypeScript `createJustBashCommands` helper: Rust owns the
+    compressed proxy and provider metadata, while the language host decides how
+    to register and execute commands.
+    """
+    raw_names = [command.command_name for provider in proxy.just_bash_providers for command in provider.tools]
+    duplicate_names = {name for name in raw_names if raw_names.count(name) > 1}
+    commands: list[JustBashCallableCommand] = []
+    for provider in proxy.just_bash_providers:
+        for command in provider.tools:
+            command_name = (
+                f"{provider.provider_name}_{command.command_name}"
+                if command.command_name in duplicate_names
+                else command.command_name
+            )
+            commands.append(
+                JustBashCallableCommand(
+                    provider_name=provider.provider_name,
+                    command_name=command_name,
+                    backend_tool_name=command.backend_tool_name,
+                    help_tool_name=provider.help_tool_name,
+                    command=command,
+                    proxy=proxy,
+                )
+            )
+    return commands

--- a/python/mcp-compressor-rust/tests/test_core.py
+++ b/python/mcp-compressor-rust/tests/test_core.py
@@ -16,6 +16,7 @@ from mcp_compressor_rust import (
     CompressorClient,
     ToolSpec,
     compress_tool_listing,
+    create_just_bash_commands,
     format_tool_schema_response,
     parse_mcp_config,
     parse_tool_argv,
@@ -219,6 +220,9 @@ def test_high_level_compressor_client_exposes_cli_and_bash_modes(monkeypatch) ->
             and command.invoke_tool_name == "alpha_invoke_tool"
             for command in providers["alpha"].tools
         )
+        commands = {command.command_name: command for command in create_just_bash_commands(proxy)}
+        assert {"alpha_echo", "beta_echo"}.issubset(commands)
+        assert commands["alpha_echo"](["--message", "via-python-bash"]) == "alpha:via-python-bash"
 
 
 def test_high_level_compressor_client_supports_remote_config_shape() -> None:

--- a/typescript/bun.lock
+++ b/typescript/bun.lock
@@ -6,12 +6,12 @@
       "name": "mcp-compressor",
       "dependencies": {
         "commander": "^14.0.3",
+        "just-bash": "^2.14.0",
         "zod": "^4.1.13",
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.3.4",
         "@types/node": "^24.10.1",
-        "just-bash": "^2.14.0",
         "oxfmt": "^0.44.0",
         "oxlint": "^1.59.0",
         "typescript": "^5.9.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -65,12 +65,12 @@
   },
   "dependencies": {
     "commander": "^14.0.3",
+    "just-bash": "^2.14.0",
     "zod": "^4.1.13"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.3.4",
     "@types/node": "^24.10.1",
-    "just-bash": "^2.14.0",
     "oxfmt": "^0.44.0",
     "oxlint": "^1.59.0",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary
- add Python `create_just_bash_commands(proxy)` helper that converts Rust-backed Just Bash provider metadata into callable command objects
- use Rust schema-driven argv parsing and route execution through the live `CompressorProxy`
- prefix duplicate backend command names with provider name, e.g. `alpha_echo` / `beta_echo`, matching the TypeScript helper behavior
- add fixture-backed Python SDK test that executes a generated command through the Rust proxy
- document the helper in the Python README

## Validation
- `cd python/mcp-compressor-rust && uv run maturin develop && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests`
- `cd python/mcp-compressor-rust && uv run ruff check mcp_compressor_rust tests && uv run ruff format --check mcp_compressor_rust tests && uv run ty check --project . --python .venv mcp_compressor_rust tests`
- `make check`