### PR TITLE
fix: polish Code Mode and schema UX

### DIFF
--- a/crates/mcp-compressor-core/src/app/runtime.rs
+++ b/crates/mcp-compressor-core/src/app/runtime.rs
@@ -134,17 +134,21 @@ pub async fn run_cli_mode(cli: CliOptions, server: CompressedServer) -> Result<(
         println!("CLI ready");
         println!("Generated CLI: {}", script.display());
     }
-    if on_path {
-        println!("Invoke with: {cli_name} <subcommand> [args...]");
+    if client_artifact_kind.is_none() {
+        if on_path {
+            println!("Invoke with: {cli_name} <subcommand> [args...]");
+        } else {
+            println!("Invoke with: {} <subcommand> [args...]", script.display());
+            println!(
+                "Note: {} is not on PATH; add it to PATH to run `{cli_name}` directly.",
+                script
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new("."))
+                    .display()
+            );
+        }
     } else {
-        println!("Invoke with: {} <subcommand> [args...]", script.display());
-        println!(
-            "Note: {} is not on PATH; add it to PATH to run `{cli_name}` directly.",
-            script
-                .parent()
-                .unwrap_or_else(|| std::path::Path::new("."))
-                .display()
-        );
+        println!("Import the generated client from your agent code while this process is running.");
     }
     println!("Bridge URL: {}", proxy.bridge_url());
     println!("Press Ctrl+C to stop.");

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -164,7 +164,9 @@ fn rust_cli_code_mode_python_generates_python_client() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Python code client ready"))
-        .stdout(predicate::str::contains("Generated files:"));
+        .stdout(predicate::str::contains("Generated files:"))
+        .stdout(predicate::str::contains("Import the generated client"))
+        .stdout(predicate::str::contains("Invoke with:").not());
 
     assert!(output_dir.join("alpha.py").exists());
 }

--- a/python/mcp-compressor/mcp_compressor/client.py
+++ b/python/mcp-compressor/mcp_compressor/client.py
@@ -171,7 +171,7 @@ class CompressorProxy:
             for item in scoped_tools
             if isinstance(item, dict)
             and item.get("tool", {}).get("name") == tool
-            and (target_server is None or item.get("server_name") == target_server)
+            and (target_server is None or (item.get("server_name") or item.get("serverName")) == target_server)
         ]
         if len(matches) == 1:
             schema = matches[0].get("tool", {}).get("input_schema", {})

--- a/tests/test_public_cli_workflows.py
+++ b/tests/test_public_cli_workflows.py
@@ -68,6 +68,8 @@ def test_public_code_modes_default_to_dist(tmp_path: Path) -> None:
             timeout=30,
         )
         assert "code client ready" in result.stdout
+        assert "Import the generated client" in result.stdout
+        assert "Invoke with:" not in result.stdout
         assert (tmp_path / "dist" / expected).exists()
 
 

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -169,7 +169,9 @@ export class CompressorProxy {
     const matches = this.info().backend_tools_by_server.filter(
       (item) =>
         item.tool.name === tool &&
-        (server === null || server === undefined || item.server_name === server),
+        (server === null ||
+          server === undefined ||
+          (item.server_name ?? item.serverName) === server),
     );
     if (matches.length === 1) {
       return matches[0]?.tool.input_schema ?? {};

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -108,7 +108,8 @@ export interface CompressedSessionInfo {
     input_schema: Record<string, unknown>;
   }>;
   backend_tools_by_server: Array<{
-    server_name: string;
+    server_name?: string;
+    serverName?: string;
     tool: {
       name: string;
       description?: string | null;


### PR DESCRIPTION
## Summary
- make Code Mode output guidance say to import generated clients instead of showing CLI-style subcommand instructions
- keep CLI Mode output guidance unchanged
- make Python/TypeScript schema lookup robust to snake_case/camelCase scoped backend metadata
- add public CLI assertions for Code Mode guidance

## Manual smoke coverage
Ran end-user-style flows for:
- public CLI help/version
- CLI Mode generated shell client against fixture backend
- Code Mode Python/TypeScript defaulting to ./dist
- backend args before/after --
- Just Bash readiness
- MCP JSON multi-server normal-mode routing
- Python SDK multi-server schema/invoke
- TypeScript SDK multi-server schema/invoke
- Rust SDK public workflow

## Validation
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary rust_cli_code_mode -- --nocapture`
- `uv run pytest -q tests/test_public_cli_workflows.py`
- `cd python/mcp-compressor && uv run maturin develop && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests`
- `cd typescript && bun run build:native && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run check`
- `PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor --test public_workflow -- --nocapture`
- `make docs-test`
- `make check`