### PR TITLE
refactor: expose public CLI binary name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
         env:
           PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: |
-          BIN=target/release/mcp-compressor-core
+          BIN=target/release/mcp-compressor
           "$BIN" --help
           if "$BIN" --compression invalid -- "$PYTHON" crates/mcp-compressor-core/tests/fixtures/alpha_server.py; then
             echo "Expected invalid compression level to fail" >&2
@@ -182,8 +182,8 @@ jobs:
       - name: Upload Rust CLI binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mcp-compressor-core-linux-x86_64
-          path: target/release/mcp-compressor-core
+          name: mcp-compressor-linux-x86_64
+          path: target/release/mcp-compressor
 
   python-rust-wheel:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -25,13 +25,13 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact-suffix: linux-x86_64
-            binary-name: mcp-compressor-core
+            binary-name: mcp-compressor
           - os: macos-latest
             artifact-suffix: macos-arm64
-            binary-name: mcp-compressor-core
+            binary-name: mcp-compressor
           - os: windows-latest
             artifact-suffix: windows-x86_64
-            binary-name: mcp-compressor-core.exe
+            binary-name: mcp-compressor.exe
     steps:
       - name: Check out
         uses: actions/checkout@v6

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -25,3 +25,7 @@ tempfile = "3"
 # binary e2e contract tests
 assert_cmd = "2"
 predicates = "3"
+
+[[bin]]
+name = "mcp-compressor"
+path = "src/main.rs"

--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -10,7 +10,7 @@ use crate::server::{BackendServerConfig, ProxyTransformMode};
 
 #[derive(Debug, Parser)]
 #[command(
