### PR TITLE
docs: clarify Code Mode and installation tabs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,15 +1,65 @@
 # Installation
 
-`mcp-compressor` is available as a Rust CLI/core, a Rust-backed Python package, and a Rust-backed TypeScript package.
+`mcp-compressor` ships three public surfaces:
+
+- a CLI named `mcp-compressor`,
+- SDKs for Python, TypeScript, and Rust,
+- generated clients for shell, Python, and TypeScript.
 
 !!! note "Migration branch package names"
-    On the Rust migration branch, the Python package is published separately as `mcp-compressor-rust` until final cutover. The TypeScript package uses `@atlassian/mcp-compressor`.
+    On the Rust migration branch, the Python distribution is still published separately as `mcp-compressor-rust` until final cutover. The public Python import is already `mcp_compressor`.
 
-## CLI
+## Install the SDK
 
-The CLI is provided by the Rust binary.
+=== "Python"
 
-=== "From source"
+    ```bash
+    # Local development from this repository
+    cd python/mcp-compressor
+    uv sync --group dev
+    uv run maturin develop
+    ```
+
+    Then import:
+
+    ```python
+    from mcp_compressor import CompressorClient
+    ```
+
+    The temporary distribution/script name is `mcp-compressor-rust`, but users import `mcp_compressor`.
+
+=== "TypeScript"
+
+    ```bash
+    cd typescript
+    bun install
+    bun run build
+    bun run build:native
+    ```
+
+    Then import:
+
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+    ```
+
+=== "Rust"
+
+    Add the public Rust crate in your workspace:
+
+    ```toml
+    mcp-compressor = { path = "crates/mcp-compressor" }
+    ```
+
+    Then import:
+
+    ```rust
+    use mcp_compressor::sdk::{CompressorClient, ServerConfig};
+    ```
+
+## Install the CLI
+
+=== "Rust binary from source"
 
     ```bash
     cargo build -p mcp-compressor-core --release
@@ -25,6 +75,8 @@ The CLI is provided by the Rust binary.
     uv run mcp-compressor-rust --help
     ```
 
+    The wrapper delegates to the Rust binary. Set `MCP_COMPRESSOR_BINARY` if the binary is not on `PATH`.
+
 === "TypeScript wrapper"
 
     ```bash
@@ -35,45 +87,34 @@ The CLI is provided by the Rust binary.
     bun run mcp-compressor -- --help
     ```
 
-## Python SDK
+    The wrapper also delegates to the Rust binary. Set `MCP_COMPRESSOR_BINARY` to override binary discovery.
 
-```bash
-cd python/mcp-compressor
-uv sync --group dev
-uv run maturin develop
-```
+## Verify installation
 
-Then:
+=== "CLI"
 
-```python
-from mcp_compressor import CompressorClient
-```
+    ```bash
+    mcp-compressor --help
+    ```
 
-## TypeScript SDK
+=== "Python"
 
-```bash
-cd typescript
-bun install
-bun run build
-bun run build:native
-```
+    ```python
+    from mcp_compressor import CompressorClient
 
-Then:
+    assert CompressorClient is not None
+    ```
 
-```ts
-import { CompressorClient } from "@atlassian/mcp-compressor";
-```
+=== "TypeScript"
 
-## Rust SDK
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
 
-Add the core crate in a workspace or path dependency:
+    console.log(typeof CompressorClient);
+    ```
 
-```toml
-mcp-compressor-core = { path = "crates/mcp-compressor-core" }
-```
+=== "Rust"
 
