### PR TITLE
test: add public workflow smoke tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,9 @@ jobs:
       - name: Run public Rust SDK import smoke test
         env:
           PYTHON: ${{ github.workspace }}/.venv/bin/python
-        run: cargo test -p mcp-compressor --test public_api -- --nocapture
+        run: |
+          cargo test -p mcp-compressor --test public_api -- --nocapture
+          cargo test -p mcp-compressor --test public_workflow -- --nocapture
 
       - name: Run Rust core library tests
         env:
@@ -100,7 +102,11 @@ jobs:
         uses: ./.github/actions/setup-python-env
 
       - name: Run Rust binary normal-mode FastMCP e2e
-        run: uv run pytest -q tests/test_rust_core_normal_mode.py
+        env:
+          PYTHON: ${{ github.workspace }}/.venv/bin/python
+        run: |
+          uv run pytest -q tests/test_rust_core_normal_mode.py
+          uv run pytest -q tests/test_public_cli_workflows.py
 
   rust-contract-compile:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,8 @@ name = "mcp-compressor"
 version = "0.1.0"
 dependencies = [
  "mcp-compressor-core",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/mcp-compressor/Cargo.toml
+++ b/crates/mcp-compressor/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2021"
 
 [dependencies]
 mcp-compressor-core = { path = "../mcp-compressor-core" }
+
+[dev-dependencies]
+serde_json = "1"
+tokio      = { version = "1", features = ["macros"] }

--- a/crates/mcp-compressor/tests/public_workflow.rs
+++ b/crates/mcp-compressor/tests/public_workflow.rs
@@ -1,0 +1,42 @@
+use mcp_compressor::compression::CompressionLevel;
+use mcp_compressor::sdk::{CompressorClient, ServerConfig};
+use serde_json::json;
+
+fn fixture_path(name: &str) -> String {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    root.join("crates")
+        .join("mcp-compressor-core")
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+        .to_string_lossy()
+        .to_string()
+}
+
+fn python_command() -> String {
+    std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+}
+
+#[tokio::test]
+async fn public_rust_sdk_quickstart_flow() {
+    let client = CompressorClient::builder()
+        .server(
+            "alpha",
+            ServerConfig::command(python_command()).arg(fixture_path("alpha_server.py")),
+        )
+        .compression_level(CompressionLevel::Medium)
+        .build();
+
+    let proxy = client.connect().await.unwrap();
+    let tool_names: Vec<_> = proxy.tools().iter().map(|tool| tool.name.as_str()).collect();
+    assert!(tool_names.contains(&"alpha_get_tool_schema"));
+    assert!(tool_names.contains(&"alpha_invoke_tool"));
+
+    let response = proxy.invoke("echo", json!({ "message": "public-rust" })).await.unwrap();
+    assert_eq!(response, "alpha:public-rust");
+}

--- a/python/mcp-compressor/tests/test_public_sdk_workflow.py
+++ b/python/mcp-compressor/tests/test_public_sdk_workflow.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from mcp_compressor import CompressorClient
+
+ROOT = Path(__file__).resolve().parents[3]
+FIXTURE = ROOT / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
+PYTHON = os.environ.get("PYTHON", sys.executable)
+
+
+def test_public_python_sdk_quickstart_flow() -> None:
+    with CompressorClient(
+        servers={"alpha": {"command": PYTHON, "args": [str(FIXTURE)]}},
+        compression_level="max",
+    ) as proxy:
+        tool_names = {tool.name for tool in proxy.tools}
+        assert "alpha_get_tool_schema" in tool_names
+        assert "alpha_invoke_tool" in tool_names
+
+        response = proxy.invoke("echo", {"message": "public-python"})
+        assert response == "alpha:public-python"

--- a/tests/test_public_cli_workflows.py
+++ b/tests/test_public_cli_workflows.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BINARY = ROOT / "target" / "debug" / "mcp-compressor"
+FIXTURE = ROOT / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
+PYTHON = os.environ.get("PYTHON", sys.executable)
+
+
+def _ensure_binary() -> None:
+    if not BINARY.exists():
+        subprocess.run(["cargo", "build", "-p", "mcp-compressor-core"], cwd=ROOT, check=True)  # noqa: S607
+
+
+def test_public_cli_mode_creates_executable_script(tmp_path: Path) -> None:
+    _ensure_binary()
+    output_dir = tmp_path / "bin"
+
+    result = subprocess.run(  # noqa: S603
+        [
+            str(BINARY),
+            "--cli-mode",
+            "--server-name",
+            "alpha",
+            "--output-dir",
+            str(output_dir),
+            "--",
+            PYTHON,
+            str(FIXTURE),
+        ],
+        cwd=tmp_path,
+        env={**os.environ, "MCP_COMPRESSOR_EXIT_AFTER_READY": "1"},
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+
+    assert "CLI ready" in result.stdout
+    assert (output_dir / "alpha").exists()
+
+
+def test_public_code_modes_default_to_dist(tmp_path: Path) -> None:
+    _ensure_binary()
+
+    for language, expected in [("python", "alpha.py"), ("typescript", "alpha.ts")]:
+        result = subprocess.run(  # noqa: S603
+            [
+                str(BINARY),
+                "--code-mode",
+                language,
+                "--server-name",
+                "alpha",
+                "--",
+                PYTHON,
+                str(FIXTURE),
+            ],
+            cwd=tmp_path,
+            env={**os.environ, "MCP_COMPRESSOR_EXIT_AFTER_READY": "1"},
+            text=True,
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+        assert "code client ready" in result.stdout
+        assert (tmp_path / "dist" / expected).exists()
+
+
+def test_public_backend_options_belong_after_separator(tmp_path: Path) -> None:
+    _ensure_binary()
+
+    before = subprocess.run(  # noqa: S603
+        [str(BINARY), "--cwd", str(tmp_path), "--", PYTHON, str(FIXTURE)],
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    assert before.returncode != 0
+    assert "unexpected argument '--cwd'" in before.stderr
+
+    after = subprocess.run(  # noqa: S603
+        [
+            str(BINARY),
+            "--cli-mode",
+            "--server-name",
+            "alpha",
+            "--output-dir",
+            str(tmp_path / "bin"),
+            "--",
+            PYTHON,
+            str(FIXTURE),
+            "--cwd",
+            str(tmp_path),
+            "-e",
+            "PUBLIC_WORKFLOW_SMOKE=1",
+        ],
+        env={**os.environ, "MCP_COMPRESSOR_EXIT_AFTER_READY": "1"},
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    assert "CLI ready" in after.stdout

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -189,6 +189,31 @@ const sampleTool: ToolSpec = {
   },
 };
 
+describe("Public TypeScript SDK workflow", () => {
+  it("matches the documented CompressorClient quickstart", async () => {
+    const client = new CompressorClient({
+      servers: {
+        alpha: {
+          command: process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python"),
+          args: [fixturePath("alpha_server.py")],
+        },
+      },
+      compressionLevel: "max",
+    });
+
+    const proxy = await client.connect();
+    try {
+      expect(proxy.tools.map((tool) => tool.name)).toContain("alpha_get_tool_schema");
+      expect(proxy.tools.map((tool) => tool.name)).toContain("alpha_invoke_tool");
+      const response = await proxy.invoke("echo", { message: "public-ts" });
+      expect(response).toBe("alpha:public-ts");
+    } finally {
+      proxy.close();
+      client.close();
+    }
+  });
+});
+
 describe("Rust native core wrapper", () => {
   it("compresses tool listings through the native addon", () => {
     expect(compressToolListing("high", [sampleTool])).toBe("<tool>echo(message)</tool>");


### PR DESCRIPTION
## Summary
- add black-box CLI workflow smoke tests for CLI Mode, Code Mode defaults, and backend-arg placement
- add public Python SDK quickstart smoke test
- add public TypeScript SDK quickstart smoke test
- add public Rust SDK runtime smoke test
- wire the new CLI/Rust public workflow tests into CI

## Validation
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor --test public_workflow -- --nocapture`
- `uv run pytest -q tests/test_public_cli_workflows.py`
- `cd python/mcp-compressor && uv run maturin develop && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests/test_public_sdk_workflow.py`
- `cd typescript && bun run build:native && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "Public TypeScript SDK workflow"`
- `make check`