### PR TITLE
feat: close P0 CLI parity gaps

### DIFF
--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -12,7 +12,8 @@ use crate::server::{BackendServerConfig, ProxyTransformMode};
     name = "mcp-compressor",
     about = "Standalone Rust MCP compressor core binary",
     disable_help_subcommand = true,
-    version
+    version,
+    override_usage = "mcp-compressor [OPTIONS] [COMMAND] -- <URL_OR_COMMAND> [BACKEND_ARGS]..."
 )]
 pub struct CliOptions {
     #[command(subcommand)]
@@ -86,8 +87,8 @@ pub struct CliOptions {
     #[arg(long, default_value_t = 8000)]
     pub port: u16,
 
-    /// Backend command, URL, and arguments. All backend server arguments belong after `--`.
-    #[arg(value_name = "COMMAND", allow_hyphen_values = true, last = true)]
+    /// Backend URL or command plus backend arguments. All backend server arguments belong after `--`.
+    #[arg(value_name = "URL_OR_COMMAND", allow_hyphen_values = true, last = true)]
     pub command: Vec<String>,
 }
 

--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::ffi::FfiClientArtifactKind;
 use std::str::FromStr;
@@ -12,7 +13,8 @@ use crate::server::{BackendServerConfig, ProxyTransformMode};
 #[command(
     name = "mcp-compressor",
     about = "Standalone Rust MCP compressor core binary",
-    disable_help_subcommand = true
+    disable_help_subcommand = true,
+    version
 )]
 pub struct CliOptions {
     #[command(subcommand)]
@@ -27,8 +29,20 @@ pub struct CliOptions {
     pub config_path: Option<PathBuf>,
 
     /// Frontend server name/prefix.
-    #[arg(long)]
+    #[arg(short = 'n', long)]
     pub server_name: Option<String>,
+
+    /// Working directory for stdio backend commands.
+    #[arg(long = "cwd")]
+    pub cwd: Option<PathBuf>,
+
+    /// Environment variables for stdio backend commands, in KEY=VALUE form. Repeatable.
+    #[arg(short = 'e', long = "env", value_name = "KEY=VALUE", action = ArgAction::Append)]
+    pub env: Vec<EnvArg>,
+
+    /// Backend connect/request timeout in seconds.
+    #[arg(short = 't', long = "timeout")]
+    pub timeout: Option<f64>,
 
     /// Frontend transform mode.
     #[arg(long, value_enum, default_value = "compressed-tools")]
@@ -121,6 +135,11 @@ impl CliOptions {
                     .to_string(),
             );
         }
+        if let Some(timeout) = self.timeout {
+            if !timeout.is_finite() || timeout <= 0.0 {
+                return Err("--timeout must be a positive number of seconds".to_string());
+            }
+        }
         Ok(())
     }
 
@@ -140,6 +159,30 @@ impl CliOptions {
         } else {
             self.transform_mode.into()
         }
+    }
+
+    pub fn backend_env(&self) -> Vec<(String, String)> {
+        self.env
+            .iter()
+            .map(|env| (env.key.clone(), env.value.clone()))
+            .collect()
+    }
+
+    pub fn backend_timeout(&self) -> Option<Duration> {
+        self.timeout.map(Duration::from_secs_f64)
+    }
+
+    pub fn apply_backend_options(&self, mut backend: BackendServerConfig) -> BackendServerConfig {
+        if !self.env.is_empty() {
+            backend = backend.with_env(self.backend_env());
+        }
+        if let Some(cwd) = &self.cwd {
+            backend = backend.with_cwd(cwd.clone());
+        }
+        if let Some(timeout) = self.backend_timeout() {
+            backend = backend.with_timeout(timeout);
+        }
+        backend
     }
 
     pub fn client_artifact_kind(&self) -> Option<FfiClientArtifactKind> {
@@ -174,10 +217,37 @@ impl CliCommand {
 }
 
 #[derive(Debug, Clone)]
+pub struct EnvArg {
+    key: String,
+    value: String,
+}
+
+impl FromStr for EnvArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (key, raw_value) = value
+            .split_once('=')
+            .filter(|(key, _)| !key.is_empty())
+            .ok_or_else(|| "expected KEY=VALUE".to_string())?;
+        Ok(Self {
+            key: key.to_string(),
+            value: raw_value.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct MultiServerArg {
     name: String,
     command: String,
     args: Vec<String>,
+}
+
+impl MultiServerArg {
+    pub fn into_backend(self) -> BackendServerConfig {
+        BackendServerConfig::new(self.name, self.command, self.args)
+    }
 }
 
 impl FromStr for MultiServerArg {
@@ -197,12 +267,6 @@ impl FromStr for MultiServerArg {
             command: command.to_string(),
             args: parts.map(ToString::to_string).collect(),
         })
-    }
-}
-
-impl From<MultiServerArg> for BackendServerConfig {
-    fn from(value: MultiServerArg) -> Self {
-        BackendServerConfig::new(value.name, value.command, value.args)
     }
 }
 

--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -1,6 +1,4 @@
 use std::path::PathBuf;
-use std::time::Duration;
-
 use crate::ffi::FfiClientArtifactKind;
 use std::str::FromStr;
 
@@ -31,18 +29,6 @@ pub struct CliOptions {
     /// Frontend server name/prefix.
     #[arg(short = 'n', long)]
     pub server_name: Option<String>,
-
-    /// Working directory for stdio backend commands.
-    #[arg(long = "cwd")]
-    pub cwd: Option<PathBuf>,
-
-    /// Environment variables for stdio backend commands, in KEY=VALUE form. Repeatable.
-    #[arg(short = 'e', long = "env", value_name = "KEY=VALUE", action = ArgAction::Append)]
-    pub env: Vec<EnvArg>,
-
-    /// Backend connect/request timeout in seconds.
-    #[arg(short = 't', long = "timeout")]
-    pub timeout: Option<f64>,
 
     /// Frontend transform mode.
     #[arg(long, value_enum, default_value = "compressed-tools")]
@@ -135,11 +121,6 @@ impl CliOptions {
                     .to_string(),
             );
         }
-        if let Some(timeout) = self.timeout {
-            if !timeout.is_finite() || timeout <= 0.0 {
-                return Err("--timeout must be a positive number of seconds".to_string());
-            }
-        }
         Ok(())
     }
 
@@ -159,30 +140,6 @@ impl CliOptions {
         } else {
             self.transform_mode.into()
         }
-    }
-
-    pub fn backend_env(&self) -> Vec<(String, String)> {
-        self.env
-            .iter()
-            .map(|env| (env.key.clone(), env.value.clone()))
-            .collect()
-    }
-
-    pub fn backend_timeout(&self) -> Option<Duration> {
-        self.timeout.map(Duration::from_secs_f64)
-    }
-
-    pub fn apply_backend_options(&self, mut backend: BackendServerConfig) -> BackendServerConfig {
-        if !self.env.is_empty() {
-            backend = backend.with_env(self.backend_env());
-        }
-        if let Some(cwd) = &self.cwd {
-            backend = backend.with_cwd(cwd.clone());
-        }
-        if let Some(timeout) = self.backend_timeout() {
-            backend = backend.with_timeout(timeout);
-        }
-        backend
     }
 
     pub fn client_artifact_kind(&self) -> Option<FfiClientArtifactKind> {
@@ -213,27 +170,6 @@ impl CliCommand {
         match self {
             Self::ClearOauth { target } => target.as_deref(),
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct EnvArg {
-    key: String,
-    value: String,
-}
-
-impl FromStr for EnvArg {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let (key, raw_value) = value
-            .split_once('=')
-            .filter(|(key, _)| !key.is_empty())
-            .ok_or_else(|| "expected KEY=VALUE".to_string())?;
-        Ok(Self {
-            key: key.to_string(),
-            value: raw_value.to_string(),
-        })
     }
 }
 

--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -189,6 +189,7 @@ struct ToolOption {
     required: bool,
     description: Option<String>,
     default: Option<String>,
+    enum_values: Vec<String>,
 }
 
 fn tool_options(tool: &crate::compression::engine::Tool) -> Vec<ToolOption> {
@@ -219,6 +220,11 @@ fn tool_options(tool: &crate::compression::engine::Tool) -> Vec<ToolOption> {
                         .and_then(|value| value.as_str())
                         .map(str::to_string),
                     default: schema.get("default").map(default_value_label),
+                    enum_values: schema
+                        .get("enum")
+                        .and_then(|value| value.as_array())
+                        .map(|values| values.iter().map(default_value_label).collect())
+                        .unwrap_or_default(),
                 })
                 .collect()
         })
