### PR TITLE
feat(typescript): add custom fetch support for dynamic auth headers

### DIFF
--- a/typescript/src/backend-client.ts
+++ b/typescript/src/backend-client.ts
@@ -83,6 +83,7 @@ export class BackendClient {
         new StreamableHTTPClientTransport(new URL(this.config.url), {
           authProvider: this.oauthProvider,
           requestInit: { headers: this.config.headers },
+          fetch: this.config.fetch,
         }),
       );
     } else if (this.config.type === "sse") {
@@ -91,6 +92,7 @@ export class BackendClient {
         new SSEClientTransport(new URL(this.config.url), {
           authProvider: this.oauthProvider,
           requestInit: { headers: this.config.headers },
+          fetch: this.config.fetch,
         }),
       );
     } else {

--- a/typescript/src/config.ts
+++ b/typescript/src/config.ts
@@ -119,5 +119,6 @@ export function normalizeConfigServer(entry: JsonConfigServerEntry): BackendConf
     type: interpolated.transport === "sse" ? "sse" : "http",
     url: interpolated.url.toString(),
     headers: interpolated.headers,
+    ...(entry.fetch !== undefined ? { fetch: entry.fetch } : {}),
   };
 }

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -1,3 +1,4 @@
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 export type CompressionLevel = "low" | "medium" | "high" | "max";
@@ -23,6 +24,7 @@ export interface HttpBackendConfig {
   url: string;
   headers?: Record<string, string>;
   timeoutMs?: number;
+  fetch?: FetchLike;
 }
 
 export interface SseBackendConfig {
@@ -30,6 +32,7 @@ export interface SseBackendConfig {
   url: string;
   headers?: Record<string, string>;
   timeoutMs?: number;
+  fetch?: FetchLike;
 }
 
 export type BackendConfig = StdioBackendConfig | HttpBackendConfig | SseBackendConfig;
@@ -43,6 +46,7 @@ export interface JsonConfigServerEntry {
   url?: URL | string;
   headers?: Record<string, string>;
   transport?: "sse";
+  fetch?: FetchLike;
 }
 
 export interface MCPConfigShape {

--- a/typescript/tests/backend-client-fetch.test.ts
+++ b/typescript/tests/backend-client-fetch.test.ts
@@ -6,10 +6,13 @@ test("BackendClient passes custom fetch to StreamableHTTPClientTransport", async
   const fetchCalls: Array<{ url: string | URL; init?: RequestInit }> = [];
   const customFetch = async (url: string | URL, init?: RequestInit) => {
     fetchCalls.push({ url, init });
-    return new Response(JSON.stringify({ jsonrpc: "2.0", id: 0, error: { code: -1, message: "test" } }), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: 0, error: { code: -1, message: "test" } }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
   };
 
   const config: HttpBackendConfig = {

--- a/typescript/tests/backend-client-fetch.test.ts
+++ b/typescript/tests/backend-client-fetch.test.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "vitest";
+import { BackendClient } from "../src/backend-client.js";
+import type { HttpBackendConfig, SseBackendConfig } from "../src/types.js";
+
+test("BackendClient passes custom fetch to StreamableHTTPClientTransport", async () => {
+  const fetchCalls: Array<{ url: string | URL; init?: RequestInit }> = [];
+  const customFetch = async (url: string | URL, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: 0, error: { code: -1, message: "test" } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const config: HttpBackendConfig = {
+    type: "http",
+    url: "http://localhost:19999/mcp",
+    fetch: customFetch,
+  };
+
+  const client = new BackendClient(config);
+
+  // connect() will attempt to initialize via the transport, which calls our custom fetch.
+  // The MCP handshake will fail because we return an error response, but that's fine —
+  // the point is to verify our custom fetch was actually invoked by the transport.
+  try {
+    await client.connect();
+  } catch {
+    // Expected — no real server, handshake fails
+  }
+
+  expect(fetchCalls.length).toBeGreaterThan(0);
+  expect(fetchCalls[0]!.url.toString()).toBe("http://localhost:19999/mcp");
+});
+
+test("BackendClient passes custom fetch to SSEClientTransport", async () => {
+  const fetchCalls: Array<{ url: string | URL; init?: RequestInit }> = [];
+  const customFetch = async (url: string | URL, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    return new Response("", {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  };
+
+  const config: SseBackendConfig = {
+    type: "sse",
+    url: "http://localhost:19999/sse",
+    fetch: customFetch,
+  };
+
+  const client = new BackendClient(config);
+
+  try {
+    await client.connect();
+  } catch {
+    // Expected — no real server
+  }
+
+  expect(fetchCalls.length).toBeGreaterThan(0);
+  expect(fetchCalls[0]!.url.toString()).toBe("http://localhost:19999/sse");
+});
+
+test("BackendClient uses global fetch when custom fetch is not provided", async () => {
+  const config: HttpBackendConfig = {
+    type: "http",
+    url: "http://localhost:19999/mcp",
+  };
+
+  const client = new BackendClient(config);
+
+  // With no custom fetch, the transport uses global fetch which will fail to connect.
+  // We just verify it doesn't throw a type error and attempts to connect normally.
+  try {
+    await client.connect();
+  } catch {
+    // Expected — no real server
+  }
+
+  // If we got here without a TypeError about fetch, the undefined fallback works correctly.
+  expect(true).toBe(true);
+});

--- a/typescript/tests/config.test.ts
+++ b/typescript/tests/config.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "vitest";
-import { interpolateMCPConfig, interpolateString, parseServerConfigJson } from "../src/config.js";
+import {
+  interpolateMCPConfig,
+  interpolateString,
+  normalizeConfigServer,
+  parseServerConfigJson,
+} from "../src/config.js";
 
 test("parseServerConfigJson parses a single stdio server", () => {
   const parsed = parseServerConfigJson(
@@ -139,4 +144,34 @@ test("interpolateMCPConfig preserves unset placeholders", () => {
     mcpServers: { srv: { url: "https://example.com", headers: { X: "${UNSET_VAR}" } } },
   });
   expect(result.mcpServers["srv"]?.headers?.["X"]).toBe("${UNSET_VAR}");
+});
+
+test("normalizeConfigServer preserves fetch for HTTP config", () => {
+  const customFetch = async (url: string | URL, init?: RequestInit) =>
+    new Response(null, { status: 200 });
+  const result = normalizeConfigServer({ url: "http://localhost:3000", fetch: customFetch });
+  expect(result.type).toBe("http");
+  expect((result as { fetch?: unknown }).fetch).toBe(customFetch);
+});
+
+test("normalizeConfigServer preserves fetch for SSE config", () => {
+  const customFetch = async (url: string | URL, init?: RequestInit) =>
+    new Response(null, { status: 200 });
+  const result = normalizeConfigServer({
+    url: "http://localhost:3000",
+    transport: "sse",
+    fetch: customFetch,
+  });
+  expect(result.type).toBe("sse");
+  expect((result as { fetch?: unknown }).fetch).toBe(customFetch);
+});
+
+test("normalizeConfigServer does not set fetch when not provided", () => {
+  const result = normalizeConfigServer({ url: "http://localhost:3000" });
+  expect("fetch" in result).toBe(false);
+});
+
+test("normalizeConfigServer does not set fetch for stdio config", () => {
+  const result = normalizeConfigServer({ command: "uvx", args: ["my-server"] });
+  expect("fetch" in result).toBe(false);
 });

--- a/typescript/tests/config.test.ts
+++ b/typescript/tests/config.test.ts
@@ -147,7 +147,7 @@ test("interpolateMCPConfig preserves unset placeholders", () => {
 });
 
 test("normalizeConfigServer preserves fetch for HTTP config", () => {
-  const customFetch = async (url: string | URL, init?: RequestInit) =>
+  const customFetch = async (_url: string | URL, _init?: RequestInit) =>
     new Response(null, { status: 200 });
   const result = normalizeConfigServer({ url: "http://localhost:3000", fetch: customFetch });
   expect(result.type).toBe("http");
@@ -155,7 +155,7 @@ test("normalizeConfigServer preserves fetch for HTTP config", () => {
 });
 
 test("normalizeConfigServer preserves fetch for SSE config", () => {
-  const customFetch = async (url: string | URL, init?: RequestInit) =>
+  const customFetch = async (_url: string | URL, _init?: RequestInit) =>
     new Response(null, { status: 200 });
   const result = normalizeConfigServer({
     url: "http://localhost:3000",


### PR DESCRIPTION
Thread an optional FetchLike function from config through BackendClient to MCP SDK transport constructors (StreamableHTTPClientTransport and SSEClientTransport). This enables upstream consumers to inject per-request auth token refresh middleware (e.g. OAuth token rotation).

Changes:
- Add fetch?: FetchLike to HttpBackendConfig, SseBackendConfig, and JsonConfigServerEntry types
- Preserve fetch function reference in normalizeConfigServer() (read from original entry, not interpolated, since fetch is not a string)
- Pass config.fetch to both HTTP and SSE transport constructors
- Add 4 tests covering fetch preservation for HTTP/SSE configs and absence for stdio/omitted cases