### PR TITLE
docs: polish public SDK documentation

### DIFF
--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -15,10 +15,7 @@ You can configure backends directly or with MCP config JSON.
     ```python
     servers = {
         "alpha": {"command": "python", "args": ["alpha_server.py"]},
-        "atlassian": {
-            "url": "https://mcp.atlassian.com/v1/mcp",
-            "headers": {"Authorization": f"Basic {token}"},
-        },
+        "atlassian": {"url": "https://mcp.atlassian.com/v1/mcp"},
     }
     ```
 
@@ -27,10 +24,7 @@ You can configure backends directly or with MCP config JSON.
     ```ts
     const servers = {
       alpha: { command: "python", args: ["alpha_server.py"] },
-      atlassian: {
-        url: "https://mcp.atlassian.com/v1/mcp",
-        headers: { Authorization: `Basic ${token}` },
-      },
+      atlassian: { url: "https://mcp.atlassian.com/v1/mcp" },
     };
     ```
 
@@ -39,11 +33,7 @@ You can configure backends directly or with MCP config JSON.
     ```rust
     let client = CompressorClient::builder()
         .server("alpha", ServerConfig::command("python").arg("alpha_server.py"))
-        .server(
-            "atlassian",
-            ServerConfig::url("https://mcp.atlassian.com/v1/mcp")
-                .header("Authorization", format!("Basic {token}")),
-        )
+        .server("atlassian", ServerConfig::url("https://mcp.atlassian.com/v1/mcp"))
         .build();
     ```
 
@@ -58,6 +48,18 @@ MCP config JSON is the easiest way to describe multiple backends.
       "command": "python",
       "args": ["alpha_server.py"]
     },