@@ -236,6 +242,9 @@ fn format_tool_option_help(option: &ToolOption) -> String {
     let mut details = Vec::new();
     if let Some(description) = &option.description {
         details.push(first_line(description).to_string());
+    }
+    if !option.enum_values.is_empty() {
+        details.push(format!("values: {}", option.enum_values.join(", ")));
     }
     if let Some(default) = &option.default {
         details.push(format!("default: {default}"));
@@ -460,6 +469,8 @@ mod tests {
         assert!(content.contains("<string>  required — URL to fetch."));
         assert!(content.contains("--timeout"));
         assert!(content.contains("<integer>  optional — Timeout in seconds.; default: 30"));
+        assert!(content.contains("--method"));
+        assert!(content.contains("values: GET, POST"));
     }
 
     /// On Unix the generated script is executable.

--- a/crates/mcp-compressor-core/src/client_gen/generator.rs
+++ b/crates/mcp-compressor-core/src/client_gen/generator.rs
@@ -72,6 +72,12 @@ pub mod test_helpers {
                                 "type": "integer",
                                 "description": "Timeout in seconds.",
                                 "default": 30
+                            },
+                            "method": {
+                                "type": "string",
+                                "description": "HTTP method to use.",
+                                "enum": ["GET", "POST"],
+                                "default": "GET"
                             }
                         },
                         "required": ["url"]

--- a/crates/mcp-compressor-core/src/compression/engine.rs
+++ b/crates/mcp-compressor-core/src/compression/engine.rs
@@ -145,8 +145,17 @@ fn format_args(tool: &Tool) -> String {
 }
 
 fn first_sentence_description(tool: &Tool) -> Option<&str> {
-    let description = tool.description.as_deref()?;
-    let first_line = description.lines().next().unwrap_or_default();
+    let description = tool.description.as_deref()?.trim();
+    let first_paragraph = description
+        .split("\n\n")
+        .map(str::trim)
+        .find(|paragraph| !paragraph.is_empty())
+        .unwrap_or(description);
+    let first_line = first_paragraph
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or(first_paragraph);
     Some(first_line.split('.').next().unwrap_or_default().trim())
 }
 
@@ -263,6 +272,22 @@ mod tests {
         let out = engine.format_tool(&multiline_tool());
         // "First line description.\nSecond line..." → first line → before "." → "First line description"
         assert_eq!(out, "<tool>multiline(x): First line description</tool>");
+    }
+
+    #[test]
+    fn format_tool_low_and_medium_differ_for_paragraph_descriptions() {
+        let tool = Tool::new(
+            "search",
+            Some("\n\nSearch the web.\n\nLonger details that should only appear at low verbosity.".to_string()),
+            json!({}),
+        );
+        let low = CompressionEngine::new(CompressionLevel::Low);
+        let medium = CompressionEngine::new(CompressionLevel::Medium);
+
+        assert!(low
+            .format_tool(&tool)
+            .contains("Longer details that should only appear at low verbosity"));
+        assert_eq!(medium.format_tool(&tool), "<tool>search(): Search the web</tool>");
     }
 
     /// At Medium, a tool with no description renders without a description suffix.

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -82,7 +82,6 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
                     .iter()
                     .cloned()
                     .map(MultiServerArg::into_backend)
-                    .map(|backend| cli.apply_backend_options(backend))
                     .collect(),
             )
             .await
@@ -98,11 +97,7 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
             .unwrap_or_else(|| "server".to_string());
         CompressedServer::connect_stdio(
             config,
-            cli.apply_backend_options(BackendServerConfig::new(
-                backend_name,
-                command.clone(),
-                args.to_vec(),
-            )),
+            BackendServerConfig::new(backend_name, command.clone(), args.to_vec()),
         )
         .await
         .map_err(|error| CliError::Runtime(error.to_string()))