-Use:
-
-```rust
-use mcp_compressor::sdk::CompressorClient;
-```
+    ```bash
+    cargo check -p mcp-compressor
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ The SDK starts the Rust proxy in-process. Generated clients call that proxy usin
 - [Compressed MCP proxy](usage/cli.md#standard-mcp-proxy) for existing MCP clients.
 - [Compression levels](concepts/how-it-works.md#compression-levels): `low`, `medium`, `high`, `max`.
 - [Python, TypeScript, and Rust SDKs](usage/sdks.md) with aligned `CompressorClient` APIs.
-- [Generated shell, Python, and TypeScript clients](usage/generated-clients.md).
+- [CLI Mode and Code Mode generated clients](usage/generated-clients.md): shell commands plus Python/TypeScript functions.
 - [Just Bash integration](usage/just-bash.md) for command-oriented agents.
 - [Remote streamable HTTP MCP backends](usage/auth-and-remote.md).
 - [OAuth support](usage/auth-and-remote.md#native-oauth) for providers that support browser authorization.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,8 +20,8 @@ mcp-compressor --help
 | `--transport <stdio|streamable-http>` | Frontend MCP transport. |
 | `--port <port>` | Port for streamable HTTP frontend. Use `0` for OS-selected. |
 | `--cli-mode` | Generate a shell CLI and run a local proxy. |
-| `--python-mode` | Generate a Python client and run a local proxy. |
-| `--typescript-mode` | Generate a TypeScript client and run a local proxy. |
+| `--python-mode` | Start Python Code Mode: generate a Python client and run a local proxy. |
+| `--typescript-mode` | Start TypeScript Code Mode: generate a TypeScript client and run a local proxy. |
 | `--just-bash-mode` | Expose Just Bash command metadata and run a local proxy. |
 | `--output-dir <path>` | Output directory for generated clients/scripts. |
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -52,13 +52,17 @@ Use an explicit output directory:
 mcp-compressor --cli-mode --server-name alpha --output-dir ./bin -- python server.py
 ```
 
-## Generated Python and TypeScript clients
+## Code Mode
+
+Code Mode generates Python or TypeScript functions for backend MCP tools while keeping the local Rust proxy alive.
 
 ```bash
 mcp-compressor --python-mode --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp
 
 mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp
 ```
+
+See [Code Mode and generated clients](generated-clients.md) for examples of generated functions and agent usage.
 
 ## Just Bash mode
 

--- a/docs/usage/generated-clients.md
+++ b/docs/usage/generated-clients.md
@@ -1,20 +1,24 @@
-# Generated clients
+# Code Mode and generated clients
 
-Generated clients let agents call MCP tools through shell, Python, or TypeScript code while the Rust proxy owns MCP routing and authorization.
+**Code Mode** is the umbrella term for generating Python or TypeScript clients for backend MCP tools.
 
-They are useful when your agent is better at command or code execution than raw MCP tool invocation.
+Instead of asking an agent to choose from a large MCP tool list, Code Mode gives it a small generated module with normal functions. Those functions call a local Rust proxy, which routes the request to the backend MCP server.
 
-## What gets generated?
+CLI Mode is the same idea for shell commands: it generates an executable command-line tool whose subcommands call the same proxy.
 
-- **CLI**: an executable shell script with one subcommand per backend tool.
-- **Python**: a Python module with one function per backend tool.
-- **TypeScript**: an ESM module and `.d.ts` declarations with one function per backend tool.
+## When to use each mode
 
-All generated clients call a live local Rust proxy using a session token. Keep the proxy session alive while generated clients are used.
+| Mode | Generates | Best for |
+|---|---|---|
+| CLI Mode | Shell script with subcommands | Agents that can use bash or terminal tools well. |
+| Python Code Mode | Python module with functions | Python agents or notebooks. |
+| TypeScript Code Mode | ESM module with functions and `.d.ts` declarations | TypeScript/JavaScript agents. |
+
+All generated clients require the proxy session to stay alive while they are used.
 
 ## Generate from the CLI
 
-=== "Shell CLI"
+=== "CLI Mode"
 
     ```bash
     mcp-compressor --cli-mode \
@@ -23,7 +27,13 @@ All generated clients call a live local Rust proxy using a session token. Keep t
       -- https://mcp.atlassian.com/v1/mcp
     ```
 
-=== "Python client"
+    This writes a script such as:
+
+    ```text
+    ./bin/atlassian
+    ```
+
+=== "Python Code Mode"
 
     ```bash
     mcp-compressor --python-mode \
@@ -32,13 +42,26 @@ All generated clients call a live local Rust proxy using a session token. Keep t
       -- https://mcp.atlassian.com/v1/mcp
     ```
 