+    "remote": {
+      "url": "https://mcp.example.com/v1/mcp"
+    }
+  }
+}
+```
+
+For providers that require OAuth, the URL-only form triggers native OAuth. For non-interactive CI or static-token providers, add explicit headers:
+
+```json
+{
+  "mcpServers": {
     "remote": {
       "url": "https://mcp.example.com/v1/mcp",
       "headers": {

--- a/docs/examples/atlassian.md
+++ b/docs/examples/atlassian.md
@@ -6,17 +6,17 @@ This example uses the Atlassian remote MCP server:
 https://mcp.atlassian.com/v1/mcp
 ```
 
-The examples below assume you have a token available as:
+Atlassian MCP supports OAuth. The examples below intentionally use OAuth-first configuration and do not include explicit `Authorization` headers.
+
+!!! note "Automated tests"
+    CI may use explicit Basic headers for non-interactive real-world tests, but end-user documentation should prefer OAuth.
+
+## CLI compression with OAuth
+
+The first run opens a browser to authorize the backend. Subsequent runs reuse stored OAuth credentials.
 
 ```bash
-export ATLASSIAN_MCP_BASIC_TOKEN="..."
-```
-
-## CLI compression
-
-```bash
-mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
 ```
 
 ## Tool filters
@@ -25,59 +25,109 @@ mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1
 mcp-compressor -c medium \
   --server-name atlassian \
   --include-tools getAccessibleAtlassianResources,getConfluencePage \
-  -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+  -- https://mcp.atlassian.com/v1/mcp
 ```
 
-## Python SDK
+## SDK usage
 
-```python
-from mcp_compressor_rust import CompressorClient
+=== "Python"
 
-with CompressorClient(
-    servers={
-        "atlassian": {
-            "url": "https://mcp.atlassian.com/v1/mcp",
-            "headers": {"Authorization": f"Basic {token}"},
-        }
-    },
-    compression_level="medium",
-    server_name="atlassian",
-    include_tools=["getAccessibleAtlassianResources"],
-) as proxy:
-    print(proxy.invoke("getAccessibleAtlassianResources"))
-```
+    ```python
+    from mcp_compressor import CompressorClient
 
-## TypeScript SDK
+    with CompressorClient(
+        servers={
+            "atlassian": {
+                "url": "https://mcp.atlassian.com/v1/mcp",
+            }
+        },
+        compression_level="medium",
+        server_name="atlassian",
+        include_tools=["getAccessibleAtlassianResources"],
+    ) as proxy:
+        print(proxy.invoke("getAccessibleAtlassianResources"))
+    ```
 
-```ts
-import { CompressorClient } from "@atlassian/mcp-compressor";
+=== "TypeScript"
 
-const proxy = await new CompressorClient({
-  servers: {
-    atlassian: {
-      url: "https://mcp.atlassian.com/v1/mcp",
-      headers: { Authorization: `Basic ${process.env.ATLASSIAN_MCP_BASIC_TOKEN}` },
-    },
-  },
-  compressionLevel: "medium",
-  serverName: "atlassian",
-  includeTools: ["getAccessibleAtlassianResources"],
-}).connect();
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
 
-try {
-  console.log(await proxy.invoke("getAccessibleAtlassianResources"));
-} finally {
-  proxy.close();
-}
-```
+    const proxy = await new CompressorClient({
+      servers: {
+        atlassian: {
+          url: "https://mcp.atlassian.com/v1/mcp",
+        },
+      },
+      compressionLevel: "medium",
+      serverName: "atlassian",
+      includeTools: ["getAccessibleAtlassianResources"],
+    }).connect();
+
+    try {
+      console.log(await proxy.invoke("getAccessibleAtlassianResources"));
+    } finally {
+      proxy.close();
+    }
+    ```
+
+=== "Rust"
+
+    ```rust
+    use mcp_compressor::compression::CompressionLevel;
+    use mcp_compressor::sdk::{CompressorClient, ServerConfig};
+    use serde_json::json;
+
+    let proxy = CompressorClient::builder()
+        .server("atlassian", ServerConfig::url("https://mcp.atlassian.com/v1/mcp"))
+        .server_name("atlassian")
+        .compression_level(CompressionLevel::Medium)
+        .include_tools(["getAccessibleAtlassianResources"])
+        .build()
+        .connect()
+        .await?;
+
+    let output = proxy
+        .invoke("getAccessibleAtlassianResources", json!({}))
+        .await?;
+    ```
 
 ## Generated clients
 
-```python
-with CompressorClient(servers=servers, server_name="atlassian") as proxy:
-    proxy.write_client("python", "./generated-py", name="atlassian")
-    proxy.write_client("typescript", "./generated-ts", name="atlassian")
-```
+=== "Python"
 
-The generated clients call the live Rust proxy, so the proxy session must remain alive while they are used.
+    ```python
+    with CompressorClient(
+        servers={"atlassian": {"url": "https://mcp.atlassian.com/v1/mcp"}},
+        server_name="atlassian",
+    ) as proxy:
+        proxy.write_client("cli", "./bin", name="atlassian")
+        proxy.write_client("python", "./generated-py", name="atlassian")
+        proxy.write_client("typescript", "./generated-ts", name="atlassian")
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    const proxy = await new CompressorClient({
+      servers: { atlassian: { url: "https://mcp.atlassian.com/v1/mcp" } },
+      serverName: "atlassian",
+    }).connect();
+
+    try {
+      proxy.writeClient("cli", "./bin", { name: "atlassian" });
+      proxy.writeClient("python", "./generated-py", { name: "atlassian" });
+      proxy.writeClient("typescript", "./generated-ts", { name: "atlassian" });
+    } finally {
+      proxy.close();
+    }
+    ```
+
+Generated clients call the live Rust proxy, so keep the proxy session alive while they are used.
+
+## Clear OAuth credentials
+
+```bash
+mcp-compressor clear-oauth atlassian
+mcp-compressor clear-oauth https://mcp.atlassian.com/v1/mcp
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -46,7 +46,7 @@ uv run maturin develop
 Then:
 
 ```python
-from mcp_compressor_rust import CompressorClient
+from mcp_compressor import CompressorClient
 ```
 
 ## TypeScript SDK
@@ -75,5 +75,5 @@ mcp-compressor-core = { path = "crates/mcp-compressor-core" }
 Use:
 
 ```rust
-use mcp_compressor_core::sdk::CompressorClient;
+use mcp_compressor::sdk::CompressorClient;
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -15,7 +15,7 @@ This quickstart uses a local MCP server command. Replace it with any stdio MCP s
 === "Python"
 
     ```python
-    from mcp_compressor_rust import CompressorClient
+    from mcp_compressor import CompressorClient
 
     with CompressorClient(
         servers={"local": {"command": "python", "args": ["server.py"]}},
@@ -48,8 +48,8 @@ This quickstart uses a local MCP server command. Replace it with any stdio MCP s
 === "Rust"
 
     ```rust
-    use mcp_compressor_core::compression::CompressionLevel;
-    use mcp_compressor_core::sdk::{CompressorClient, ServerConfig};
+    use mcp_compressor::compression::CompressionLevel;
+    use mcp_compressor::sdk::{CompressorClient, ServerConfig};
     use serde_json::json;
 
     let proxy = CompressorClient::builder()
@@ -64,25 +64,19 @@ This quickstart uses a local MCP server command. Replace it with any stdio MCP s
 
 ## Remote MCP server
 
-For a remote streamable HTTP backend, pass a URL and any required headers.
+For a remote streamable HTTP backend, pass a URL. If the server requires OAuth and no explicit `Authorization` header is provided, `mcp-compressor` starts the OAuth flow.
 
 === "CLI"
 
     ```bash
-    mcp-compressor -c medium -- https://mcp.example.com/v1/mcp \
-      -H "Authorization=Bearer ${TOKEN}"
+    mcp-compressor -c medium -- https://mcp.example.com/v1/mcp
     ```
 
 === "Python"
 
     ```python
     with CompressorClient(
-        servers={
-            "remote": {
-                "url": "https://mcp.example.com/v1/mcp",
-                "headers": {"Authorization": f"Bearer {token}"},
-            }
-        },
+        servers={"remote": {"url": "https://mcp.example.com/v1/mcp"}},
         compression_level="medium",
     ) as proxy:
         print(proxy.tools)
@@ -92,12 +86,7 @@ For a remote streamable HTTP backend, pass a URL and any required headers.
 
     ```ts
     const proxy = await new CompressorClient({
-      servers: {
-        remote: {
-          url: "https://mcp.example.com/v1/mcp",
-          headers: { Authorization: `Bearer ${token}` },
-        },
-      },
+      servers: { remote: { url: "https://mcp.example.com/v1/mcp" } },
       compressionLevel: "medium",
     }).connect();
     ```
@@ -106,11 +95,7 @@ For a remote streamable HTTP backend, pass a URL and any required headers.
 
     ```rust
     let proxy = CompressorClient::builder()
-        .server(
-            "remote",
-            ServerConfig::url("https://mcp.example.com/v1/mcp")
-                .header("Authorization", format!("Bearer {token}")),
-        )
+        .server("remote", ServerConfig::url("https://mcp.example.com/v1/mcp"))
         .compression_level(CompressionLevel::Medium)
         .build()
         .connect()

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,53 +1,95 @@
 # mcp-compressor
 
-`mcp-compressor` lets agents use large MCP servers without paying the full token cost of every tool description on every request.
+`mcp-compressor` helps agents use large MCP servers without spending huge amounts of context on tool descriptions and schemas.
 
-Instead of exposing every backend tool directly, it exposes a small compressed interface:
+It can run as a CLI MCP proxy, or be embedded directly from Python, TypeScript, or Rust.
 
-- `get_tool_schema` — fetch the full schema only when needed.
-- `invoke_tool` — invoke the backend tool after selecting it.
-- `list_tools` — optional discovery helper at `max` compression.
+## The problem
 
-It works as:
+A powerful MCP server can expose dozens or hundreds of tools. Each tool has a name, description, input schema, and sometimes large nested JSON Schema details. Sending all of that to a model up front can waste thousands of tokens before the agent has done any useful work.
 
-- a **CLI** that runs as an MCP proxy,
-- a **Rust SDK**,
-- a **Python SDK**,
-- a **TypeScript SDK**,
-- generated shell/Python/TypeScript clients,
-- a Just Bash integration surface.
+`mcp-compressor` changes the interaction pattern: the model sees a small compressed surface first, asks for the full schema only for the selected tool, and then invokes that tool.
 
-## Why use it?
+## Pattern 1: compressed MCP proxy
 
-MCP servers can expose dozens or hundreds of tools. Tool descriptions and JSON schemas can quickly consume thousands of tokens before the model has done any useful work.
+Use this when you want any MCP client to see a smaller tool surface.
 
-`mcp-compressor` keeps tool discovery cheap and lets the model ask for full schemas only when it has selected a tool.
+```mermaid
+sequenceDiagram
+    participant Client as MCP client / agent
+    participant Proxy as mcp-compressor
+    participant Backend as Backend MCP server
 
-## Common use cases
+    Client->>Proxy: tools/list
+    Proxy->>Backend: tools/list
+    Backend-->>Proxy: all backend tools and schemas
+    Proxy-->>Client: compact wrapper tools
+    Client->>Proxy: get_tool_schema(tool_name)
+    Proxy-->>Client: full schema for selected tool
+    Client->>Proxy: invoke_tool(tool_name, input)
+    Proxy->>Backend: tools/call selected backend tool
+    Backend-->>Proxy: tool result
+    Proxy-->>Client: result
+```
 
-- Add several MCP servers to a coding agent without overwhelming context.
-- Put a compressed MCP proxy in front of remote servers such as Atlassian MCP.
-- Give agents shell-style or code-style access to MCP tools.
-- Embed compression directly in Rust, Python, or TypeScript applications without spawning a compressor subprocess.
+The frontend usually exposes only:
 
-## Choose your path
+- `get_tool_schema`
+- `invoke_tool`
+- optionally `list_tools` at `max` compression
+
+## Pattern 2: local proxy for generated clients and SDKs
+
+Use this when your application wants to embed compression directly and call tools from code or shell commands.
+
+```mermaid
+flowchart LR
+    App[Python / TypeScript / Rust app]
+    SDK[CompressorClient]
+    Proxy[Local Rust proxy\n/token auth]
+    Generated[Generated CLI / Python / TS clients]
+    Backend[MCP backend servers]
+
+    App --> SDK
+    SDK --> Proxy
+    Generated --> Proxy
+    Proxy --> Backend
+```
+
+The SDK starts the Rust proxy in-process. Generated clients call that proxy using a session token. Your app does **not** need to spawn a `mcp-compressor` stdio subprocess.
+
+## Features
+
+- [Compressed MCP proxy](usage/cli.md#standard-mcp-proxy) for existing MCP clients.
+- [Compression levels](concepts/how-it-works.md#compression-levels): `low`, `medium`, `high`, `max`.
+- [Python, TypeScript, and Rust SDKs](usage/sdks.md) with aligned `CompressorClient` APIs.
+- [Generated shell, Python, and TypeScript clients](usage/generated-clients.md).
+- [Just Bash integration](usage/just-bash.md) for command-oriented agents.
+- [Remote streamable HTTP MCP backends](usage/auth-and-remote.md).
+- [OAuth support](usage/auth-and-remote.md#native-oauth) for providers that support browser authorization.
+- [Tool filters and TOON output](concepts/configuration.md#filters) to further reduce context.
+- [Atlassian MCP example](examples/atlassian.md) with OAuth-first usage.
+- [CLI reference](reference/cli.md) and [SDK reference overview](reference/sdk.md).
+
+## Quick example
 
 === "CLI"
 
     ```bash
-    mcp-compressor -c medium -- python my_mcp_server.py
+    mcp-compressor -c medium -- python server.py
     ```
 
 === "Python"
 
     ```python
-    from mcp_compressor_rust import CompressorClient
+    from mcp_compressor import CompressorClient
 
     with CompressorClient(
         servers={"alpha": {"command": "python", "args": ["server.py"]}},
         compression_level="medium",
     ) as proxy:
         print([tool.name for tool in proxy.tools])
+        print(proxy.invoke("echo", {"message": "hello"}))
     ```
 
 === "TypeScript"
@@ -62,6 +104,7 @@ MCP servers can expose dozens or hundreds of tools. Tool descriptions and JSON s
 
     try {
       console.log(proxy.tools.map((tool) => tool.name));
+      console.log(await proxy.invoke("echo", { message: "hello" }));
     } finally {
       proxy.close();
     }
@@ -70,8 +113,9 @@ MCP servers can expose dozens or hundreds of tools. Tool descriptions and JSON s
 === "Rust"
 
     ```rust
-    use mcp_compressor_core::compression::CompressionLevel;
-    use mcp_compressor_core::sdk::{CompressorClient, ServerConfig};
+    use mcp_compressor::compression::CompressionLevel;
+    use mcp_compressor::sdk::{CompressorClient, ServerConfig};
+    use serde_json::json;
 
     let proxy = CompressorClient::builder()
         .server("alpha", ServerConfig::command("python").arg("server.py"))
@@ -79,8 +123,13 @@ MCP servers can expose dozens or hundreds of tools. Tool descriptions and JSON s
         .build()
         .connect()
         .await?;
+
+    let result = proxy.invoke("echo", json!({ "message": "hello" })).await?;
     ```
 
-## Next
+## Where to go next
 
-Start with [Installation](getting-started/installation.md), then run the [Quickstart](getting-started/quickstart.md).
+1. [Install the package you need](getting-started/installation.md).
+2. Run the [quickstart](getting-started/quickstart.md).
+3. Read [how compression works](concepts/how-it-works.md).
+4. Choose between [CLI usage](usage/cli.md), [SDK usage](usage/sdks.md), [generated clients](usage/generated-clients.md), and [Just Bash](usage/just-bash.md).

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -15,7 +15,7 @@ This page is a human-oriented map of the main SDK objects. Generated API referen
 ## Python imports
 
 ```python
-from mcp_compressor_rust import (
+from mcp_compressor import (
     CompressorClient,
     ToolSpec,
     create_just_bash_commands,
@@ -35,8 +35,8 @@ import {
 ## Rust imports
 
 ```rust
-use mcp_compressor_core::compression::CompressionLevel;
-use mcp_compressor_core::sdk::{
+use mcp_compressor::compression::CompressionLevel;
+use mcp_compressor::sdk::{
     CompressorClient,
     GeneratedClientKind,
     ServerConfig,

--- a/docs/usage/auth-and-remote.md
+++ b/docs/usage/auth-and-remote.md
@@ -2,9 +2,74 @@
 
 `mcp-compressor` supports remote streamable HTTP MCP backends.
 
+Most hosted MCP servers require authentication. `mcp-compressor` supports two patterns:
+
+1. **OAuth** — preferred for end users and interactive development.
+2. **Explicit headers** — useful for CI, service accounts, or providers that issue static tokens.
+
+## Native OAuth
+
+When a remote backend requires OAuth and you do not provide an explicit `Authorization` header, `mcp-compressor` starts the native OAuth flow:
+
+1. discovers provider metadata,
+2. opens a browser to authorize,
+3. listens on a local loopback callback URL,
+4. exchanges the code for tokens,
+5. stores credentials for future runs.
+
+=== "CLI"
+
+    ```bash
+    mcp-compressor -c medium --server-name remote -- https://mcp.example.com/v1/mcp
+    ```
+
+=== "Python"
+
+    ```python
+    from mcp_compressor import CompressorClient
+
+    with CompressorClient(
+        servers={"remote": {"url": "https://mcp.example.com/v1/mcp"}},
+        server_name="remote",
+    ) as proxy:
+        print(proxy.tools)
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+
+    const proxy = await new CompressorClient({
+      servers: { remote: { url: "https://mcp.example.com/v1/mcp" } },
+      serverName: "remote",
+    }).connect();
+    ```
+
+=== "Rust"
+
+    ```rust
+    let proxy = CompressorClient::builder()
+        .server("remote", ServerConfig::url("https://mcp.example.com/v1/mcp"))
+        .server_name("remote")
+        .build()
+        .connect()
+        .await?;
+    ```
+
+## Clear OAuth credentials
+
+```bash
+mcp-compressor clear-oauth
+mcp-compressor clear-oauth https://mcp.example.com/v1/mcp
+mcp-compressor clear-oauth remote
+```
+
+Python and TypeScript also expose OAuth store helper APIs for applications that need to list or clear stored credentials.
+
 ## Explicit headers
 
-Use explicit headers when you already have a token.
+Use explicit headers when you already have a token or need non-interactive CI.
 
 === "CLI"
 
@@ -52,22 +117,5 @@ CLI backend arguments use `Header=Value` syntax after `--`:
 mcp-compressor -- https://mcp.example.com/v1/mcp -H "Authorization=Bearer ${TOKEN}"
 ```
 
-## Native OAuth
-
-Native OAuth support exists for remote MCP servers that require browser authorization. It includes:
-
-- authorization URL generation,
-- browser opening,
-- loopback callback listener,
-- file-backed token/state persistence,
-- `clear-oauth`.
-
-Clear stored OAuth state:
-
-```bash
-mcp-compressor clear-oauth
-mcp-compressor clear-oauth https://mcp.example.com/v1/mcp
-```
-
 !!! note
-    OAuth behavior should be validated against your target MCP provider. Explicit headers are currently the most predictable option for automated CI.
+    OAuth is the recommended public-user flow for providers such as Atlassian MCP. Explicit headers remain useful for automated tests and service-account style usage.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -20,9 +20,10 @@ mcp-compressor -c max -- python server.py
 ## Custom server name
 
 ```bash
-mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
 ```
+
+The first run opens a browser for OAuth if no stored credentials exist.
 
 ## Streamable HTTP frontend
 
@@ -35,8 +36,7 @@ mcp-compressor -c medium --transport streamable-http --port 9000 -- python serve
 CLI mode writes a shell script that calls a local Rust proxy.
 
 ```bash
-mcp-compressor --cli-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+mcp-compressor --cli-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
 ```
 
 Then run commands through the generated script:
@@ -55,18 +55,15 @@ mcp-compressor --cli-mode --server-name alpha --output-dir ./bin -- python serve
 ## Generated Python and TypeScript clients
 
 ```bash
-mcp-compressor --python-mode --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+mcp-compressor --python-mode --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp
 
-mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp
 ```
 
 ## Just Bash mode
 
 ```bash
-mcp-compressor --just-bash-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+mcp-compressor --just-bash-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
 ```
 
 Just Bash mode exposes provider metadata for language hosts to register commands. See [Just Bash](just-bash.md).

--- a/docs/usage/generated-clients.md
+++ b/docs/usage/generated-clients.md
@@ -2,24 +2,54 @@
 
 Generated clients let agents call MCP tools through shell, Python, or TypeScript code while the Rust proxy owns MCP routing and authorization.
 
+They are useful when your agent is better at command or code execution than raw MCP tool invocation.
+
+## What gets generated?
+
+- **CLI**: an executable shell script with one subcommand per backend tool.
+- **Python**: a Python module with one function per backend tool.
+- **TypeScript**: an ESM module and `.d.ts` declarations with one function per backend tool.
+
+All generated clients call a live local Rust proxy using a session token. Keep the proxy session alive while generated clients are used.
+
 ## Generate from the CLI
 
-```bash
-mcp-compressor --cli-mode --server-name atlassian --output-dir ./bin -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+=== "Shell CLI"
 
-mcp-compressor --python-mode --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+    ```bash
+    mcp-compressor --cli-mode \
+      --server-name atlassian \
+      --output-dir ./bin \
+      -- https://mcp.atlassian.com/v1/mcp
+    ```
 
-mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp \
-  -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
-```
+=== "Python client"
+
+    ```bash
+    mcp-compressor --python-mode \
+      --server-name atlassian \
+      --output-dir ./generated-py \
+      -- https://mcp.atlassian.com/v1/mcp
+    ```
+
+=== "TypeScript client"
+
+    ```bash
+    mcp-compressor --typescript-mode \
+      --server-name atlassian \
+      --output-dir ./generated-ts \
+      -- https://mcp.atlassian.com/v1/mcp
+    ```
+
+The Atlassian examples use OAuth. The first run opens a browser if no stored credentials exist.
 
 ## Generate from SDKs
 
 === "Python"
 
     ```python
+    from mcp_compressor import CompressorClient
+
     with CompressorClient(servers=servers, compression_level="max") as proxy:
         proxy.write_client("cli", "./bin", name="atlassian")
         proxy.write_client("python", "./generated-py", name="atlassian")
@@ -29,6 +59,8 @@ mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generate
 === "TypeScript"
 
     ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+
     const proxy = await new CompressorClient({ servers, compressionLevel: "max" }).connect();
     try {
       proxy.writeClient("cli", "./bin", { name: "atlassian" });
@@ -42,17 +74,34 @@ mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generate
 === "Rust"
 
     ```rust
-    use mcp_compressor_core::sdk::GeneratedClientKind;
+    use mcp_compressor::sdk::GeneratedClientKind;
 
+    proxy.write_client(GeneratedClientKind::Cli, "./bin", Some("atlassian"))?;
     proxy.write_client(GeneratedClientKind::Python, "./generated-py", Some("atlassian"))?;
     proxy.write_client(GeneratedClientKind::TypeScript, "./generated-ts", Some("atlassian"))?;
-    proxy.write_client(GeneratedClientKind::Cli, "./bin", Some("atlassian"))?;
     ```
 
-## What gets generated?
+## Example generated CLI usage
 
-- **CLI**: an executable shell script with one subcommand per backend tool.
-- **Python**: a Python module with one function per backend tool.
-- **TypeScript**: an ESM module and `.d.ts` declarations with one function per backend tool.
+```bash
+./bin/atlassian --help
+./bin/atlassian get-accessible-atlassian-resources
+```
 
-All generated clients call the local Rust proxy using a session token. Keep the proxy process/session alive while generated clients are being used.
+## Example generated Python usage
+
+```python
+import sys
+sys.path.insert(0, "./generated-py")
+
+import atlassian
+print(atlassian.getAccessibleAtlassianResources())
+```
+
+## Example generated TypeScript usage
+
+```ts
+import { getAccessibleAtlassianResources } from "./generated-ts/atlassian.ts";
+
+console.log(await getAccessibleAtlassianResources());
+```

--- a/docs/usage/just-bash.md
+++ b/docs/usage/just-bash.md
@@ -37,7 +37,7 @@ try {
 ## Python host helper
 
 ```python
-from mcp_compressor_rust import CompressorClient, create_just_bash_commands
+from mcp_compressor import CompressorClient, create_just_bash_commands
 
 with CompressorClient(servers=servers, mode="bash") as proxy:
     commands = {command.command_name: command for command in create_just_bash_commands(proxy)}

--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -1,19 +1,26 @@
 # SDK usage
 
-The SDKs let applications start compressed proxy sessions directly, without spawning the `mcp-compressor` stdio CLI.
+The SDKs are for applications that want to use compressed MCP tools directly without launching `mcp-compressor` as a stdio subprocess.
+
+Each SDK follows the same model:
+
+1. Create a `CompressorClient` with one or more MCP backend servers.
+2. Connect to get a `CompressorProxy`.
+3. Inspect compressed frontend tools or invoke backend tools through the proxy.
+4. Close/drop the proxy when finished.
 
 ## Create a compressed proxy
 
 === "Python"
 
     ```python
-    from mcp_compressor_rust import CompressorClient
+    from mcp_compressor import CompressorClient
 
     with CompressorClient(
         servers={"alpha": {"command": "python", "args": ["server.py"]}},
         compression_level="medium",
     ) as proxy:
-        print(proxy.tools)
+        print([tool.name for tool in proxy.tools])
         print(proxy.invoke("echo", {"message": "hello"}))
     ```
 
@@ -29,7 +36,7 @@ The SDKs let applications start compressed proxy sessions directly, without spaw
 
     const proxy = await client.connect();
     try {
-      console.log(proxy.tools);
+      console.log(proxy.tools.map((tool) => tool.name));
       console.log(await proxy.invoke("echo", { message: "hello" }));
     } finally {
       proxy.close();
@@ -39,8 +46,8 @@ The SDKs let applications start compressed proxy sessions directly, without spaw
 === "Rust"
 
     ```rust
-    use mcp_compressor_core::compression::CompressionLevel;
-    use mcp_compressor_core::sdk::{CompressorClient, ServerConfig};
+    use mcp_compressor::compression::CompressionLevel;
+    use mcp_compressor::sdk::{CompressorClient, ServerConfig};
     use serde_json::json;
 
     let proxy = CompressorClient::builder()
@@ -54,6 +61,8 @@ The SDKs let applications start compressed proxy sessions directly, without spaw
     ```
 
 ## Multi-server routing
+
+When more than one backend server is configured, specify the server when invoking a backend tool.
 
 === "Python"
 
@@ -75,7 +84,11 @@ The SDKs let applications start compressed proxy sessions directly, without spaw
       },
     }).connect();
 
-    await proxy.invoke("echo", { message: "hi" }, { server: "alpha" });
+    try {
+      await proxy.invoke("echo", { message: "hi" }, { server: "alpha" });
+    } finally {
+      proxy.close();
+    }
     ```
 
 === "Rust"
@@ -86,9 +99,76 @@ The SDKs let applications start compressed proxy sessions directly, without spaw
         .await?;
     ```
 
-## Lifecycle
+## Compression options
 
-Python context managers close sessions automatically. TypeScript and Rust proxies expose explicit close/drop behavior.
+The SDKs expose the same main compression options as the CLI.
+
+=== "Python"
+
+    ```python
+    CompressorClient(
+        servers=servers,
+        compression_level="high",
+        include_tools=["search", "getPage"],
+        exclude_tools=["dangerousDelete"],
+        toonify=True,
+    )
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    new CompressorClient({
+      servers,
+      compressionLevel: "high",
+      includeTools: ["search", "getPage"],
+      excludeTools: ["dangerousDelete"],
+      toonify: true,
+    });
+    ```
+
+=== "Rust"
+
+    ```rust
+    CompressorClient::builder()
+        .compression_level(CompressionLevel::High)
+        .include_tools(["search", "getPage"])
+        .exclude_tools(["dangerousDelete"])
+        .toonify(true)
+        .build();
+    ```
+
+## Modes
+
+| Mode | Purpose |
+|---|---|
+| `compressed` | Standard `get_tool_schema` / `invoke_tool` compressed surface. |
+| `cli` | Help-tool-oriented surface for generated shell command usage. |
+| `bash` | Just Bash provider metadata plus proxy routing. |
+
+=== "Python"
+
+    ```python
+    CompressorClient(servers=servers, mode="bash")
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    new CompressorClient({ servers, mode: "bash" });
+    ```
+
+=== "Rust"
+
+    ```rust
+    use mcp_compressor::sdk::CompressorMode;
+
+    CompressorClient::builder()
+        .mode(CompressorMode::JustBash)
+        .build();
+    ```
+
+## Lifecycle
 
 === "Python"
 


### PR DESCRIPTION
## Summary
- expand the landing page with compression/proxy diagrams, feature links, and richer overview text
- update public examples to use final import names: `mcp_compressor`, `@atlassian/mcp-compressor`, and `mcp_compressor` for Rust
- make Atlassian examples OAuth-first instead of explicit Basic-header based
- consolidate repeated language examples into tabbed sections
- expand SDK, generated-client, auth, config, and quickstart docs

## Validation
- `make docs-test`
- `make check`