### PR TITLE
ci: rename release artifact workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,4 +1,4 @@
-name: Rust Migration Artifacts
+name: Release Artifacts
 
 on:
   workflow_dispatch:

--- a/docs/development/rust-migration.md
+++ b/docs/development/rust-migration.md
@@ -48,4 +48,4 @@ bun run check
 - Rust binary smoke is in CI.
 - Python wheel smoke is in CI.
 - TypeScript package/native-addon smoke is in CI.
-- A manual `Rust Migration Artifacts` workflow builds all three artifact classes together.
+- A `Release Artifacts` workflow builds all three artifact classes together.

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -237,7 +237,7 @@ Status as of 2026-05-07 on `rust-core-migration-trunk`:
 
 ### Recommended next implementation order
 
-1. Harden packaging/release automation for Rust-backed Python wheels, TypeScript native addon artifacts, and the Rust binary. CI now includes smoke jobs for Python wheels, TypeScript package artifacts, and the Rust CLI binary. A manual `Rust Migration Artifacts` workflow builds all three artifact classes together without publishing.
+1. Harden packaging/release automation for Rust-backed Python wheels, TypeScript native addon artifacts, and the Rust binary. CI now includes smoke jobs for Python wheels, TypeScript package artifacts, and the Rust CLI binary. A `Release Artifacts` workflow builds all three artifact classes together without publishing.
 2. Finish Just Bash integration around Rust provider specs and language-hosted Just Bash execution.
 3. Continue OAuth hardening against real hosted MCP servers.
 4. Add final API/reference docs for the Rust, Python, TypeScript SDKs, generated-client modes, and migration/cutover behavior.


### PR DESCRIPTION
## Summary
- rename `.github/workflows/rust-migration-artifacts.yml` to `.github/workflows/release-artifacts.yml`
- rename the workflow from `Rust Migration Artifacts` to `Release Artifacts`
- update docs to avoid migration-oriented CI naming

## Validation
- parsed updated workflow YAML locally
- `make docs-test`
- `make check`