### PR TITLE
fix: package just-bash as runtime dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,9 +260,9 @@ jobs:
           PACKAGE_TGZ=$(bun pm pack --filename /tmp/mcp-compressor-ts-package.tgz)
           mkdir -p /tmp/mcp-compressor-ts-package-test
           cd /tmp/mcp-compressor-ts-package-test
-          bun init -y >/dev/null
-          bun add --registry https://registry.npmjs.org /tmp/mcp-compressor-ts-package.tgz
-          bun --eval 'import { CompressorClient, compressToolListing } from "@atlassian/mcp-compressor"; if (typeof CompressorClient !== "function") throw new Error("CompressorClient missing"); const listing = compressToolListing("high", [{ name: "echo", description: "Echo", inputSchema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] } }]); if (!listing.includes("echo") || !listing.includes("message")) throw new Error(`bad listing: ${listing}`); console.log("Rust-backed TypeScript package smoke test passed");'
+          printf '{"type":"module"}\n' > package.json
+          npm install --registry https://registry.npmjs.org /tmp/mcp-compressor-ts-package.tgz
+          node --input-type=module -e 'import { CompressorClient, compressToolListing } from "@atlassian/mcp-compressor"; if (typeof CompressorClient !== "function") throw new Error("CompressorClient missing"); const listing = compressToolListing("high", [{ name: "echo", description: "Echo", inputSchema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] } }]); if (!listing.includes("echo") || !listing.includes("message")) throw new Error(`bad listing: ${listing}`); console.log("Rust-backed TypeScript package smoke test passed");'
 
       - name: Upload npm package artifact
         uses: actions/upload-artifact@v4

--- a/typescript/bun.lock
+++ b/typescript/bun.lock
@@ -6,12 +6,12 @@
       "name": "mcp-compressor",
       "dependencies": {
         "commander": "^14.0.3",
+        "just-bash": "^2.14.0",
         "zod": "^4.1.13",
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.3.4",
         "@types/node": "^24.10.1",
-        "just-bash": "^2.14.0",
         "oxfmt": "^0.44.0",
         "oxlint": "^1.59.0",
         "typescript": "^5.9.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -65,12 +65,12 @@
   },
   "dependencies": {
     "commander": "^14.0.3",
+    "just-bash": "^2.14.0",
     "zod": "^4.1.13"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.3.4",
     "@types/node": "^24.10.1",
-    "just-bash": "^2.14.0",
     "oxfmt": "^0.44.0",
     "oxlint": "^1.59.0",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary
- move `just-bash` from devDependencies to dependencies because the root package exports `createJustBashCommands`
- switch the TypeScript package smoke test from `bun add` to `npm install --registry https://registry.npmjs.org` in a clean package to avoid registry leakage and better match consumer installs

## Validation
- `cd typescript && bun install && bun run check && bun run build && bun run build:native`
- packed package installed into a clean temp project with `npm install --registry https://registry.npmjs.org /tmp/tmp_rovodev_mcp_compressor_ts_pkg_fix.tgz`
- smoke imported `CompressorClient`, `createJustBashCommands`, and `compressToolListing` from the packed package
- `make check`