### PR TITLE
test: lock public SDK import names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Set up the Python environment
         uses: ./.github/actions/setup-python-env
 
+      - name: Check public Rust SDK crate
+        run: cargo check -p mcp-compressor
+
       - name: Check Rust core library
         run: cargo check -p mcp-compressor-core
 
@@ -45,6 +48,11 @@ jobs:
 
       - name: Check Rust-backed Node extension crate
         run: cargo check -p mcp-compressor-node
+
+      - name: Run public Rust SDK import smoke test
+        env:
+          PYTHON: ${{ github.workspace }}/.venv/bin/python
+        run: cargo test -p mcp-compressor --test public_api -- --nocapture
 
       - name: Run Rust core library tests
         env:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ check: ## Run code quality tools.
 	@uv run pre-commit run -a
 	@echo "🚀 Static type checking: Running ty"
 	@uv run ty check
+	@echo "🚀 Checking public API names"
+	@uv run python scripts/check_public_api_names.py
 	@echo "🚀 Checking for obsolete dependencies: Running deptry"
 	@uv run deptry .
 

--- a/crates/mcp-compressor/tests/public_api.rs
+++ b/crates/mcp-compressor/tests/public_api.rs
@@ -1,0 +1,13 @@
+use mcp_compressor::compression::CompressionLevel;
+use mcp_compressor::sdk::{CompressorClient, CompressorMode, GeneratedClientKind, ServerConfig};
+
+#[test]
+fn public_crate_exports_expected_sdk_surface() {
+    let _client = CompressorClient::builder()
+        .server("alpha", ServerConfig::command("python").arg("alpha_server.py"))
+        .compression_level(CompressionLevel::Max)
+        .mode(CompressorMode::CompressedTools)
+        .build();
+
+    let _kind = GeneratedClientKind::Python;
+}

--- a/scripts/check_public_api_names.py
+++ b/scripts/check_public_api_names.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+FORBIDDEN = {
+    "mcp_compressor_rust": "Use public Python import package `mcp_compressor` instead.",
+    "mcp_compressor_core::": "Use public Rust crate path `mcp_compressor::` in user-facing examples.",
+    "from mcp_compressor_core": "Use public Rust crate path `mcp_compressor` in user-facing examples.",
+}
+
+SEARCH_ROOTS = [
+    Path("docs"),
+    Path("README.md"),
+    Path("python/mcp-compressor-rust/README.md"),
+    Path("typescript/README.md"),
+    Path("tests"),
+]
+
+IGNORED_PARTS = {
+    "__pycache__",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".venv",
+    "dist",
+    "site",
+}
+
+
+def candidate_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SEARCH_ROOTS:
+        if not root.exists():
+            continue
+        if root.is_file():
+            files.append(root)
+            continue
+        for path in root.rglob("*"):
+            if any(part in IGNORED_PARTS for part in path.parts):
+                continue
+            if path.suffix in {".md", ".py", ".ts", ".tsx", ".yml", ".yaml"}:
+                files.append(path)
+    return files
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in candidate_files():
+        text = path.read_text(errors="ignore")
+        for forbidden, message in FORBIDDEN.items():
+            if forbidden in text:
+                failures.append(f"{path}: found `{forbidden}`. {message}")
+    if failures:
+        print("Public API name check failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Rust public-crate import smoke test for `mcp_compressor`
- run the public Rust crate smoke test in CI
- add a public API name guard to prevent user-facing docs/tests from reintroducing implementation names like `mcp_compressor_rust` or `mcp_compressor_core::`
- wire the guard into `make check`

## Validation
- `uv run python scripts/check_public_api_names.py`
- `cargo test -p mcp-compressor --test public_api -- --nocapture`
- `cargo check -p mcp-compressor`
- `make check`