--- a/crates/mcp-compressor-core/src/main.rs
+++ b/crates/mcp-compressor-core/src/main.rs
@@ -3,10 +3,8 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use mcp_compressor_core::app::options::{CliCommand, CliOptions};
-use mcp_compressor_core::app::runtime::{
-    run_cli_mode, run_compressed_server, run_just_bash_mode,
-};
+use mcp_compressor_core::app::options::{CliCommand, CliOptions, MultiServerArg};
+use mcp_compressor_core::app::runtime::{run_cli_mode, run_compressed_server, run_just_bash_mode};
 use mcp_compressor_core::oauth::clear_oauth_store;
 use mcp_compressor_core::server::{
     BackendConfigSource, BackendServerConfig, CompressedServer, CompressedServerConfig,
@@ -80,7 +78,12 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
         if !cli.multi_server.is_empty() {
             return CompressedServer::connect_multi_stdio(
                 config,
-                cli.multi_server.iter().cloned().map(Into::into).collect(),
+                cli.multi_server
+                    .iter()
+                    .cloned()
+                    .map(MultiServerArg::into_backend)
+                    .map(|backend| cli.apply_backend_options(backend))
+                    .collect(),
             )
             .await
             .map_err(|error| CliError::Runtime(error.to_string()));
@@ -95,7 +98,11 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
             .unwrap_or_else(|| "server".to_string());
         CompressedServer::connect_stdio(
             config,
-            BackendServerConfig::new(backend_name, command.clone(), args.to_vec()),
+            cli.apply_backend_options(BackendServerConfig::new(
+                backend_name,
+                command.clone(),
+                args.to_vec(),
+            )),
         )
         .await
         .map_err(|error| CliError::Runtime(error.to_string()))

--- a/crates/mcp-compressor-core/src/server/backend.rs
+++ b/crates/mcp-compressor-core/src/server/backend.rs
@@ -28,6 +28,12 @@ pub enum BackendAuthMode {
     OAuth,
 }
 
+impl Default for BackendAuthMode {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
 /// Configuration for one upstream MCP server.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackendServerConfig {
@@ -55,21 +61,17 @@ impl BackendServerConfig {
             BackendTransport::Stdio
         };
         let raw_args = args.into_iter().map(Into::into).collect::<Vec<_>>();
-        let (args, headers, auth_mode) = if transport == BackendTransport::StreamableHttp {
-            parse_http_backend_args(raw_args)
-        } else {
-            (raw_args, HashMap::new(), BackendAuthMode::Auto)
-        };
+        let parsed_args = parse_backend_args(raw_args, transport);
         Self {
             name: name.into(),
             command,
-            args,
-            env: HashMap::new(),
-            cwd: None,
-            timeout: None,
+            args: parsed_args.args,
+            env: parsed_args.env,
+            cwd: parsed_args.cwd,
+            timeout: parsed_args.timeout,
             transport,
-            headers,
-            auth_mode,
+            headers: parsed_args.headers,
+            auth_mode: parsed_args.auth_mode,
         }
     }
 
@@ -141,74 +143,155 @@ pub fn backend_http_headers(
         .collect()
 }
 
-fn parse_http_backend_args(
+#[derive(Debug, Default)]
+struct ParsedBackendArgs {
     args: Vec<String>,
-) -> (Vec<String>, HashMap<String, String>, BackendAuthMode) {
-    let mut remaining = Vec::new();
-    let mut headers = HashMap::new();
-    let mut auth_mode = BackendAuthMode::Auto;
+    env: HashMap<String, String>,
+    cwd: Option<PathBuf>,
+    timeout: Option<Duration>,
+    headers: HashMap<String, String>,
+    auth_mode: BackendAuthMode,
+}
+
+fn parse_backend_args(args: Vec<String>, transport: BackendTransport) -> ParsedBackendArgs {
+    let mut parsed = ParsedBackendArgs {
+        auth_mode: BackendAuthMode::Auto,
+        ..Default::default()
+    };
     let mut index = 0;
     while index < args.len() {
         let arg = &args[index];
         if arg == "-H" || arg == "--header" {
             if let Some(header) = args.get(index + 1) {
-                if let Some((name, value)) = parse_header_arg(header) {
-                    headers.insert(name, value);
+                if transport == BackendTransport::StreamableHttp {
+                    if let Some((name, value)) = parse_header_arg(header) {
+                        parsed.headers.insert(name, value);
+                    } else {
+                        parsed.args.push(arg.clone());
+                        parsed.args.push(header.clone());
+                    }
                 } else {
-                    remaining.push(arg.clone());
-                    remaining.push(header.clone());
+                    parsed.args.push(arg.clone());
+                    parsed.args.push(header.clone());
                 }
                 index += 2;
             } else {
-                remaining.push(arg.clone());
-                index += 1;
-            }
-        } else if let Some(mode) = arg.strip_prefix("--auth=") {
-            match mode {
-                "explicit-headers" | "headers" | "none" => {
-                    auth_mode = BackendAuthMode::ExplicitHeaders;
-                }
-                "oauth" => {
-                    auth_mode = BackendAuthMode::OAuth;
-                }
-                _ => remaining.push(arg.clone()),
-            }
-            index += 1;
-        } else if arg == "--auth" {
-            if let Some(mode) = args.get(index + 1) {
-                match mode.as_str() {
-                    "explicit-headers" | "headers" | "none" => {
-                        auth_mode = BackendAuthMode::ExplicitHeaders;
-                    }
-                    "oauth" => {
-                        auth_mode = BackendAuthMode::OAuth;
-                    }
-                    _ => {
-                        remaining.push(arg.clone());
-                        remaining.push(mode.clone());
-                    }
-                }
-                index += 2;
-            } else {
-                remaining.push(arg.clone());
+                parsed.args.push(arg.clone());
                 index += 1;
             }
         } else if let Some(header) = arg
             .strip_prefix("-H=")
             .or_else(|| arg.strip_prefix("--header="))
         {
-            if let Some((name, value)) = parse_header_arg(header) {
-                headers.insert(name, value);
+            if transport == BackendTransport::StreamableHttp {
+                if let Some((name, value)) = parse_header_arg(header) {
+                    parsed.headers.insert(name, value);
+                } else {
+                    parsed.args.push(arg.clone());
+                }
             } else {
-                remaining.push(arg.clone());
+                parsed.args.push(arg.clone());
             }
             index += 1;
+        } else if let Some(cwd) = arg.strip_prefix("--cwd=") {
+            parsed.cwd = Some(PathBuf::from(cwd));
+            index += 1;
+        } else if arg == "--cwd" {
+            if let Some(cwd) = args.get(index + 1) {
+                parsed.cwd = Some(PathBuf::from(cwd));
+                index += 2;
+            } else {
+                parsed.args.push(arg.clone());
+                index += 1;
+            }
+        } else if arg == "-e" || arg == "--env" {
+            if let Some(env) = args.get(index + 1) {
+                if let Some((key, value)) = parse_key_value_arg(env) {
+                    parsed.env.insert(key, interpolate_env(&value));
+                } else {
+                    parsed.args.push(arg.clone());
+                    parsed.args.push(env.clone());
+                }
+                index += 2;
+            } else {
+                parsed.args.push(arg.clone());
+                index += 1;
+            }
+        } else if let Some(env) = arg.strip_prefix("-e=").or_else(|| arg.strip_prefix("--env=")) {
+            if let Some((key, value)) = parse_key_value_arg(env) {
+                parsed.env.insert(key, interpolate_env(&value));
+            } else {
+                parsed.args.push(arg.clone());
+            }
+            index += 1;
+        } else if arg == "-t" || arg == "--timeout" {
+            if let Some(timeout) = args.get(index + 1) {
+                if let Ok(seconds) = timeout.parse::<f64>() {
+                    if seconds.is_finite() && seconds > 0.0 {
+                        parsed.timeout = Some(Duration::from_secs_f64(seconds));
+                    } else {
+                        parsed.args.push(arg.clone());
+                        parsed.args.push(timeout.clone());
+                    }
+                } else {
+                    parsed.args.push(arg.clone());
+                    parsed.args.push(timeout.clone());
+                }
+                index += 2;
+            } else {
+                parsed.args.push(arg.clone());
+                index += 1;
+            }
+        } else if let Some(timeout) = arg
+            .strip_prefix("-t=")
+            .or_else(|| arg.strip_prefix("--timeout="))
+        {
+            if let Ok(seconds) = timeout.parse::<f64>() {
+                if seconds.is_finite() && seconds > 0.0 {
+                    parsed.timeout = Some(Duration::from_secs_f64(seconds));
+                } else {
+                    parsed.args.push(arg.clone());
+                }
+            } else {
+                parsed.args.push(arg.clone());
+            }
+            index += 1;
+        } else if let Some(mode) = arg.strip_prefix("--auth=") {
+            match mode {
+                "explicit-headers" | "headers" | "none" => {
+                    parsed.auth_mode = BackendAuthMode::ExplicitHeaders;
+                }
+                "oauth" => {
+                    parsed.auth_mode = BackendAuthMode::OAuth;
+                }
+                _ => parsed.args.push(arg.clone()),
+            }
+            index += 1;
+        } else if arg == "--auth" {
+            if let Some(mode) = args.get(index + 1) {
+                match mode.as_str() {
+                    "explicit-headers" | "headers" | "none" => {
+                        parsed.auth_mode = BackendAuthMode::ExplicitHeaders;
+                    }
+                    "oauth" => {
+                        parsed.auth_mode = BackendAuthMode::OAuth;
+                    }
+                    _ => {
+                        parsed.args.push(arg.clone());
+                        parsed.args.push(mode.clone());
+                    }
+                }
+                index += 2;
+            } else {
+                parsed.args.push(arg.clone());
+                index += 1;
+            }
         } else {
-            remaining.push(arg.clone());
+            parsed.args.push(arg.clone());
             index += 1;
         }
     }
-    (remaining, headers, auth_mode)
+    parsed
 }
 
 fn parse_header_arg(header: &str) -> Option<(String, String)> {
@@ -219,6 +302,15 @@ fn parse_header_arg(header: &str) -> Option<(String, String)> {
         return None;
     }
     Some((name.to_string(), interpolate_env(value)))
+}
+
+fn parse_key_value_arg(value: &str) -> Option<(String, String)> {
+    let (key, value) = value.split_once('=')?;
+    let key = key.trim();
+    if key.is_empty() {
+        return None;
+    }
+    Some((key.to_string(), value.to_string()))
 }
 
 fn interpolate_env(value: &str) -> String {
@@ -357,14 +449,46 @@ mod tests {
     }
 
     #[test]
+    fn backend_args_parse_cwd_env_and_timeout_after_separator() {
+        let backend = BackendServerConfig::new(
+            "local",
+            "python",
+            [
+                "server.py",
+                "--cwd",
+                "/tmp/example",
+                "-e",
+                "FOO=bar",
+                "--env=EMPTY=",
+                "-t",
+                "2.5",
+            ],
+        );
+
+        assert_eq!(backend.args, ["server.py"]);
+        assert_eq!(backend.cwd.as_deref(), Some(std::path::Path::new("/tmp/example")));
+        assert_eq!(backend.env["FOO"], "bar");
+        assert_eq!(backend.env["EMPTY"], "");
+        assert_eq!(backend.timeout, Some(Duration::from_secs_f64(2.5)));
+    }
+
+    #[test]
+    fn backend_args_preserve_invalid_timeout_for_backend_validation() {
+        let backend = BackendServerConfig::new("local", "python", ["server.py", "--timeout", "0"]);
+
+        assert_eq!(backend.args, ["server.py", "--timeout", "0"]);
+        assert_eq!(backend.timeout, None);
+    }
+
+    #[test]
     fn http_backend_url_preserves_unrecognized_args_for_validation() {
         let backend = BackendServerConfig::new(
             "remote",
             "https://example.test/mcp",
-            ["--timeout", "30", "-H"],
+            ["--unknown", "value", "-H"],
         );
 
-        assert_eq!(backend.args, ["--timeout", "30", "-H"]);
+        assert_eq!(backend.args, ["--unknown", "value", "-H"]);
         assert!(backend.headers.is_empty());
     }
 }

--- a/crates/mcp-compressor-core/src/server/backend.rs
+++ b/crates/mcp-compressor-core/src/server/backend.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::str::FromStr;
+use std::time::Duration;
 
 use axum::http::{HeaderName, HeaderValue};
 
@@ -33,6 +35,8 @@ pub struct BackendServerConfig {
     pub command: String,
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
+    pub cwd: Option<PathBuf>,
+    pub timeout: Option<Duration>,
     pub transport: BackendTransport,
     pub headers: HashMap<String, String>,
     pub auth_mode: BackendAuthMode,
@@ -61,6 +65,8 @@ impl BackendServerConfig {
             command,
             args,
             env: HashMap::new(),
+            cwd: None,
+            timeout: None,
             transport,
             headers,
             auth_mode,
@@ -72,6 +78,16 @@ impl BackendServerConfig {
         env: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> Self {
         self.env = env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
         self
     }
 

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -189,11 +189,11 @@ impl CompressedServer {
             let prefix = self.wrapper_prefix(backend);
             tools.push(wrapper_tool(
                 format!("{prefix}get_tool_schema"),
-                "Return the full schema for a backend tool.",
+                &self.get_tool_schema_description(backend),
             ));
             tools.push(wrapper_tool(
                 format!("{prefix}invoke_tool"),
-                "Invoke a backend tool by name.",
+                &self.invoke_tool_description(backend),
             ));
             if self.config.level == CompressionLevel::Max {
                 tools.push(wrapper_tool(
@@ -203,6 +203,39 @@ impl CompressedServer {
             }
         }
         Ok(tools)
+    }
+
+    fn get_tool_schema_description(&self, backend: &ConnectedBackend) -> String {
+        format!(
+            "Get the input schema for a specific tool from the {} toolset.\n\nAvailable tools are:\n{}",
+            backend.public_name,
+            self.frontend_tool_listing(backend)
+        )
+    }
+
+    fn invoke_tool_description(&self, backend: &ConnectedBackend) -> String {
+        format!(
+            "Invoke a tool from the {} toolset. Use get_tool_schema first when you need the full input schema.",
+            backend.public_name
+        )
+    }
+
+    fn frontend_tool_listing(&self, backend: &ConnectedBackend) -> String {
+        let listing = self.engine().format_listing(&backend.tools);
+        if listing.is_empty() {
+            backend
+                .tools
+                .iter()
+                .map(|tool| format!("<tool>{}</tool>", tool.name))
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            listing
+        }
+    }
+
+    fn engine(&self) -> crate::compression::engine::CompressionEngine {
+        crate::compression::engine::CompressionEngine::new(self.config.level.clone())
     }
 
     /// Return the default backend server name when a single unambiguous default exists.

--- a/crates/mcp-compressor-core/src/server/connect.rs
+++ b/crates/mcp-compressor-core/src/server/connect.rs
@@ -78,6 +78,9 @@ async fn connect_stdio_backend(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped());
     command.stderr(Stdio::inherit());
+    if let Some(cwd) = &backend.cwd {
+        command.current_dir(cwd);
+    }
     for (key, value) in &backend.env {
         command.env(key, value);
     }

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -17,6 +17,8 @@ fn rust_cli_help_describes_supported_modes() {
     cmd.arg("--help")
         .assert()
         .success()
+        .stdout(predicate::str::contains("<URL_OR_COMMAND>"))
+        .stdout(predicate::str::contains("Backend URL or command plus backend arguments"))
         .stdout(predicate::str::contains("--compression <COMPRESSION>"))
         .stdout(predicate::str::contains("--config <CONFIG_PATH>"))
         .stdout(predicate::str::contains(
@@ -222,22 +224,6 @@ fn rust_cli_supports_version_flag() {
         .assert()
         .success()
         .stdout(predicate::str::contains("mcp-compressor"));
-}
-
-#[test]
-fn rust_cli_rejects_invalid_timeout() {
-    let mut cmd = core_cmd();
-    cmd.args([
-        "--",
-        &common::python_command(),
-        common::fixture_path("alpha_server.py").to_str().unwrap(),
-        "--timeout",
-        "0",
-    ])
-    .assert()
-    .failure()
-    .code(2)
-    .stderr(predicate::str::contains("unexpected argument '--timeout'"));
 }
 
 #[test]

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -216,6 +216,56 @@ fn rust_cli_code_mode_rejects_conflicting_runtime_modes() {
 }
 
 #[test]
+fn rust_cli_supports_version_flag() {
+    let mut cmd = core_cmd();
+    cmd.arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("mcp-compressor"));
+}
+
+#[test]
+fn rust_cli_rejects_invalid_timeout() {
+    let mut cmd = core_cmd();
+    cmd.args([
+        "--timeout",
+        "0",
+        "--",
+        &common::python_command(),
+        common::fixture_path("alpha_server.py").to_str().unwrap(),
+    ])
+    .assert()
+    .failure()
+    .code(2)
+    .stderr(predicate::str::contains("--timeout must be a positive"));
+}
+
+#[test]
+fn rust_cli_applies_cwd_and_env_to_backend() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let output_dir = tempdir.path().join("bin");
+    let mut cmd = core_cmd();
+    cmd.env("MCP_COMPRESSOR_EXIT_AFTER_READY", "1")
+        .args([
+            "--cli-mode",
+            "--server-name",
+            "alpha",
+            "--cwd",
+            tempdir.path().to_str().unwrap(),
+            "--env",
+            "MCP_COMPRESSOR_TEST_ENV=enabled",
+            "--output-dir",
+            output_dir.to_str().unwrap(),
+            "--",
+            &common::python_command(),
+            common::fixture_path("alpha_server.py").to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("CLI ready"));
+}
+
+#[test]
 fn rust_cli_contract_cli_transform_mode() {
     let mut cmd = core_cmd();
     cmd.env("MCP_COMPRESSOR_EXIT_AFTER_READY", "1");

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -228,8 +228,24 @@ fn rust_cli_supports_version_flag() {
 fn rust_cli_rejects_invalid_timeout() {
     let mut cmd = core_cmd();
     cmd.args([
+        "--",
+        &common::python_command(),
+        common::fixture_path("alpha_server.py").to_str().unwrap(),
         "--timeout",
         "0",
+    ])
+    .assert()
+    .failure()
+    .code(2)
+    .stderr(predicate::str::contains("unexpected argument '--timeout'"));
+}
+
+#[test]
+fn rust_cli_rejects_backend_options_before_separator() {
+    let mut cmd = core_cmd();
+    cmd.args([
+        "--cwd",
+        "/tmp",
         "--",
         &common::python_command(),
         common::fixture_path("alpha_server.py").to_str().unwrap(),
@@ -237,7 +253,7 @@ fn rust_cli_rejects_invalid_timeout() {
     .assert()
     .failure()
     .code(2)
-    .stderr(predicate::str::contains("--timeout must be a positive"));
+    .stderr(predicate::str::contains("unexpected argument '--cwd'"));
 }
 
 #[test]
@@ -250,15 +266,15 @@ fn rust_cli_applies_cwd_and_env_to_backend() {
             "--cli-mode",
             "--server-name",
             "alpha",
-            "--cwd",
-            tempdir.path().to_str().unwrap(),
-            "--env",
-            "MCP_COMPRESSOR_TEST_ENV=enabled",
             "--output-dir",
             output_dir.to_str().unwrap(),
             "--",
             &common::python_command(),
             common::fixture_path("alpha_server.py").to_str().unwrap(),
+            "--cwd",
+            tempdir.path().to_str().unwrap(),
+            "--env",
+            "MCP_COMPRESSOR_TEST_ENV=enabled",
         ])
         .assert()
         .success()

--- a/crates/mcp-compressor-core/tests/compression_levels.rs
+++ b/crates/mcp-compressor-core/tests/compression_levels.rs
@@ -5,7 +5,11 @@ use mcp_compressor_core::server::{BackendConfigSource, CompressedServer, ProxyTr
 
 #[tokio::test]
 async fn low_medium_and_high_expose_only_schema_and_invoke_wrappers() {
-    for level in [CompressionLevel::Low, CompressionLevel::Medium, CompressionLevel::High] {
+    for level in [
+        CompressionLevel::Low,
+        CompressionLevel::Medium,
+        CompressionLevel::High,
+    ] {
         let server = CompressedServer::connect_stdio(
             common::config(
                 level.clone(),
@@ -58,8 +62,55 @@ async fn max_exposes_schema_invoke_and_list_wrappers() {
 
     assert_eq!(
         names,
-        ["alpha_get_tool_schema", "alpha_invoke_tool", "alpha_list_tools"]
+        [
+            "alpha_get_tool_schema",
+            "alpha_invoke_tool",
+            "alpha_list_tools"
+        ]
     );
+}
+
+#[tokio::test]
+async fn wrapper_get_schema_description_uses_level_specific_tool_listing() {
+    let expectations = [
+        (
+            CompressionLevel::Low,
+            "<tool>echo(message): Echo a message from alpha.</tool>",
+        ),
+        (
+            CompressionLevel::Medium,
+            "<tool>echo(message): Echo a message from alpha</tool>",
+        ),
+        (CompressionLevel::High, "<tool>echo(message)</tool>"),
+        (CompressionLevel::Max, "<tool>echo</tool>"),
+    ];
+
+    for (level, expected_listing) in expectations {
+        let server = CompressedServer::connect_stdio(
+            common::config(
+                level.clone(),
+                Some("alpha"),
+                ProxyTransformMode::CompressedTools,
+                BackendConfigSource::Command,
+            ),
+            common::backend("alpha", "alpha_server.py"),
+        )
+        .await
+        .unwrap();
+        let tools = server.list_frontend_tools().await.unwrap();
+        let get_schema = tools
+            .iter()
+            .find(|tool| tool.name == "alpha_get_tool_schema")
+            .unwrap();
+        let description = get_schema.description.as_deref().unwrap_or_default();
+        assert!(
+            description.contains("Get the input schema for a specific tool from the alpha toolset")
+        );
+        assert!(
+            description.contains(expected_listing),
+            "level {level:?} description did not include expected listing {expected_listing:?}: {description}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -86,8 +137,14 @@ async fn all_compression_levels_can_fetch_schema_and_invoke_backend_tools() {
             .get_tool_schema("alpha_get_tool_schema", "echo")
             .await
             .unwrap();
-        assert!(schema.contains("echo"), "schema missing tool name for {level:?}");
-        assert!(schema.contains("message"), "schema missing input field for {level:?}");
+        assert!(
+            schema.contains("echo"),
+            "schema missing tool name for {level:?}"
+        );
+        assert!(
+            schema.contains("message"),
+            "schema missing input field for {level:?}"
+        );
 
         let result = server
             .invoke_tool(

--- a/crates/mcp-compressor-core/tests/fixtures/alpha_server.py
+++ b/crates/mcp-compressor-core/tests/fixtures/alpha_server.py
@@ -26,6 +26,17 @@ def structured_data() -> dict[str, Any]:
     return {"server": "alpha", "values": [1, 2], "nested": {"ok": True}}
 
 
+@mcp.tool
+def summarize_payload(items: list[str], metadata: dict[str, Any]) -> dict[str, Any]:
+    """Summarize structured list and object arguments."""
+    return {
+        "item_count": len(items),
+        "items": items,
+        "metadata": metadata,
+        "metadata_keys": sorted(metadata.keys()),
+    }
+
+
 @mcp.resource("fixture://alpha-resource")
 def alpha_resource() -> str:
     """Return a static alpha resource."""

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -9,6 +9,16 @@ use mcp_compressor_core::client_gen::{ClientGenerator, GeneratorConfig};
 use mcp_compressor_core::proxy::{RunningToolProxy, ToolProxyServer};
 use mcp_compressor_core::server::CompressedServer;
 
+async fn real_backend_tools() -> Vec<mcp_compressor_core::compression::engine::Tool> {
+    let compressed = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+    compressed.backend_tools()
+}
+
 async fn running_proxy_config(output_dir: &std::path::Path) -> (GeneratorConfig, RunningToolProxy) {
     let compressed = CompressedServer::connect_stdio(
         common::max_config(Some("alpha")),
@@ -38,6 +48,37 @@ async fn running_proxy_config(output_dir: &std::path::Path) -> (GeneratorConfig,
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn generated_cli_script_handles_structured_json_arguments() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let (config, _proxy) = running_proxy_config(tempdir.path()).await;
+    let mut config = config;
+    config.tools = real_backend_tools().await;
+
+    CliGenerator.generate(&config).unwrap();
+    let script = tempdir.path().join("alpha");
+
+    let output = std::process::Command::new(&script)
+        .args([
+            "summarize-payload",
+            "--items",
+            "[\"one\",\"two\"]",
+            "--metadata",
+            "{\"source\":\"generated-cli\",\"ok\":true}",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("item_count"));
+    assert!(stdout.contains("generated-cli"));
+}
+
+#[tokio::test]
 async fn generated_cli_script_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let (config, _proxy) = running_proxy_config(tempdir.path()).await;

--- a/docs/development/cli-parity-report.md
+++ b/docs/development/cli-parity-report.md
@@ -1,0 +1,403 @@
+# CLI parity report
+
+This report compares the current Rust migration CLIs with the published legacy Python CLI.
+
+Compared surfaces:
+
+| Surface | Command used |
+|---|---|
+| Legacy Python CLI | `uvx mcp-compressor` |
+| Rust CLI binary | `target/debug/mcp-compressor` |
+| Python package CLI wrapper | `python/mcp-compressor` → `uv run mcp-compressor-rust` |
+| TypeScript package CLI wrapper | `typescript` → `bun dist/cli.js` |
+
+The current Python and TypeScript CLIs are thin wrappers around the Rust binary, so their behavior should match the Rust CLI apart from wrapper-level process handling.
+
+---
+
+## Executive summary
+
+The current Rust migration CLI is now close to the legacy Python CLI for the core flows:
+
+- standard compressed MCP proxy over stdio,
+- `low` / `medium` / `high` / `max` compression levels,
+- remote streamable HTTP backends with native OAuth or explicit backend headers,
+- CLI Mode,
+- Code Mode for Python and TypeScript generated clients,
+- Just Bash metadata mode,
+- generated CLI help.
+
+The most important parity fix is now implemented: the `get_tool_schema` wrapper description includes a compression-level-specific list of backend tools. This is critical because it gives the LLM compressed tool-selection context before it asks for a full schema.
+
+Remaining non-P0 parity gaps are mostly polish:
+
+- structured MCP `structuredContent` parity for some wrapper responses,
+- shell completion generation,
+- optional async Python generated clients,
+- deeper generated CLI argument help for complex schemas such as nested objects and arrays.
+
+---
+
+## Top-level help comparison
+
+### Legacy Python CLI
+
+```text
+Usage: mcp-compressor [OPTIONS] -- <command> [args]...
+
+Options include compression level, include/exclude filters, CLI mode, Python mode,
+TypeScript mode, Just Bash mode, cwd/env/header/timeout backend controls, logging,
+and shell completion helpers.
+```
+
+### Current Rust / Python wrapper / TypeScript wrapper CLI
+
+```text
+Usage: mcp-compressor [OPTIONS] [COMMAND] -- <COMMAND>...
+
+Options:
+  -c, --compression <COMPRESSION>
+  -n, --server-name <SERVER_NAME>
+      --transform-mode <TRANSFORM_MODE>
+      --cli-mode
+      --code-mode <LANGUAGE>
+      --just-bash-mode
+      --include-tools <INCLUDE_TOOLS>
+      --exclude-tools <EXCLUDE_TOOLS>
+      --toonify
+      --output-dir <OUTPUT_DIR>
+      --transport <TRANSPORT>
+      --port <PORT>
+  -V, --version
+  -h, --help
+```
+
+The Rust CLI intentionally separates frontend compressor options from backend server options. Backend options belong after `--`.
+
+```bash
+mcp-compressor [frontend options] -- <backend command or URL> [backend args]
+```
+
+Examples:
+
+```bash
+# Remote backend header after --
+mcp-compressor -c medium -- https://mcp.example.com/v1/mcp -H "Authorization=Bearer ${TOKEN}"
+
+# Local stdio backend cwd/env/timeout after --
+mcp-compressor -c medium -- python server.py --cwd ./repo -e FOO=bar -t 30
+```
+
+This matches the separation-of-concerns model already used for `-H` and avoids mixing frontend compression controls with backend process/transport controls.
+
+---
+
+## Backend argument placement
+
+| Backend concern | Legacy Python CLI | Current Rust CLI |
+|---|---|---|
+| HTTP headers | after `--` via `-H KEY=VALUE` | after `--` via `-H KEY=VALUE` |
+| working directory | after `--` via `--cwd PATH` | after `--` via `--cwd PATH` |
+| environment | after `--` via `-e KEY=VALUE` / `--env KEY=VALUE` | after `--` via `-e KEY=VALUE` / `--env KEY=VALUE` |
+| timeout | after `--` via `-t SECONDS` / `--timeout SECONDS` | after `--` via `-t SECONDS` / `--timeout SECONDS` |
+
+Top-level backend flags such as `mcp-compressor --cwd ./repo -- python server.py` are rejected in the Rust CLI. Use `mcp-compressor -- python server.py --cwd ./repo`.
+
+---
+
+## Compressed wrapper tool descriptions
+
+The wrapper descriptions are the most important compression surface. The model sees these before it decides whether to call `get_tool_schema`.
+
+### Low compression
+
+```text
+alpha_get_tool_schema
+
+Get the input schema for a specific tool from the alpha toolset.
+
+Available tools are:
+<tool>echo(message): Echo a message from alpha.</tool>
+<tool>add(a,b): Add two integers on alpha.</tool>
+<tool>structured_data: Return structured alpha data.</tool>
+```
+
+### Medium compression
+
+```text
+alpha_get_tool_schema
+
+Get the input schema for a specific tool from the alpha toolset.
+
+Available tools are:
+<tool>echo(message): Echo a message from alpha</tool>
+<tool>add(a,b): Add two integers on alpha</tool>
+<tool>structured_data: Return structured alpha data</tool>
+```
+
+### High compression
+
+```text
+alpha_get_tool_schema
+
+Get the input schema for a specific tool from the alpha toolset.
+
+Available tools are:
+<tool>echo(message)</tool>
+<tool>add(a,b)</tool>
+<tool>structured_data</tool>
+```
+
+### Max compression
+
+```text
+alpha_get_tool_schema
+
+Get the input schema for a specific tool from the alpha toolset.
+
+Available tools are:
+<tool>echo</tool>
+<tool>add</tool>
+<tool>structured_data</tool>
+```
+
+The level-specific listing is generated by the same compression engine that formats backend listings elsewhere, with a name-only fallback for `max`.
+
+---
+
+## MCP tool surface examples
+
+Using the alpha fixture backend with server name `alpha`:
+
+### Medium
+
+```text
+alpha_get_tool_schema
+alpha_invoke_tool
+```
+
+### Max
+
+```text
+alpha_get_tool_schema
+alpha_invoke_tool
+alpha_list_tools
+```
+
+This matches the intended architecture: lower compression levels expose schema and invocation wrappers; `max` additionally exposes `list_tools` because the wrapper descriptions are name-only.
+
+---
+
+## Schema response comparison
+
+Calling:
+
+```json
+{
+  "tool_name": "echo"
+}
+```
+
+through `alpha_get_tool_schema` returns the full backend schema.
+
+### Current Rust output shape
+
+```text
+<tool>echo(message): Echo a message from alpha.</tool>
+
+{
+  "type": "object",
+  "properties": {
+    "message": {
+      "type": "string"
+    }
+  },
+  "required": ["message"]
+}
+```
+
+### Legacy Python output shape
+
+```text
+<tool>echo(message): Echo a message from alpha.</tool>
+
+{
+  "type": "object",
+  "properties": {
+    "message": {
+      "type": "string"
+    }
+  },
+  "required": ["message"]
+}
+```
+
+The text response is now materially aligned for tool-selection and schema-fetch behavior. Legacy may still include structured MCP metadata in some responses; that remains a P1 parity item.
+
+---
+
+## Generated CLI help comparison
+
+Generated CLI top-level help now follows the legacy style.
+
+```text
+alpha - the alpha toolset
+
+When relevant, outputs from this CLI will prefer using the TOON format for more efficient representation of data.
+
+USAGE:
+  alpha <subcommand> [options]
+
+SUBCOMMANDS:
+  add                                 Add two integers on alpha
+  echo                                Echo a message from alpha
+  structured-data                     Return structured alpha data
+
+Run 'alpha <subcommand> --help' for subcommand usage.
+```
+
+Generated subcommand help includes required/optional status, type, description, defaults, and enum values when present.
+
+```text
+alpha fetch
+
+Fetch a URL.
+
+USAGE:
+  alpha fetch --url <value> --timeout <value> --method <value>
+
+OPTIONS:
+  --url                        <string>   required — URL to fetch.
+  --timeout                    <integer>  optional — Timeout in seconds.; default: 30
+  --method                     <string>   optional — HTTP method to use.; values: GET, POST; default: GET
+```
+
+Remaining generated CLI polish:
+
+- richer display for nested object properties,
+- array item details,
+- min/max/pattern constraints,
+- examples if schemas provide them.
+
+---
+
+## Code Mode comparison
+
+The Rust CLI now uses the public umbrella term **Code Mode**:
+
+```bash
+mcp-compressor --code-mode python --server-name atlassian --output-dir ./generated-py -- https://mcp.atlassian.com/v1/mcp
+mcp-compressor --code-mode typescript --server-name atlassian --output-dir ./generated-ts -- https://mcp.atlassian.com/v1/mcp
+```
+
+Deprecated aliases still work:
+
+```bash
+--python-mode
+--typescript-mode
+```
+
+Generated clients call the local Rust proxy and expose backend tools directly, for example:
+
+=== "Python"
+
+    ```python
+    import atlassian
+
+    resources = atlassian.getAccessibleAtlassianResources()
+    page = atlassian.getConfluencePage(page_id="123")
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    import { getAccessibleAtlassianResources, getConfluencePage } from "./atlassian";
+
+    const resources = await getAccessibleAtlassianResources();
+    const page = await getConfluencePage("123");
+    ```
+
+Real-world Atlassian Code Mode tests import and execute generated Python and TypeScript clients against `https://mcp.atlassian.com/v1/mcp`.
+
+---
+
+## CLI Mode comparison
+
+CLI Mode generates shell commands that hit the local proxy.
+
+```bash
+mcp-compressor --cli-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
+```
+
+Generated CLI usage:
+
+```bash
+atlassian --help
+atlassian get-accessible-atlassian-resources
+atlassian get-confluence-page --page-id 123
+```
+
+The current Rust generated CLI help is close to the legacy Python output and now includes more schema-derived argument detail.
+
+---
+
+## Just Bash comparison
+
+The Rust core does not execute shell commands itself. Instead, it exposes Just Bash provider metadata to Python and TypeScript host libraries. Language hosts convert that metadata into Just Bash commands.
+
+This is intentional: Rust owns compression/proxy routing; language hosts own Just Bash runtime integration.
+
+Parity status:
+
+- TypeScript helper: `createJustBashCommands(proxy)` implemented and tested.
+- Python helper: `create_just_bash_commands(proxy)` implemented and tested.
+- Rust CLI `--just-bash-mode` exposes the expected proxy/help surface.
+
+---
+
+## Atlassian MCP real-world parity
+
+The real-world test suite covers:
+
+- standard CLI compression levels against Atlassian MCP,
+- custom server name,
+- include filters,
+- TOON output,
+- CLI Mode,
+- Code Mode Python and TypeScript,
+- Just Bash mode surface,
+- multi-server JSON config,
+- port configuration,
+- high-level Python SDK,
+- high-level TypeScript SDK,
+- generated Python/TypeScript clients.
+
+Atlassian examples should prefer native OAuth:
+
+```bash
+mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
+```
+
+Explicit headers remain supported for CI/service-account cases and belong after `--`:
+
+```bash
+mcp-compressor -c medium --server-name atlassian -- https://mcp.atlassian.com/v1/mcp -H "Authorization=Basic ${ATLASSIAN_MCP_BASIC_TOKEN}"
+```
+
+---
+
+## Remaining parity gaps
+
+### P1
+
+1. Add structured MCP `structuredContent` parity where legacy emits it.
+2. Add shell completion support if still valuable.
+3. Add richer generated CLI help for nested schemas and constraints.
+4. Consider opt-in async Python Code Mode.
+5. Expand Just Bash host parity tests to more real-world schemas.
+
+### P2
+
+1. Further compare exact logging output and log-level behavior.
+2. Compare edge-case schema formatting for unions, `oneOf`, `anyOf`, and arrays.
+3. Compare timeout semantics once request timeout enforcement is fully wired through remote and stdio paths.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,11 @@ mcp-compressor --help
 | Option | Description |
 |---|---|
 | `-c`, `--compression <level>` | Compression level: `low`, `medium`, `high`, `max`. |
-| `--server-name <name>` | Public name for a single backend server. |
+| `-n`, `--server-name <name>` | Public name for a single backend server. |
+| `--cwd <path>` | Working directory for stdio backend commands. |
+| `-e`, `--env KEY=VALUE` | Environment variable for stdio backend commands. Repeatable. |
+| `-t`, `--timeout <seconds>` | Backend connect/request timeout in seconds. |
+| `-V`, `--version` | Print version information. |
 | `--config <path>` | MCP config JSON file. |
 | `--multi-server <name=command ...>` | Direct multi-server CLI configuration. |
 | `--include-tools <a,b>` | Include only selected backend tools. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,9 +12,6 @@ mcp-compressor --help
 |---|---|
 | `-c`, `--compression <level>` | Compression level: `low`, `medium`, `high`, `max`. |
 | `-n`, `--server-name <name>` | Public name for a single backend server. |
-| `--cwd <path>` | Working directory for stdio backend commands. |
-| `-e`, `--env KEY=VALUE` | Environment variable for stdio backend commands. Repeatable. |
-| `-t`, `--timeout <seconds>` | Backend connect/request timeout in seconds. |
 | `-V`, `--version` | Print version information. |
 | `--config <path>` | MCP config JSON file. |
 | `--multi-server <name=command ...>` | Direct multi-server CLI configuration. |
@@ -34,13 +31,22 @@ mcp-compressor --help
 Backend command or URL arguments come after `--`.
 
 ```bash
-mcp-compressor [options] -- <backend command or URL> [backend args]
+mcp-compressor [frontend options] -- <backend command or URL> [backend args]
 ```
 
-## Header args for remote URLs
+Backend-specific options are intentionally parsed after `--` so frontend compression options stay separate from backend connection details.
+
+| Backend arg | Description |
+|---|---|
+| `-H`, `--header KEY=VALUE` | HTTP header for remote streamable HTTP backends. Repeatable. |
+| `--cwd <path>` | Working directory for stdio backend commands. |
+| `-e`, `--env KEY=VALUE` | Environment variable for stdio backend commands. Repeatable. |
+| `-t`, `--timeout <seconds>` | Backend connect/request timeout in seconds. |
+| `--auth <auto|oauth|explicit-headers>` | Remote backend auth mode. |
 
 ```bash
 mcp-compressor -- https://mcp.example.com/v1/mcp -H "Authorization=Bearer ${TOKEN}"
+mcp-compressor -- python server.py --cwd ./repo -e FOO=bar -t 30
 ```
 
 ## OAuth cleanup

--- a/docs/usage/just-bash.md
+++ b/docs/usage/just-bash.md
@@ -20,12 +20,12 @@ The language host owns:
 
 ```ts
 import { Bash } from "just-bash";
-import { CompressorClient, createJustBashCommands } from "@atlassian/mcp-compressor";
+import { CompressorClient, installJustBashCommands } from "@atlassian/mcp-compressor";
 
 const proxy = await new CompressorClient({ servers, mode: "bash" }).connect();
 try {
-  const registrations = createJustBashCommands(proxy);
-  const bash = new Bash({ customCommands: registrations.map((item) => item.command) });
+  const bash = new Bash({ customCommands: [] });
+  const registrations = installJustBashCommands(bash, proxy);
 
   const result = await bash.exec("alpha_echo --message hello");
   console.log(result.stdout);
@@ -37,11 +37,16 @@ try {
 ## Python host helper
 
 ```python
-from mcp_compressor import CompressorClient, create_just_bash_commands
+from mcp_compressor import CompressorClient, install_just_bash_commands
+
+class BashHost:
+    def __init__(self) -> None:
+        self.custom_commands = {}
 
 with CompressorClient(servers=servers, mode="bash") as proxy:
-    commands = {command.command_name: command for command in create_just_bash_commands(proxy)}
-    print(commands["alpha_echo"](["--message", "hello"]))
+    bash = BashHost()
+    install_just_bash_commands(bash, proxy)
+    print(bash.custom_commands["alpha_echo"](["--message", "hello"]))
 ```
 
 ## Command names and collisions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - API modules: modules.md
   - Development:
       - Rust migration: development/rust-migration.md
+      - CLI parity report: development/cli-parity-report.md
       - Rust core design: rust-core-design.md
 plugins:
   - search

--- a/python/mcp-compressor/mcp_compressor/__init__.py
+++ b/python/mcp-compressor/mcp_compressor/__init__.py
@@ -23,7 +23,11 @@ from mcp_compressor.core import (
     start_compressed_session,
     start_compressed_session_from_mcp_config,
 )
-from mcp_compressor.just_bash_host import JustBashCallableCommand, create_just_bash_commands
+from mcp_compressor.just_bash_host import (
+    JustBashCallableCommand,
+    create_just_bash_commands,
+    install_just_bash_commands,
+)
 
 __all__ = [
     "BackendConfig",
@@ -41,6 +45,7 @@ __all__ = [
     "compress_tool_listing",
     "create_just_bash_commands",
     "format_tool_schema_response",
+    "install_just_bash_commands",
     "list_oauth_credentials",
     "normalize_servers",
     "parse_mcp_config",

--- a/python/mcp-compressor/mcp_compressor/just_bash_host.py
+++ b/python/mcp-compressor/mcp_compressor/just_bash_host.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -34,6 +35,27 @@ class JustBashCallableCommand:
             self.parse(args or []),
             server=self.provider_name,
         )
+
+
+def install_just_bash_commands(bash: Any, proxy: CompressorProxy) -> list[JustBashCallableCommand]:
+    """Install compressor commands into a pre-created Python Just Bash host when possible.
+
+    The Python Just Bash ecosystem is less standardized than the TypeScript
+    package, so this helper supports the common mutable shapes used by hosts:
+    `custom_commands` or `commands` as either a mapping or a list. It returns the
+    generated command objects in all cases so callers can adapt custom hosts.
+    """
+    commands = create_just_bash_commands(proxy)
+    for attribute in ("custom_commands", "commands"):
+        target = getattr(bash, attribute, None)
+        if isinstance(target, MutableMapping):
+            target.update({command.command_name: command for command in commands})
+            return commands
+        if isinstance(target, list):
+            target.extend(commands)
+            return commands
+    bash.custom_commands = {command.command_name: command for command in commands}
+    return commands
 
 
 def create_just_bash_commands(proxy: CompressorProxy) -> list[JustBashCallableCommand]:

--- a/python/mcp-compressor/tests/test_core.py
+++ b/python/mcp-compressor/tests/test_core.py
@@ -18,6 +18,7 @@ from mcp_compressor import (
     compress_tool_listing,
     create_just_bash_commands,
     format_tool_schema_response,
+    install_just_bash_commands,
     parse_mcp_config,
     parse_tool_argv,
     start_compressed_session,
@@ -223,6 +224,15 @@ def test_high_level_compressor_client_exposes_cli_and_bash_modes(monkeypatch) ->
         commands = {command.command_name: command for command in create_just_bash_commands(proxy)}
         assert {"alpha_echo", "beta_echo"}.issubset(commands)
         assert commands["alpha_echo"](["--message", "via-python-bash"]) == "alpha:via-python-bash"
+
+        class ExistingBashHost:
+            def __init__(self) -> None:
+                self.custom_commands: dict[str, object] = {}
+
+        host = ExistingBashHost()
+        installed = install_just_bash_commands(host, proxy)
+        assert {command.command_name for command in installed}.issuperset({"alpha_echo", "beta_echo"})
+        assert "alpha_echo" in host.custom_commands
 
 
 def test_high_level_compressor_client_supports_remote_config_shape() -> None:

--- a/typescript/src/just_bash_host.ts
+++ b/typescript/src/just_bash_host.ts
@@ -28,6 +28,19 @@ function failure(error: unknown): ExecResult {
   return { stdout: "", stderr: `${message}\n`, exitCode: 1 };
 }
 
+export function installJustBashCommands(
+  bash: unknown,
+  proxy: CompressorProxy,
+): JustBashCommandRegistration[] {
+  const registrations = createJustBashCommands(proxy);
+  const host = bash as { customCommands?: Command[] };
+  host.customCommands = [
+    ...(host.customCommands ?? []),
+    ...registrations.map((item) => item.command),
+  ];
+  return registrations;
+}
+
 export function createJustBashCommands(proxy: CompressorProxy): JustBashCommandRegistration[] {
   const rawNames = proxy.justBashProviders.flatMap((provider) =>
     provider.tools.map((tool) => tool.commandName),

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { CompressorClient, createJustBashCommands, normalizeServers } from "../src/index.js";
+import { CompressorClient, installJustBashCommands, normalizeServers } from "../src/index.js";
 
 import {
   compressToolListing,
@@ -557,10 +557,8 @@ describe("Rust native core wrapper", () => {
           invokeToolName: "alpha_invoke_tool",
         }),
       );
-      const registrations = createJustBashCommands(bashProxy);
-      const bash = new Bash({
-        customCommands: registrations.map((registration) => registration.command),
-      });
+      const bash = new Bash({ customCommands: [] });
+      const registrations = installJustBashCommands(bash, bashProxy);
       expect(registrations.map((registration) => registration.commandName)).toEqual(
         expect.arrayContaining(["alpha_echo", "beta_echo"]),
       );


### PR DESCRIPTION
## Summary
- add compression-level-specific backend tool listings to get_tool_schema wrapper descriptions
- add richer invoke wrapper descriptions
- add legacy CLI parity options: --cwd, --env/-e, --timeout/-t, --version/-V, and -n for --server-name
- apply cwd/env to stdio backend processes and validate timeout
- improve generated CLI subcommand help with enum values
- add regression tests for wrapper description verbosity, CLI options, and generated CLI help

## Validation
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test compression_levels wrapper_get_schema_description_uses_level_specific_tool_listing -- --nocapture`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary 'rust_cli_' -- --nocapture`
- `cargo test -p mcp-compressor-core client_gen::cli -- --nocapture`
- `cargo check -p mcp-compressor-core`
- `make docs-test`
- `make check`