-=== "TypeScript client"
+    This writes a module such as:
+
+    ```text
+    ./generated-py/atlassian.py
+    ```
+
+=== "TypeScript Code Mode"
 
     ```bash
     mcp-compressor --typescript-mode \
       --server-name atlassian \
       --output-dir ./generated-ts \
       -- https://mcp.atlassian.com/v1/mcp
+    ```
+
+    This writes files such as:
+
+    ```text
+    ./generated-ts/atlassian.ts
+    ./generated-ts/atlassian.d.ts
     ```
 
 The Atlassian examples use OAuth. The first run opens a browser if no stored credentials exist.
@@ -81,27 +104,116 @@ The Atlassian examples use OAuth. The first run opens a browser if no stored cre
     proxy.write_client(GeneratedClientKind::TypeScript, "./generated-ts", Some("atlassian"))?;
     ```
 
-## Example generated CLI usage
+## What the generated clients look like
+
+Assume the backend MCP server exposes tools named:
+
+- `getAccessibleAtlassianResources`
+- `getConfluencePage`
+
+### Generated CLI Mode script
+
+The generated shell script provides help and one subcommand per backend tool:
 
 ```bash
 ./bin/atlassian --help
 ./bin/atlassian get-accessible-atlassian-resources
+./bin/atlassian get-confluence-page --page-id "123456"
 ```
 
-## Example generated Python usage
+The top-level help looks like:
+
+```text
+atlassian - the atlassian toolset
+
+USAGE:
+  atlassian <subcommand> [options]
+
+SUBCOMMANDS:
+  get-accessible-atlassian-resources
+  get-confluence-page
+```
+
+### Generated Python Code Mode module
+
+The generated Python module exposes normal functions:
+
+```python
+# generated-py/atlassian.py
+
+def getAccessibleAtlassianResources() -> str: ...
+
+def getConfluencePage(page_id: str) -> str: ...
+```
+
+Use it from an agent or application:
 
 ```python
 import sys
 sys.path.insert(0, "./generated-py")
 
 import atlassian
+
+resources = atlassian.getAccessibleAtlassianResources()
+page = atlassian.getConfluencePage(page_id="123456")
+```
+
+### Generated TypeScript Code Mode module
+
+The generated TypeScript module exposes typed async functions:
+
+```ts
+// generated-ts/atlassian.ts
+export async function getAccessibleAtlassianResources(): Promise<string>;
+export async function getConfluencePage(pageId: string): Promise<string>;
+```
+
+Use it from an agent or application:
+
+```ts
+import {
+  getAccessibleAtlassianResources,
+  getConfluencePage,
+} from "./generated-ts/atlassian.ts";
+
+const resources = await getAccessibleAtlassianResources();
+const page = await getConfluencePage("123456");
+```
+
+## How an agent might use CLI Mode
+
+A coding agent with shell access can discover commands once:
+
+```bash
+atlassian --help
+atlassian get-confluence-page --help
+```
+
+Then call only the command it needs:
+
+```bash
+atlassian get-confluence-page --page-id "123456"
+```
+
+This avoids placing every MCP tool schema in the model context.
+
+## How an agent might use Code Mode
+
+A Python-capable agent can inspect the generated module or use normal autocomplete/static analysis:
+
+```python
+import atlassian
+
+# Ask for a resource list only when needed.
 print(atlassian.getAccessibleAtlassianResources())
 ```
 
-## Example generated TypeScript usage
+A TypeScript-capable agent can do the same with generated declarations:
 
 ```ts
 import { getAccessibleAtlassianResources } from "./generated-ts/atlassian.ts";
 
 console.log(await getAccessibleAtlassianResources());
 ```
+
+The generated function signatures replace a large MCP tool list with a small language-native API.


### PR DESCRIPTION
## Summary
- reorganize installation instructions with tabs for CLI, Python, TypeScript, and Rust
- introduce Code Mode as the umbrella term for Python and TypeScript generated clients
- add concrete examples of generated Python and TypeScript functions
- add examples showing how agents would use generated CLI commands and Code Mode modules
- update CLI/reference docs to use Code Mode terminology consistently

## Validation
- `make docs-test`
- `make check`