### PR TITLE
docs: build out public user documentation

### DIFF
--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -1,0 +1,107 @@
+# Configuration
+
+You can configure backends directly or with MCP config JSON.
+
+## Direct server config
+
+=== "CLI"
+
+    ```bash
+    mcp-compressor --server-name alpha -- python alpha_server.py
+    ```
+
+=== "Python"
+
+    ```python
+    servers = {
+        "alpha": {"command": "python", "args": ["alpha_server.py"]},
+        "atlassian": {
+            "url": "https://mcp.atlassian.com/v1/mcp",
+            "headers": {"Authorization": f"Basic {token}"},
+        },
+    }
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    const servers = {
+      alpha: { command: "python", args: ["alpha_server.py"] },
+      atlassian: {
+        url: "https://mcp.atlassian.com/v1/mcp",
+        headers: { Authorization: `Basic ${token}` },
+      },
+    };
+    ```
+
+=== "Rust"
+
+    ```rust
+    let client = CompressorClient::builder()
+        .server("alpha", ServerConfig::command("python").arg("alpha_server.py"))
+        .server(
+            "atlassian",
+            ServerConfig::url("https://mcp.atlassian.com/v1/mcp")
+                .header("Authorization", format!("Basic {token}")),
+        )
+        .build();
+    ```
+
+## MCP config JSON
+
+MCP config JSON is the easiest way to describe multiple backends.
+
+```json
+{
+  "mcpServers": {
+    "alpha": {
+      "command": "python",
+      "args": ["alpha_server.py"]
+    },
+    "remote": {
+      "url": "https://mcp.example.com/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer ${TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Environment variables inside header values can be interpolated by the Rust backend argument/header parser.
+
+## Filters
+
+Use include/exclude filters to reduce the backend tool set before compression.
+
+=== "CLI"
+
+    ```bash
+    mcp-compressor -c medium --include-tools getPage,updatePage -- python server.py
+    ```
+
+=== "Python"
+
+    ```python
+    CompressorClient(
+        servers=servers,
+        include_tools=["getPage", "updatePage"],
+    )
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    new CompressorClient({
+      servers,
+      includeTools: ["getPage", "updatePage"],
+    });
+    ```
+
+=== "Rust"
+
+    ```rust
+    CompressorClient::builder()
+        .include_tools(["getPage", "updatePage"])
+        .build();
+    ```

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -1,0 +1,61 @@
+# How it works
+
+`mcp-compressor` sits between an MCP client and one or more backend MCP servers.
+
+```mermaid
+flowchart LR
+  Client[MCP client or SDK user]
+  Compressor[mcp-compressor]
+  BackendA[Backend MCP server A]
+  BackendB[Backend MCP server B]
+
+  Client --> Compressor
+  Compressor --> BackendA
+  Compressor --> BackendB
+```
+
+The compressor connects to backend servers, reads their tool metadata, and exposes a smaller frontend tool surface.
+
+## Normal compressed tools
+
+Instead of exposing every backend tool directly, the frontend exposes wrappers such as:
+
+- `<server>_get_tool_schema`
+- `<server>_invoke_tool`
+- `<server>_list_tools` at `max` compression
+
+For a single server named `atlassian`, the client might see:
+
+```text
+atlassian_get_tool_schema
+atlassian_invoke_tool
+atlassian_list_tools
+```
+
+A model can first inspect the compact listing, then call `get_tool_schema` only for the tool it wants, then call `invoke_tool`.
+
+## Compression levels
+
+| Level | Tool listing behavior | Typical use |
+|---|---|---|
+| `low` | More descriptive compressed listings | Smaller servers or exploratory use |
+| `medium` | Balanced descriptions and parameter names | Default choice |
+| `high` | Very compact listings focused on names/args | Large toolsets |
+| `max` | Minimal frontend surface plus `list_tools` | Very large/multi-server setups |
+
+## Transports
+
+Backends can be:
+
+- local stdio MCP server commands,
+- remote streamable HTTP MCP URLs.
+
+Frontends can be:
+
+- stdio MCP server mode,
+- streamable HTTP MCP server mode,
+- local proxy server for generated clients and SDK use.
+
+## Native SDKs
+
+Rust, Python, and TypeScript SDKs can start a compressed proxy in-process without spawning the `mcp-compressor` stdio CLI. The SDKs still start the backend MCP servers or connect to remote backend URLs as configured.

--- a/docs/development/rust-migration.md
+++ b/docs/development/rust-migration.md
@@ -1,0 +1,51 @@
+# Rust migration notes
+
+The migration branch moves shared behavior into Rust while keeping Python and TypeScript wrappers idiomatic.
+
+## Current architecture
+
+```mermaid
+flowchart LR
+  RustCore[Rust core]
+  RustCli[Rust CLI]
+  Py[Python PyO3 package]
+  Ts[TypeScript napi package]
+  Backends[MCP backends]
+
+  RustCli --> RustCore
+  Py --> RustCore
+  Ts --> RustCore
+  RustCore --> Backends
+```
+
+## Development commands
+
+```bash
+make check
+cargo check -p mcp-compressor-core
+PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --lib -- --nocapture
+```
+
+Python package:
+
+```bash
+cd python/mcp-compressor-rust
+uv run maturin develop
+uv run pytest -q tests
+```
+
+TypeScript package:
+
+```bash
+cd typescript
+bun install
+bun run build:native
+bun run check
+```
+
+## Artifact smoke tests
+
+- Rust binary smoke is in CI.
+- Python wheel smoke is in CI.
+- TypeScript package/native-addon smoke is in CI.
+- A manual `Rust Migration Artifacts` workflow builds all three artifact classes together.

--- a/docs/examples/atlassian.md
+++ b/docs/examples/atlassian.md
@@ -1,0 +1,83 @@
+# Atlassian MCP example
+
+This example uses the Atlassian remote MCP server:
+
+```text
+https://mcp.atlassian.com/v1/mcp
+```
+
+The examples below assume you have a token available as:
+
+```bash
+export ATLASSIAN_MCP_BASIC_TOKEN="..."
+```
+
+## CLI compression
+
+```bash
+mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+```
+
+## Tool filters
+
+```bash
+mcp-compressor -c medium \
+  --server-name atlassian \
+  --include-tools getAccessibleAtlassianResources,getConfluencePage \
+  -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+```
+
+## Python SDK
+
+```python
+from mcp_compressor_rust import CompressorClient
+
+with CompressorClient(
+    servers={
+        "atlassian": {
+            "url": "https://mcp.atlassian.com/v1/mcp",
+            "headers": {"Authorization": f"Basic {token}"},
+        }
+    },
+    compression_level="medium",
+    server_name="atlassian",
+    include_tools=["getAccessibleAtlassianResources"],
+) as proxy:
+    print(proxy.invoke("getAccessibleAtlassianResources"))
+```
+
+## TypeScript SDK
+
+```ts
+import { CompressorClient } from "@atlassian/mcp-compressor";
+
+const proxy = await new CompressorClient({
+  servers: {
+    atlassian: {
+      url: "https://mcp.atlassian.com/v1/mcp",
+      headers: { Authorization: `Basic ${process.env.ATLASSIAN_MCP_BASIC_TOKEN}` },
+    },
+  },
+  compressionLevel: "medium",
+  serverName: "atlassian",
+  includeTools: ["getAccessibleAtlassianResources"],
+}).connect();
+
+try {
+  console.log(await proxy.invoke("getAccessibleAtlassianResources"));
+} finally {
+  proxy.close();
+}
+```
+
+## Generated clients
+
+```python
+with CompressorClient(servers=servers, server_name="atlassian") as proxy:
+    proxy.write_client("python", "./generated-py", name="atlassian")
+    proxy.write_client("typescript", "./generated-ts", name="atlassian")
+```
+
+The generated clients call the live Rust proxy, so the proxy session must remain alive while they are used.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,79 @@
+# Installation
+
+`mcp-compressor` is available as a Rust CLI/core, a Rust-backed Python package, and a Rust-backed TypeScript package.
+
+!!! note "Migration branch package names"
+    On the Rust migration branch, the Python package is published separately as `mcp-compressor-rust` until final cutover. The TypeScript package uses `@atlassian/mcp-compressor`.
+
+## CLI
+
+The CLI is provided by the Rust binary.
+
+=== "From source"
+
+    ```bash
+    cargo build -p mcp-compressor-core --release
+    ./target/release/mcp-compressor-core --help
+    ```
+
+=== "Python wrapper"
+
+    ```bash
+    cd python/mcp-compressor-rust
+    uv sync --group dev
+    uv run maturin develop
+    uv run mcp-compressor-rust --help
+    ```
+
+=== "TypeScript wrapper"
+
+    ```bash
+    cd typescript
+    bun install
+    bun run build
+    bun run build:native
+    bun run mcp-compressor -- --help
+    ```
+
+## Python SDK
+
+```bash
+cd python/mcp-compressor-rust
+uv sync --group dev
+uv run maturin develop
+```
+
+Then:
+
+```python
+from mcp_compressor_rust import CompressorClient
+```
+
+## TypeScript SDK
+
+```bash
+cd typescript
+bun install
+bun run build
+bun run build:native
+```
+
+Then:
+
+```ts
+import { CompressorClient } from "@atlassian/mcp-compressor";
+```
+
+## Rust SDK
+
+Add the core crate in a workspace or path dependency:
+
+```toml
+mcp-compressor-core = { path = "crates/mcp-compressor-core" }
+```
+
+Use:
+
+```rust
+use mcp_compressor_core::sdk::CompressorClient;
+```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart
+
+This quickstart uses a local MCP server command. Replace it with any stdio MCP server command or a remote streamable HTTP MCP URL.
+
+## Start a compressed MCP proxy
+
+=== "CLI"
+
+    ```bash
+    mcp-compressor -c medium -- python server.py
+    ```
+
+    MCP clients connected to this process see compressed tools instead of the full backend tool list.
+
+=== "Python"
+
+    ```python
+    from mcp_compressor_rust import CompressorClient
+
+    with CompressorClient(
+        servers={"local": {"command": "python", "args": ["server.py"]}},
+        compression_level="medium",
+    ) as proxy:
+        print([tool.name for tool in proxy.tools])
+        result = proxy.invoke("myTool", {"arg": "value"})
+        print(result)
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+
+    const client = new CompressorClient({
+      servers: { local: { command: "python", args: ["server.py"] } },
+      compressionLevel: "medium",
+    });
+
+    const proxy = await client.connect();
+    try {
+      console.log(proxy.tools.map((tool) => tool.name));
+      console.log(await proxy.invoke("myTool", { arg: "value" }));
+    } finally {
+      proxy.close();
+    }
+    ```
+
+=== "Rust"
+
+    ```rust
+    use mcp_compressor_core::compression::CompressionLevel;
+    use mcp_compressor_core::sdk::{CompressorClient, ServerConfig};
+    use serde_json::json;
+
+    let proxy = CompressorClient::builder()
+        .server("local", ServerConfig::command("python").arg("server.py"))
+        .compression_level(CompressionLevel::Medium)
+        .build()
+        .connect()
+        .await?;
+
+    let result = proxy.invoke("myTool", json!({ "arg": "value" })).await?;
+    ```
+
+## Remote MCP server
+
+For a remote streamable HTTP backend, pass a URL and any required headers.
+
+=== "CLI"
+
+    ```bash
+    mcp-compressor -c medium -- https://mcp.example.com/v1/mcp \
+      -H "Authorization=Bearer ${TOKEN}"
+    ```
+
+=== "Python"
+
+    ```python
+    with CompressorClient(
+        servers={
+            "remote": {
+                "url": "https://mcp.example.com/v1/mcp",
+                "headers": {"Authorization": f"Bearer {token}"},
+            }
+        },
+        compression_level="medium",
+    ) as proxy:
+        print(proxy.tools)
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    const proxy = await new CompressorClient({
+      servers: {
+        remote: {
+          url: "https://mcp.example.com/v1/mcp",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      },
+      compressionLevel: "medium",
+    }).connect();
+    ```
+
+=== "Rust"
+
+    ```rust
+    let proxy = CompressorClient::builder()
+        .server(
+            "remote",
+            ServerConfig::url("https://mcp.example.com/v1/mcp")
+                .header("Authorization", format!("Bearer {token}")),
+        )
+        .compression_level(CompressionLevel::Medium)
+        .build()
+        .connect()
+        .await?;
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,86 @@
-{%
-   include-markdown "../README.md"
-%}
+# mcp-compressor
+
+`mcp-compressor` lets agents use large MCP servers without paying the full token cost of every tool description on every request.
+
+Instead of exposing every backend tool directly, it exposes a small compressed interface:
+
+- `get_tool_schema` — fetch the full schema only when needed.
+- `invoke_tool` — invoke the backend tool after selecting it.
+- `list_tools` — optional discovery helper at `max` compression.
+
+It works as:
+
+- a **CLI** that runs as an MCP proxy,
+- a **Rust SDK**,
+- a **Python SDK**,
+- a **TypeScript SDK**,
+- generated shell/Python/TypeScript clients,
+- a Just Bash integration surface.
+
+## Why use it?
+
+MCP servers can expose dozens or hundreds of tools. Tool descriptions and JSON schemas can quickly consume thousands of tokens before the model has done any useful work.
+
+`mcp-compressor` keeps tool discovery cheap and lets the model ask for full schemas only when it has selected a tool.
+
+## Common use cases
+
+- Add several MCP servers to a coding agent without overwhelming context.
+- Put a compressed MCP proxy in front of remote servers such as Atlassian MCP.
+- Give agents shell-style or code-style access to MCP tools.
+- Embed compression directly in Rust, Python, or TypeScript applications without spawning a compressor subprocess.
+
+## Choose your path
+
+=== "CLI"
+
+    ```bash
+    mcp-compressor -c medium -- python my_mcp_server.py
+    ```
+
+=== "Python"
+
+    ```python
+    from mcp_compressor_rust import CompressorClient
+
+    with CompressorClient(
+        servers={"alpha": {"command": "python", "args": ["server.py"]}},
+        compression_level="medium",
+    ) as proxy:
+        print([tool.name for tool in proxy.tools])
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+
+    const proxy = await new CompressorClient({
+      servers: { alpha: { command: "python", args: ["server.py"] } },
+      compressionLevel: "medium",
+    }).connect();
+
+    try {
+      console.log(proxy.tools.map((tool) => tool.name));
+    } finally {
+      proxy.close();
+    }
+    ```
+
+=== "Rust"
+
+    ```rust
+    use mcp_compressor_core::compression::CompressionLevel;
+    use mcp_compressor_core::sdk::{CompressorClient, ServerConfig};
+
+    let proxy = CompressorClient::builder()
+        .server("alpha", ServerConfig::command("python").arg("server.py"))
+        .compression_level(CompressionLevel::Medium)
+        .build()
+        .connect()
+        .await?;
+    ```
+
+## Next
+
+Start with [Installation](getting-started/installation.md), then run the [Quickstart](getting-started/quickstart.md).

--- a/docs/reference/api-status.md
+++ b/docs/reference/api-status.md
@@ -1,0 +1,27 @@
+# API status
+
+The Rust migration branch is under active development. This page describes current stability expectations.
+
+## Stable enough to build against on the migration branch
+
+- Rust core compression behavior.
+- Rust CLI standard compression mode.
+- Rust CLI CLI/Python/TypeScript generation modes.
+- Python `CompressorClient` high-level SDK.
+- TypeScript `CompressorClient` high-level SDK.
+- Rust `CompressorClient` high-level SDK.
+- Explicit-header remote streamable HTTP backends.
+- Generated shell/Python/TypeScript clients.
+
+## Still being hardened
+
+- Native OAuth flows across providers.
+- Just Bash command host integration semantics.
+- Cross-platform release artifacts.
+- Final Python package name and cutover from `mcp-compressor-rust` to `mcp-compressor`.
+
+## Compatibility notes
+
+- TypeScript legacy runtime/client/server code has been removed from the migration branch.
+- Python legacy top-level package has been removed from the migration branch.
+- Public SDKs should not expose Rust implementation details in object names.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,45 @@
+# CLI reference
+
+Run:
+
+```bash
+mcp-compressor --help
+```
+
+## Common options
+
+| Option | Description |
+|---|---|
+| `-c`, `--compression <level>` | Compression level: `low`, `medium`, `high`, `max`. |
+| `--server-name <name>` | Public name for a single backend server. |
+| `--config <path>` | MCP config JSON file. |
+| `--multi-server <name=command ...>` | Direct multi-server CLI configuration. |
+| `--include-tools <a,b>` | Include only selected backend tools. |
+| `--exclude-tools <a,b>` | Exclude selected backend tools. |
+| `--toonify` | Convert JSON text outputs to TOON where applicable. |
+| `--transport <stdio|streamable-http>` | Frontend MCP transport. |
+| `--port <port>` | Port for streamable HTTP frontend. Use `0` for OS-selected. |
+| `--cli-mode` | Generate a shell CLI and run a local proxy. |
+| `--python-mode` | Generate a Python client and run a local proxy. |
+| `--typescript-mode` | Generate a TypeScript client and run a local proxy. |
+| `--just-bash-mode` | Expose Just Bash command metadata and run a local proxy. |
+| `--output-dir <path>` | Output directory for generated clients/scripts. |
+
+Backend command or URL arguments come after `--`.
+
+```bash
+mcp-compressor [options] -- <backend command or URL> [backend args]
+```
+
+## Header args for remote URLs
+
+```bash
+mcp-compressor -- https://mcp.example.com/v1/mcp -H "Authorization=Bearer ${TOKEN}"
+```
+
+## OAuth cleanup
+
+```bash
+mcp-compressor clear-oauth
+mcp-compressor clear-oauth <name-or-uri>
+```

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -1,0 +1,44 @@
+# SDK reference overview
+
+This page is a human-oriented map of the main SDK objects. Generated API references can be added once the migration package layout is finalized.
+
+## Shared concepts
+
+| Concept | Python | TypeScript | Rust |
+|---|---|---|---|
+| High-level client | `CompressorClient` | `CompressorClient` | `CompressorClient` |
+| Connected proxy/session | `CompressorProxy` | `CompressorProxy` | `CompressorProxy` |
+| Tool metadata | `ToolSpec`, `ProxyTool` | `ToolSpec`, `ProxyTool` | `Tool` |
+| Just Bash provider | `JustBashProvider` | `JustBashProvider` | `JustBashProviderSpec` |
+| Generated client kind | string: `cli`, `python`, `typescript` | string union | `GeneratedClientKind` |
+
+## Python imports
+
+```python
+from mcp_compressor_rust import (
+    CompressorClient,
+    ToolSpec,
+    create_just_bash_commands,
+)
+```
+
+## TypeScript imports
+
+```ts
+import {
+  CompressorClient,
+  type ToolSpec,
+  createJustBashCommands,
+} from "@atlassian/mcp-compressor";
+```
+
+## Rust imports
+
+```rust
+use mcp_compressor_core::compression::CompressionLevel;
+use mcp_compressor_core::sdk::{
+    CompressorClient,
+    GeneratedClientKind,
+    ServerConfig,
+};
+```

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,3 +1,0 @@
-{%
-   include-markdown "../typescript/README.md"
-%}

--- a/docs/usage/auth-and-remote.md
+++ b/docs/usage/auth-and-remote.md
@@ -1,0 +1,73 @@
+# Remote servers and authentication
+
+`mcp-compressor` supports remote streamable HTTP MCP backends.
+
+## Explicit headers
+
+Use explicit headers when you already have a token.
+
+=== "CLI"
+
+    ```bash
+    mcp-compressor -c medium -- https://mcp.example.com/v1/mcp \
+      -H "Authorization=Bearer ${TOKEN}"
+    ```
+
+=== "Python"
+
+    ```python
+    CompressorClient(servers={
+        "remote": {
+            "url": "https://mcp.example.com/v1/mcp",
+            "headers": {"Authorization": f"Bearer {token}"},
+        }
+    })
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    new CompressorClient({
+      servers: {
+        remote: {
+          url: "https://mcp.example.com/v1/mcp",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      },
+    });
+    ```
+
+=== "Rust"
+
+    ```rust
+    ServerConfig::url("https://mcp.example.com/v1/mcp")
+        .header("Authorization", format!("Bearer {token}"));
+    ```
+
+## Header syntax in CLI backend args
+
+CLI backend arguments use `Header=Value` syntax after `--`:
+
+```bash
+mcp-compressor -- https://mcp.example.com/v1/mcp -H "Authorization=Bearer ${TOKEN}"
+```
+
+## Native OAuth
+
+Native OAuth support exists for remote MCP servers that require browser authorization. It includes:
+
+- authorization URL generation,
+- browser opening,
+- loopback callback listener,
+- file-backed token/state persistence,
+- `clear-oauth`.
+
+Clear stored OAuth state:
+
+```bash
+mcp-compressor clear-oauth
+mcp-compressor clear-oauth https://mcp.example.com/v1/mcp
+```
+
+!!! note
+    OAuth behavior should be validated against your target MCP provider. Explicit headers are currently the most predictable option for automated CI.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -1,0 +1,72 @@
+# CLI usage
+
+The CLI can serve a compressed MCP server or start helper modes that create local command/code clients.
+
+## Standard MCP proxy
+
+```bash
+mcp-compressor -c medium -- python server.py
+```
+
+Compression level shorthand:
+
+```bash
+mcp-compressor -c low -- python server.py
+mcp-compressor -c medium -- python server.py
+mcp-compressor -c high -- python server.py
+mcp-compressor -c max -- python server.py
+```
+
+## Custom server name
+
+```bash
+mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+```
+
+## Streamable HTTP frontend
+
+```bash
+mcp-compressor -c medium --transport streamable-http --port 9000 -- python server.py
+```
+
+## CLI mode
+
+CLI mode writes a shell script that calls a local Rust proxy.
+
+```bash
+mcp-compressor --cli-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+```
+
+Then run commands through the generated script:
+
+```bash
+atlassian --help
+atlassian get-accessible-atlassian-resources
+```
+
+Use an explicit output directory:
+
+```bash
+mcp-compressor --cli-mode --server-name alpha --output-dir ./bin -- python server.py
+```
+
+## Generated Python and TypeScript clients
+
+```bash
+mcp-compressor --python-mode --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+
+mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+```
+
+## Just Bash mode
+
+```bash
+mcp-compressor --just-bash-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+```
+
+Just Bash mode exposes provider metadata for language hosts to register commands. See [Just Bash](just-bash.md).

--- a/docs/usage/generated-clients.md
+++ b/docs/usage/generated-clients.md
@@ -1,0 +1,58 @@
+# Generated clients
+
+Generated clients let agents call MCP tools through shell, Python, or TypeScript code while the Rust proxy owns MCP routing and authorization.
+
+## Generate from the CLI
+
+```bash
+mcp-compressor --cli-mode --server-name atlassian --output-dir ./bin -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+
+mcp-compressor --python-mode --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+
+mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp \
+  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+```
+
+## Generate from SDKs
+
+=== "Python"
+
+    ```python
+    with CompressorClient(servers=servers, compression_level="max") as proxy:
+        proxy.write_client("cli", "./bin", name="atlassian")
+        proxy.write_client("python", "./generated-py", name="atlassian")
+        proxy.write_client("typescript", "./generated-ts", name="atlassian")
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    const proxy = await new CompressorClient({ servers, compressionLevel: "max" }).connect();
+    try {
+      proxy.writeClient("cli", "./bin", { name: "atlassian" });
+      proxy.writeClient("python", "./generated-py", { name: "atlassian" });
+      proxy.writeClient("typescript", "./generated-ts", { name: "atlassian" });
+    } finally {
+      proxy.close();
+    }
+    ```
+
+=== "Rust"
+
+    ```rust
+    use mcp_compressor_core::sdk::GeneratedClientKind;
+
+    proxy.write_client(GeneratedClientKind::Python, "./generated-py", Some("atlassian"))?;
+    proxy.write_client(GeneratedClientKind::TypeScript, "./generated-ts", Some("atlassian"))?;
+    proxy.write_client(GeneratedClientKind::Cli, "./bin", Some("atlassian"))?;
+    ```
+
+## What gets generated?
+
+- **CLI**: an executable shell script with one subcommand per backend tool.
+- **Python**: a Python module with one function per backend tool.
+- **TypeScript**: an ESM module and `.d.ts` declarations with one function per backend tool.
+
+All generated clients call the local Rust proxy using a session token. Keep the proxy process/session alive while generated clients are being used.

--- a/docs/usage/just-bash.md
+++ b/docs/usage/just-bash.md
@@ -1,0 +1,67 @@
+# Just Bash
+
+Just Bash mode exposes MCP tools as command metadata that a language host can register with `just-bash`.
+
+Rust owns:
+
+- MCP backend connections,
+- compression,
+- schema-driven argument parsing,
+- proxy routing,
+- provider metadata.
+
+The language host owns:
+
+- Just Bash environment setup,
+- command registration,
+- command execution UX.
+
+## TypeScript host helper
+
+```ts
+import { Bash } from "just-bash";
+import { CompressorClient, createJustBashCommands } from "@atlassian/mcp-compressor";
+
+const proxy = await new CompressorClient({ servers, mode: "bash" }).connect();
+try {
+  const registrations = createJustBashCommands(proxy);
+  const bash = new Bash({ customCommands: registrations.map((item) => item.command) });
+
+  const result = await bash.exec("alpha_echo --message hello");
+  console.log(result.stdout);
+} finally {
+  proxy.close();
+}
+```
+
+## Python host helper
+
+```python
+from mcp_compressor_rust import CompressorClient, create_just_bash_commands
+
+with CompressorClient(servers=servers, mode="bash") as proxy:
+    commands = {command.command_name: command for command in create_just_bash_commands(proxy)}
+    print(commands["alpha_echo"](["--message", "hello"]))
+```
+
+## Command names and collisions
+
+If two servers expose the same backend command name, helpers prefix the command with the provider/server name:
+
+```text
+alpha_echo
+beta_echo
+```
+
+This avoids one server shadowing another.
+
+## Metadata shape
+
+Provider metadata includes:
+
+- provider name,
+- help tool name,
+- command name,
+- backend tool name,
+- input schema,
+- invoke wrapper name.

--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -1,0 +1,116 @@
+# SDK usage
+
+The SDKs let applications start compressed proxy sessions directly, without spawning the `mcp-compressor` stdio CLI.
+
+## Create a compressed proxy
+
+=== "Python"
+
+    ```python
+    from mcp_compressor_rust import CompressorClient
+
+    with CompressorClient(
+        servers={"alpha": {"command": "python", "args": ["server.py"]}},
+        compression_level="medium",
+    ) as proxy:
+        print(proxy.tools)
+        print(proxy.invoke("echo", {"message": "hello"}))
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+
+    const client = new CompressorClient({
+      servers: { alpha: { command: "python", args: ["server.py"] } },
+      compressionLevel: "medium",
+    });
+
+    const proxy = await client.connect();
+    try {
+      console.log(proxy.tools);
+      console.log(await proxy.invoke("echo", { message: "hello" }));
+    } finally {
+      proxy.close();
+    }
+    ```
+
+=== "Rust"
+
+    ```rust
+    use mcp_compressor_core::compression::CompressionLevel;
+    use mcp_compressor_core::sdk::{CompressorClient, ServerConfig};
+    use serde_json::json;
+
+    let proxy = CompressorClient::builder()
+        .server("alpha", ServerConfig::command("python").arg("server.py"))
+        .compression_level(CompressionLevel::Medium)
+        .build()
+        .connect()
+        .await?;
+
+    let output = proxy.invoke("echo", json!({ "message": "hello" })).await?;
+    ```
+
+## Multi-server routing
+
+=== "Python"
+
+    ```python
+    with CompressorClient(servers={
+        "alpha": {"command": "python", "args": ["alpha.py"]},
+        "beta": {"command": "python", "args": ["beta.py"]},
+    }) as proxy:
+        print(proxy.invoke("echo", {"message": "hi"}, server="alpha"))
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    const proxy = await new CompressorClient({
+      servers: {
+        alpha: { command: "python", args: ["alpha.py"] },
+        beta: { command: "python", args: ["beta.py"] },
+      },
+    }).connect();
+
+    await proxy.invoke("echo", { message: "hi" }, { server: "alpha" });
+    ```
+
+=== "Rust"
+
+    ```rust
+    let output = proxy
+        .invoke_on(Some("alpha"), "echo", json!({ "message": "hi" }))
+        .await?;
+    ```
+
+## Lifecycle
+
+Python context managers close sessions automatically. TypeScript and Rust proxies expose explicit close/drop behavior.
+
+=== "Python"
+
+    ```python
+    with CompressorClient(servers=servers) as proxy:
+        ...
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    const proxy = await client.connect();
+    try {
+      ...
+    } finally {
+      proxy.close();
+    }
+    ```
+
+=== "Rust"
+
+    ```rust
+    let proxy = client.connect().await?;
+    // proxy closes when dropped
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,9 +9,28 @@ copyright: Maintained by <a href="https://atlassian.com">atlassian</a>.
 
 nav:
   - Home: index.md
-  - TypeScript: typescript.md
-  - Rust Core Design: rust-core-design.md
-  - Modules: modules.md
+  - Getting started:
+      - Installation: getting-started/installation.md
+      - Quickstart: getting-started/quickstart.md
+  - Concepts:
+      - How it works: concepts/how-it-works.md
+      - Configuration: concepts/configuration.md
+  - Usage:
+      - CLI: usage/cli.md
+      - SDKs: usage/sdks.md
+      - Generated clients: usage/generated-clients.md
+      - Just Bash: usage/just-bash.md
+      - Remote servers and auth: usage/auth-and-remote.md
+  - Examples:
+      - Atlassian MCP: examples/atlassian.md
+  - Reference:
+      - CLI reference: reference/cli.md
+      - SDK reference: reference/sdk.md
+      - API status: reference/api-status.md
+      - API modules: modules.md
+  - Development:
+      - Rust migration: development/rust-migration.md
+      - Rust core design: rust-core-design.md
 plugins:
   - search
   - include-markdown
@@ -20,8 +39,10 @@ theme:
   name: material
   logo: https://raw.githubusercontent.com/atlassian-forks/SWE-PolyBench/refs/heads/main/rovo-dev-logo.svg
   favicon: https://raw.githubusercontent.com/atlassian-forks/SWE-PolyBench/refs/heads/main/rovo-dev-logo.svg
-  feature:
-    tabs: true
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - content.code.copy
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -50,6 +71,10 @@ extra:
 markdown_extensions:
   - toc:
       permalink: true
+  - admonition
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.superfences:


### PR DESCRIPTION
## Summary
- replace README-included docs home with a first-class product overview
- add getting-started installation and quickstart guides
- add concepts pages for compression architecture and configuration
- add usage guides for CLI, SDKs, generated clients, Just Bash, and remote auth
- add Atlassian MCP real-world example
- add reference pages for CLI, SDK concepts, and API status
- add Rust migration development notes
- restructure mkdocs navigation and enable Material tabbed code blocks
- remove stale TypeScript include page now superseded by the new docs structure

## Validation
- `make docs-test`
- `make check`