-    name = "mcp-compressor-core",
+    name = "mcp-compressor",
     about = "Standalone Rust MCP compressor core binary",
     disable_help_subcommand = true
 )]

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -8,7 +8,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 
 fn core_cmd() -> Command {
-    Command::cargo_bin("mcp-compressor-core").unwrap()
+    Command::cargo_bin("mcp-compressor").unwrap()
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn rust_cli_mode_honors_explicit_output_dir() {
 fn rust_cli_mode_manual_flow_generates_script_that_invokes_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let output_dir = tempdir.path().join("generated");
-    let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("mcp-compressor-core"))
+    let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("mcp-compressor"))
         .env("MCP_COMPRESSOR_CLI_OUTPUT_DIR", &output_dir)
         .args([
             "--cli-mode",

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ The CLI is provided by the Rust binary.
 
     ```bash
     cargo build -p mcp-compressor-core --release
-    ./target/release/mcp-compressor-core --help
+    ./target/release/mcp-compressor --help
     ```
 
 === "Python wrapper"

--- a/docs/rust-core-design.md
+++ b/docs/rust-core-design.md
@@ -822,7 +822,7 @@ A local packaging smoke test is:
 
 ```bash
 cargo build -p mcp-compressor-core --release
-MCP_COMPRESSOR_EXIT_AFTER_READY=1 target/release/mcp-compressor-core \
+MCP_COMPRESSOR_EXIT_AFTER_READY=1 target/release/mcp-compressor \
   --cli-mode \
   --server-name alpha \
   --output-dir /tmp/mcp-compressor-bin-smoke \

--- a/python/mcp-compressor/mcp_compressor/cli.py
+++ b/python/mcp-compressor/mcp_compressor/cli.py
@@ -10,12 +10,12 @@ from pathlib import Path
 
 
 def _candidate_binaries() -> list[str]:
-    env_binary = os.environ.get("MCP_COMPRESSOR_CORE_BINARY")
+    env_binary = os.environ.get("MCP_COMPRESSOR_BINARY") or os.environ.get("MCP_COMPRESSOR_CORE_BINARY")
     candidates: list[str] = []
     if env_binary:
         return [env_binary]
-    candidates.append("mcp-compressor-core")
-    repo_binary = Path(__file__).resolve().parents[3] / "target" / "debug" / "mcp-compressor-core"
+    candidates.append("mcp-compressor")
+    repo_binary = Path(__file__).resolve().parents[3] / "target" / "debug" / "mcp-compressor"
     candidates.append(str(repo_binary))
     return candidates
 
@@ -45,8 +45,8 @@ def main(argv: list[str] | None = None) -> int:
             last_error = exc
             continue
     print(
-        "mcp-compressor-core binary was not found. Build it with `cargo build -p mcp-compressor-core` "
-        "or set MCP_COMPRESSOR_CORE_BINARY.",
+        "mcp-compressor binary was not found. Build it with `cargo build -p mcp-compressor-core` "
+        "or set MCP_COMPRESSOR_BINARY.",
         file=sys.stderr,
     )
     if last_error is not None:

--- a/python/mcp-compressor/tests/test_cli.py
+++ b/python/mcp-compressor/tests/test_cli.py
@@ -41,10 +41,10 @@ class StubbornInterruptingProcess(InterruptingProcess):
 
 def test_python_cli_delegates_to_rust_core_binary(tmp_path: Path, monkeypatch) -> None:
     log = tmp_path / "argv.txt"
-    binary = tmp_path / "mcp-compressor-core"
+    binary = tmp_path / "mcp-compressor"
     binary.write_text('#!/bin/sh\nprintf \'%s\\n\' "$@" > "$MCP_COMPRESSOR_TEST_LOG"\nexit 7\n')
     binary.chmod(0o755)
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", str(binary))
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", str(binary))
     monkeypatch.setenv("MCP_COMPRESSOR_TEST_LOG", str(log))
 
     assert main(["--version"]) == 7
@@ -52,19 +52,19 @@ def test_python_cli_delegates_to_rust_core_binary(tmp_path: Path, monkeypatch) -
 
 
 def test_python_cli_reports_missing_rust_core_binary(monkeypatch) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")
     assert main(["--help"]) == 127
 
 
 def test_python_cli_ctrl_c_terminates_child_without_traceback(monkeypatch) -> None:
-    process = InterruptingProcess(["mcp-compressor-core"])
+    process = InterruptingProcess(["mcp-compressor"])
 
     def popen(command: list[str]) -> InterruptingProcess:
         process.command = command
         return process
 
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", "mcp-compressor-core")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", "mcp-compressor")
     monkeypatch.setattr("subprocess.Popen", popen)
 
     assert main(["--cli-mode"]) == 128 + signal.SIGINT
@@ -73,13 +73,13 @@ def test_python_cli_ctrl_c_terminates_child_without_traceback(monkeypatch) -> No
 
 
 def test_python_cli_ctrl_c_kills_stubborn_child(monkeypatch) -> None:
-    process = StubbornInterruptingProcess(["mcp-compressor-core"])
+    process = StubbornInterruptingProcess(["mcp-compressor"])
 
     def popen(command: list[str]) -> StubbornInterruptingProcess:
         process.command = command
         return process
 
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", "mcp-compressor-core")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", "mcp-compressor")
     monkeypatch.setattr("subprocess.Popen", popen)
 
     assert main(["--cli-mode"]) == 128 + signal.SIGINT

--- a/python/mcp-compressor/tests/test_core.py
+++ b/python/mcp-compressor/tests/test_core.py
@@ -82,7 +82,7 @@ def test_native_extension_starts_session_and_invokes_backend() -> None:
 
 
 def test_high_level_compressor_client_exposes_compressed_tools_and_invocation(monkeypatch) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")
     with CompressorClient(
         servers={
@@ -102,7 +102,7 @@ def test_high_level_compressor_client_exposes_compressed_tools_and_invocation(mo
 
 
 def test_high_level_compressor_client_writes_generated_clients(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
     with CompressorClient(
         servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
         compression_level="max",
@@ -155,7 +155,7 @@ def test_high_level_compressor_client_reports_invalid_server_config() -> None:
 
 
 def test_high_level_compressor_client_reports_missing_wrapper(monkeypatch) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")
     with (
         CompressorClient(
@@ -168,7 +168,7 @@ def test_high_level_compressor_client_reports_missing_wrapper(monkeypatch) -> No
 
 
 def test_high_level_compressor_client_lifecycle_is_explicit(monkeypatch) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")
     client = CompressorClient(
         servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
@@ -183,7 +183,7 @@ def test_high_level_compressor_client_lifecycle_is_explicit(monkeypatch) -> None
 
 
 def test_high_level_compressor_client_defaults_single_server_wrapper(monkeypatch) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")
     with CompressorClient(
         servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
@@ -194,7 +194,7 @@ def test_high_level_compressor_client_defaults_single_server_wrapper(monkeypatch
 
 
 def test_high_level_compressor_client_exposes_cli_and_bash_modes(monkeypatch) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")
     with CompressorClient(
         servers={"alpha": {"command": PYTHON, "args": [str(FIXTURES / "alpha_server.py")]}},
@@ -243,7 +243,7 @@ def test_high_level_compressor_client_supports_remote_config_shape() -> None:
 
 
 def test_python_agent_can_start_compressed_multi_server_proxy_without_compressor_subprocess(monkeypatch) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_CORE_BINARY", os.devnull + "-missing")
+    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
     monkeypatch.setenv("PATH", "")
     session = start_compressed_session_from_mcp_config(
         CompressedSessionConfig(compression_level="max"),

--- a/tests/test_atlassian_mcp_real_world.py
+++ b/tests/test_atlassian_mcp_real_world.py
@@ -26,7 +26,7 @@ TOKEN_ENV = "ATLASSIAN_MCP_BASIC_TOKEN"
 SAFE_TOOL = "getAccessibleAtlassianResources"
 SAFE_PYTHON_FUNCTION = "get_accessible_atlassian_resources"
 SAFE_SUBCOMMAND = "get-accessible-atlassian-resources"
-CORE_BIN = ROOT / "target" / "debug" / "mcp-compressor-core"
+CORE_BIN = ROOT / "target" / "debug" / "mcp-compressor"
 
 
 def _token() -> str:

--- a/tests/test_rust_core_normal_mode.py
+++ b/tests/test_rust_core_normal_mode.py
@@ -16,6 +16,8 @@ def rust_core_command(*args: str) -> list[str]:
         "-q",
         "-p",
         "mcp-compressor-core",
+        "--bin",
+        "mcp-compressor",
         "--",
         *args,
     ]

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -218,10 +218,10 @@ function parseClearOAuthArgs(args: string[]): { target?: string; all: boolean } 
 
 function candidateCoreBinaries(): string[] {
   const candidates: string[] = [];
-  if (process.env.MCP_COMPRESSOR_CORE_BINARY) {
-    candidates.push(process.env.MCP_COMPRESSOR_CORE_BINARY);
+  if (process.env.MCP_COMPRESSOR_BINARY) {
+    candidates.push(process.env.MCP_COMPRESSOR_BINARY);
   }
-  candidates.push("mcp-compressor-core");
+  candidates.push("mcp-compressor");
   const here = dirname(fileURLToPath(import.meta.url));
   candidates.push(
     join(
@@ -230,7 +230,7 @@ function candidateCoreBinaries(): string[] {
       "..",
       "target",
       "debug",
-      process.platform === "win32" ? "mcp-compressor-core.exe" : "mcp-compressor-core",
+      process.platform === "win32" ? "mcp-compressor.exe" : "mcp-compressor",
     ),
   );
   candidates.push(
@@ -239,7 +239,7 @@ function candidateCoreBinaries(): string[] {
       "..",
       "target",
       "debug",
-      process.platform === "win32" ? "mcp-compressor-core.exe" : "mcp-compressor-core",
+      process.platform === "win32" ? "mcp-compressor.exe" : "mcp-compressor",
     ),
   );
   return candidates;
@@ -255,7 +255,7 @@ function translateArgsForRust(args: string[]): string[] {
 
 async function runRustCoreCli(args: string[]): Promise<number> {
   for (const binary of candidateCoreBinaries()) {
-    if (binary !== "mcp-compressor-core" && !existsSync(binary)) {
+    if (binary !== "mcp-compressor" && !existsSync(binary)) {
       continue;
     }
     const child = spawn(binary, translateArgsForRust(args), { stdio: "inherit" });
@@ -277,7 +277,7 @@ async function runRustCoreCli(args: string[]): Promise<number> {
     });
   }
   console.error(
-    "mcp-compressor-core binary was not found. Build it with `cargo build -p mcp-compressor-core` or set MCP_COMPRESSOR_CORE_BINARY.",
+    "mcp-compressor binary was not found. Build it with `cargo build -p mcp-compressor-core` or set MCP_COMPRESSOR_BINARY.",
   );
   return 127;
 }

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -101,7 +101,7 @@ async function startRemoteAlphaUpstream(): Promise<{
     root,
     "target",
     "debug",
-    process.platform === "win32" ? "mcp-compressor-core.exe" : "mcp-compressor-core",
+    process.platform === "win32" ? "mcp-compressor.exe" : "mcp-compressor",
   );
   const child = spawn(
     binary,
@@ -305,9 +305,9 @@ describe("Rust native core wrapper", () => {
 
   it("provides a high-level CompressorClient for compressed tools", async () => {
     const previousPath = process.env.PATH;
-    const previousBinary = process.env.MCP_COMPRESSOR_CORE_BINARY;
+    const previousBinary = process.env.MCP_COMPRESSOR_BINARY;
     process.env.PATH = "";
-    process.env.MCP_COMPRESSOR_CORE_BINARY = "definitely-missing-mcp-compressor-core";
+    process.env.MCP_COMPRESSOR_BINARY = "definitely-missing-mcp-compressor";
     try {
       const fixtureDir = join(
         process.cwd(),
@@ -345,9 +345,9 @@ describe("Rust native core wrapper", () => {
         process.env.PATH = previousPath;
       }
       if (previousBinary === undefined) {
-        delete process.env.MCP_COMPRESSOR_CORE_BINARY;
+        delete process.env.MCP_COMPRESSOR_BINARY;
       } else {
-        process.env.MCP_COMPRESSOR_CORE_BINARY = previousBinary;
+        process.env.MCP_COMPRESSOR_BINARY = previousBinary;
       }
     }
   });
@@ -479,9 +479,9 @@ describe("Rust native core wrapper", () => {
 
   it("defaults single-server CompressorClient invocation to that server", async () => {
     const previousPath = process.env.PATH;
-    const previousBinary = process.env.MCP_COMPRESSOR_CORE_BINARY;
+    const previousBinary = process.env.MCP_COMPRESSOR_BINARY;
     process.env.PATH = "";
-    process.env.MCP_COMPRESSOR_CORE_BINARY = "definitely-missing-mcp-compressor-core";
+    process.env.MCP_COMPRESSOR_BINARY = "definitely-missing-mcp-compressor";
     try {
       const fixtureDir = join(
         process.cwd(),
@@ -506,8 +506,8 @@ describe("Rust native core wrapper", () => {
     } finally {
       if (previousPath === undefined) delete process.env.PATH;
       else process.env.PATH = previousPath;
-      if (previousBinary === undefined) delete process.env.MCP_COMPRESSOR_CORE_BINARY;
-      else process.env.MCP_COMPRESSOR_CORE_BINARY = previousBinary;
+      if (previousBinary === undefined) delete process.env.MCP_COMPRESSOR_BINARY;
+      else process.env.MCP_COMPRESSOR_BINARY = previousBinary;
     }
   });
 
@@ -591,9 +591,9 @@ describe("Rust native core wrapper", () => {
 
   it("lets a TypeScript agent start a compressed multi-server proxy without a compressor subprocess", async () => {
     const previousPath = process.env.PATH;
-    const previousBinary = process.env.MCP_COMPRESSOR_CORE_BINARY;
+    const previousBinary = process.env.MCP_COMPRESSOR_BINARY;
     process.env.PATH = "";
-    process.env.MCP_COMPRESSOR_CORE_BINARY = "definitely-missing-mcp-compressor-core";
+    process.env.MCP_COMPRESSOR_BINARY = "definitely-missing-mcp-compressor";
     try {
       const fixtureDir = join(
         process.cwd(),
@@ -635,9 +635,9 @@ describe("Rust native core wrapper", () => {
         process.env.PATH = previousPath;
       }
       if (previousBinary === undefined) {
-        delete process.env.MCP_COMPRESSOR_CORE_BINARY;
+        delete process.env.MCP_COMPRESSOR_BINARY;
       } else {
-        process.env.MCP_COMPRESSOR_CORE_BINARY = previousBinary;
+        process.env.MCP_COMPRESSOR_BINARY = previousBinary;
       }
     }
   });


### PR DESCRIPTION
## Summary
- add a public Rust binary target named `mcp-compressor` while keeping the internal crate package named `mcp-compressor-core`
- update Clap help, artifact workflows, Python CLI wrapper, TypeScript CLI wrapper, and binary tests to use the public binary name
- keep internal cargo package/test fixture paths unchanged where appropriate
- use `MCP_COMPRESSOR_BINARY` as the public wrapper override while retaining legacy fallback compatibility in Python

## Validation
- `cargo build -p mcp-compressor-core`
- `target/debug/mcp-compressor --help`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary -- --nocapture`
- `uv run pytest -q tests/test_rust_core_normal_mode.py`
- `cd python/mcp-compressor && uv run maturin develop && uv run pytest -q tests/test_cli.py`
- `cd typescript && bun run build:native && bun run check`
- parsed workflow YAML locally
- `make check`