### PR TITLE
feat: add unified Code Mode CLI option

### DIFF
--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -46,12 +46,16 @@ pub struct CliOptions {
     #[arg(long = "just-bash-mode", action = ArgAction::SetTrue)]
     just_bash_mode: bool,
 
-    /// Generate a Python client module that talks to the local proxy.
-    #[arg(long = "python-mode", action = ArgAction::SetTrue)]
+    /// Generate a Python or TypeScript code client that talks to the local proxy.
+    #[arg(long = "code-mode", value_enum, value_name = "LANGUAGE")]
+    code_mode: Option<CodeModeArg>,
+
+    /// Deprecated alias for --code-mode python.
+    #[arg(long = "python-mode", action = ArgAction::SetTrue, hide = true)]
     python_mode: bool,
 
-    /// Generate a TypeScript client module that talks to the local proxy.
-    #[arg(long = "typescript-mode", action = ArgAction::SetTrue)]
+    /// Deprecated alias for --code-mode typescript.
+    #[arg(long = "typescript-mode", action = ArgAction::SetTrue, hide = true)]
     typescript_mode: bool,
 
     /// Comma-separated backend tool names to include.
@@ -88,6 +92,38 @@ pub struct CliOptions {
 }
 
 impl CliOptions {
+    pub fn validate(&self) -> Result<(), String> {
+        let mode_aliases = [
+            self.cli_mode,
+            self.just_bash || self.just_bash_mode,
+            self.code_mode.is_some() || self.python_mode || self.typescript_mode,
+        ]
+        .into_iter()
+        .filter(|enabled| *enabled)
+        .count();
+        if mode_aliases > 1 {
+            return Err(
+                "choose only one of --cli-mode, --just-bash-mode, or --code-mode".to_string(),
+            );
+        }
+
+        let code_mode_aliases = [
+            self.code_mode.is_some(),
+            self.python_mode,
+            self.typescript_mode,
+        ]
+        .into_iter()
+        .filter(|enabled| *enabled)
+        .count();
+        if code_mode_aliases > 1 {
+            return Err(
+                "choose only one code mode: --code-mode python or --code-mode typescript"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+
     pub fn compression(&self) -> CompressionLevel {
         self.compression.into()
     }
@@ -95,7 +131,11 @@ impl CliOptions {
     pub fn transform_mode(&self) -> ProxyTransformMode {
         if self.just_bash || self.just_bash_mode {
             ProxyTransformMode::JustBash
-        } else if self.cli_mode || self.python_mode || self.typescript_mode {
+        } else if self.cli_mode
+            || self.python_mode
+            || self.typescript_mode
+            || self.code_mode.is_some()
+        {
             ProxyTransformMode::Cli
         } else {
             self.transform_mode.into()
@@ -103,6 +143,9 @@ impl CliOptions {
     }
 
     pub fn client_artifact_kind(&self) -> Option<FfiClientArtifactKind> {
+        if let Some(code_mode) = self.code_mode {
+            return Some(code_mode.into());
+        }
         if self.python_mode {
             Some(FfiClientArtifactKind::Python)
         } else if self.typescript_mode {
@@ -189,6 +232,22 @@ impl From<CompressionLevelArg> for CompressionLevel {
             CompressionLevelArg::Medium => CompressionLevel::Medium,
             CompressionLevelArg::High => CompressionLevel::High,
             CompressionLevelArg::Max => CompressionLevel::Max,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CodeModeArg {
+    Python,
+    #[value(name = "typescript")]
+    TypeScript,
+}
+
+impl From<CodeModeArg> for FfiClientArtifactKind {
+    fn from(value: CodeModeArg) -> Self {
+        match value {
+            CodeModeArg::Python => FfiClientArtifactKind::Python,
+            CodeModeArg::TypeScript => FfiClientArtifactKind::TypeScript,
         }
     }
 }

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -37,6 +37,7 @@ fn run() -> Result<(), CliError> {
 }
 
 async fn run_async(cli: CliOptions) -> Result<(), CliError> {
+    cli.validate().map_err(CliError::Usage)?;
     if let Some(command) = &cli.command_kind {
         return run_command(command);
     }

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -125,6 +125,97 @@ fn rust_cli_contract_multi_server_json_config() {
 }
 
 #[test]
+fn rust_cli_code_mode_python_generates_python_client() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let output_dir = tempdir.path().join("generated-py");
+
+    let mut cmd = core_cmd();
+    cmd.env("MCP_COMPRESSOR_EXIT_AFTER_READY", "1")
+        .args([
+            "--code-mode",
+            "python",
+            "--server-name",
+            "alpha",
+            "--output-dir",
+            output_dir.to_str().unwrap(),
+            "--",
+            &common::python_command(),
+            common::fixture_path("alpha_server.py").to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Python code client ready"))
+        .stdout(predicate::str::contains("Generated files:"));
+
+    assert!(output_dir.join("alpha.py").exists());
+}
+
+#[test]
+fn rust_cli_code_mode_typescript_generates_typescript_client() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let output_dir = tempdir.path().join("generated-ts");
+
+    let mut cmd = core_cmd();
+    cmd.env("MCP_COMPRESSOR_EXIT_AFTER_READY", "1")
+        .args([
+            "--code-mode",
+            "typescript",
+            "--server-name",
+            "alpha",
+            "--output-dir",
+            output_dir.to_str().unwrap(),
+            "--",
+            &common::python_command(),
+            common::fixture_path("alpha_server.py").to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("TypeScript code client ready"))
+        .stdout(predicate::str::contains("Generated files:"));
+
+    assert!(output_dir.join("alpha.ts").exists());
+    assert!(output_dir.join("alpha.d.ts").exists());
+}
+
+#[test]
+fn rust_cli_code_mode_rejects_conflicting_mode_aliases() {
+    let mut cmd = core_cmd();
+    cmd.args([
+        "--code-mode",
+        "python",
+        "--typescript-mode",
+        "--server-name",
+        "alpha",
+        "--",
+        &common::python_command(),
+        common::fixture_path("alpha_server.py").to_str().unwrap(),
+    ])
+    .assert()
+    .failure()
+    .code(2)
+    .stderr(predicate::str::contains("choose only one code mode"));
+}
+
+#[test]
+fn rust_cli_code_mode_rejects_conflicting_runtime_modes() {
+    let mut cmd = core_cmd();
+    cmd.args([
+        "--code-mode",
+        "python",
+        "--cli-mode",
+        "--server-name",
+        "alpha",
+        "--",
+        &common::python_command(),
+        common::fixture_path("alpha_server.py").to_str().unwrap(),
+    ])
+    .assert()
+    .failure()
+    .code(2)
+    .stderr(predicate::str::contains("choose only one of --cli-mode"));
+}
+
+#[test]
 fn rust_cli_contract_cli_transform_mode() {
     let mut cmd = core_cmd();
     cmd.env("MCP_COMPRESSOR_EXIT_AFTER_READY", "1");

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,8 +20,10 @@ mcp-compressor --help
 | `--transport <stdio|streamable-http>` | Frontend MCP transport. |
 | `--port <port>` | Port for streamable HTTP frontend. Use `0` for OS-selected. |
 | `--cli-mode` | Generate a shell CLI and run a local proxy. |
-| `--python-mode` | Start Python Code Mode: generate a Python client and run a local proxy. |
-| `--typescript-mode` | Start TypeScript Code Mode: generate a TypeScript client and run a local proxy. |
+| `--code-mode python` | Start Python Code Mode: generate a Python client and run a local proxy. |
+| `--code-mode typescript` | Start TypeScript Code Mode: generate a TypeScript client and run a local proxy. |
+| `--python-mode` | Deprecated alias for `--code-mode python`. |
+| `--typescript-mode` | Deprecated alias for `--code-mode typescript`. |
 | `--just-bash-mode` | Expose Just Bash command metadata and run a local proxy. |
 | `--output-dir <path>` | Output directory for generated clients/scripts. |
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -57,9 +57,9 @@ mcp-compressor --cli-mode --server-name alpha --output-dir ./bin -- python serve
 Code Mode generates Python or TypeScript functions for backend MCP tools while keeping the local Rust proxy alive.
 
 ```bash
-mcp-compressor --python-mode --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp
+mcp-compressor --code-mode python --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp
 
-mcp-compressor --typescript-mode --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp
+mcp-compressor --code-mode typescript --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp
 ```
 
 See [Code Mode and generated clients](generated-clients.md) for examples of generated functions and agent usage.

--- a/docs/usage/generated-clients.md
+++ b/docs/usage/generated-clients.md
@@ -36,7 +36,7 @@ All generated clients require the proxy session to stay alive while they are use
 === "Python Code Mode"
 
     ```bash
-    mcp-compressor --python-mode \
+    mcp-compressor --code-mode python \
       --server-name atlassian \
       --output-dir ./generated-py \
       -- https://mcp.atlassian.com/v1/mcp
@@ -51,7 +51,7 @@ All generated clients require the proxy session to stay alive while they are use
 === "TypeScript Code Mode"
 
     ```bash
-    mcp-compressor --typescript-mode \
+    mcp-compressor --code-mode typescript \
       --server-name atlassian \
       --output-dir ./generated-ts \
       -- https://mcp.atlassian.com/v1/mcp

--- a/tests/test_atlassian_mcp_real_world.py
+++ b/tests/test_atlassian_mcp_real_world.py
@@ -63,7 +63,9 @@ def _wait_http(url: str, token: str, timeout: float = 20.0) -> None:
 
 
 def _start_proxy_mode(
-    *extra_args: str, script_name: str | None = "atlassian"
+    *extra_args: str,
+    script_name: str | None = "atlassian",
+    mode_args: tuple[str, ...] = ("--cli-mode",),
 ) -> tuple[subprocess.Popen[str], str, str, str | None]:
     env = os.environ.copy()
     explicit_output_dir = next(
@@ -74,7 +76,7 @@ def _start_proxy_mode(
     child = subprocess.Popen(
         [
             str(CORE_BIN),
-            "--cli-mode",
+            *mode_args,
             "--server-name",
             "atlassian",
             *extra_args,
@@ -195,13 +197,18 @@ def test_atlassian_cli_mode_creates_usable_cli() -> None:
         _stop(child)
 
 
-@pytest.mark.parametrize(("flag", "expected"), [("--python-mode", ".py"), ("--typescript-mode", ".ts")])
-def test_atlassian_code_modes_generate_clients(flag: str, expected: str) -> None:
+@pytest.mark.parametrize(("language", "expected"), [("python", ".py"), ("typescript", ".ts")])
+def test_atlassian_code_modes_generate_clients(language: str, expected: str) -> None:
     output_dir = tempfile.mkdtemp(prefix="mcp-compressor-code-")
-    child, _script_dir, _bridge, _token_value = _start_proxy_mode(flag, "--output-dir", output_dir, script_name=None)
+    child, _script_dir, _bridge, _token_value = _start_proxy_mode(
+        "--output-dir",
+        output_dir,
+        script_name=None,
+        mode_args=("--code-mode", language),
+    )
     try:
         assert any(path.suffix == expected for path in Path(output_dir).iterdir())
-        if flag == "--python-mode":
+        if language == "python":
             result = subprocess.run(
                 [
                     sys.executable,


### PR DESCRIPTION
## Summary
- add `--code-mode <python|typescript>` as the preferred CLI option for Code Mode
- keep `--python-mode` and `--typescript-mode` as hidden compatibility aliases
- add validation for conflicting runtime/code mode flags
- add CLI tests for Python and TypeScript Code Mode generation and conflict errors
- update docs to prefer `--code-mode python` and `--code-mode typescript`

## Validation
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary rust_cli_code_mode -- --nocapture`
- `cargo check -p mcp-compressor-core`
- `make docs-test`
- `make check`