### PR TITLE
feat: add SDK dynamic auth providers

### DIFF
--- a/crates/mcp-compressor-core/src/sdk.rs
+++ b/crates/mcp-compressor-core/src/sdk.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
@@ -31,9 +32,12 @@ impl From<CompressorMode> for ProxyTransformMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+type HeaderProvider = Arc<dyn Fn() -> Result<BTreeMap<String, String>, Error> + Send + Sync>;
+
+#[derive(Clone)]
 pub struct ServerConfig {
     inner: FfiSdkServerConfig,
+    auth_provider: Option<HeaderProvider>,
 }
 
 impl ServerConfig {
@@ -45,6 +49,7 @@ impl ServerConfig {
                 args: Vec::new(),
                 headers: BTreeMap::new(),
             },
+            auth_provider: None,
         }
     }
 
@@ -56,6 +61,7 @@ impl ServerConfig {
                 args: Vec::new(),
                 headers: BTreeMap::new(),
             },
+            auth_provider: None,
         }
     }
 
@@ -79,11 +85,29 @@ impl ServerConfig {
         }
         self
     }
+
+    pub fn auth_provider(
+        mut self,
+        provider: impl Fn() -> Result<BTreeMap<String, String>, Error> + Send + Sync + 'static,
+    ) -> Self {
+        self.auth_provider = Some(Arc::new(provider));
+        self
+    }
+
+    fn materialize(mut self) -> Result<FfiSdkServerConfig, Error> {
+        if let Some(provider) = self.auth_provider.take() {
+            let provided = provider()?;
+            if let FfiSdkServerConfig::Structured { headers, .. } = &mut self.inner {
+                headers.extend(provided);
+            }
+        }
+        Ok(self.inner)
+    }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CompressorClientBuilder {
-    servers: BTreeMap<String, FfiSdkServerConfig>,
+    servers: BTreeMap<String, ServerConfig>,
     compression_level: CompressionLevel,
     server_name: Option<String>,
     include_tools: Vec<String>,
@@ -108,7 +132,7 @@ impl Default for CompressorClientBuilder {
 
 impl CompressorClientBuilder {
     pub fn server(mut self, name: impl Into<String>, config: ServerConfig) -> Self {
-        self.servers.insert(name.into(), config.inner);
+        self.servers.insert(name.into(), config);
         self
     }
 
@@ -147,7 +171,7 @@ impl CompressorClientBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CompressorClient {
     builder: CompressorClientBuilder,
 }
@@ -158,9 +182,14 @@ impl CompressorClient {
     }
 
     pub async fn connect(&self) -> Result<CompressorProxy, Error> {
-        let backends = normalize_sdk_servers(FfiSdkServersConfig::from_iter(
-            self.builder.servers.clone(),
-        ))?;
+        let materialized = self
+            .builder
+            .servers
+            .clone()
+            .into_iter()
+            .map(|(name, config)| config.materialize().map(|config| (name, config)))
+            .collect::<Result<Vec<_>, _>>()?;
+        let backends = normalize_sdk_servers(FfiSdkServersConfig::from_iter(materialized))?;
         let server = CompressedServer::connect_multi_stdio(
             CompressedServerConfig {
                 level: self.builder.compression_level.clone(),
@@ -352,6 +381,39 @@ mod tests {
 
     fn python_command() -> String {
         std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+    }
+
+    #[test]
+    fn server_config_auth_provider_materializes_headers() {
+        let config = ServerConfig::url("https://example.test/mcp")
+            .header("X-Static", "yes")
+            .auth_provider(|| {
+                Ok(BTreeMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer dynamic".to_string(),
+                )]))
+            })
+            .materialize()
+            .unwrap();
+
+        let backends = normalize_sdk_servers(FfiSdkServersConfig::from_iter([(
+            "remote".to_string(),
+            config,
+        )]))
+        .unwrap();
+
+        assert_eq!(backends[0].command_or_url, "https://example.test/mcp");
+        assert_eq!(
+            backends[0].args,
+            [
+                "-H",
+                "Authorization=Bearer dynamic",
+                "-H",
+                "X-Static=yes",
+                "--auth",
+                "explicit-headers",
+            ]
+        );
     }
 
     #[tokio::test]

--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -168,6 +168,68 @@ The SDKs expose the same main compression options as the CLI.
         .build();
     ```
 
+## Dynamic auth providers
+
+SDK clients can supply dynamic auth header providers for remote HTTP MCP servers. The provider is evaluated when the SDK opens the compressed session and its returned headers are forwarded to the backend. This is intended for agent runtimes that already manage access tokens and need to inject the current bearer token without shelling out to the CLI.
+
+=== "Python"
+
+    ```python
+    from mcp_compressor import CompressorClient
+
+    def auth_provider() -> dict[str, str]:
+        token = token_store.current_access_token()
+        return {"Authorization": f"Bearer {token}"}
+
+    client = CompressorClient(
+        servers={
+            "atlassian": {
+                "url": "https://mcp.atlassian.com/v1/mcp",
+                "auth_provider": auth_provider,
+            }
+        }
+    )
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+
+    const client = new CompressorClient({
+      servers: {
+        atlassian: {
+          url: "https://mcp.atlassian.com/v1/mcp",
+          authProvider: async () => ({
+            Authorization: `Bearer ${await tokenStore.currentAccessToken()}`,
+          }),
+        },
+      },
+    });
+    ```
+
+=== "Rust"
+
+    ```rust
+    use std::collections::BTreeMap;
+    use mcp_compressor::sdk::{CompressorClient, ServerConfig};
+
+    let client = CompressorClient::builder()
+        .server(
+            "atlassian",
+            ServerConfig::url("https://mcp.atlassian.com/v1/mcp")
+                .auth_provider(|| {
+                    Ok(BTreeMap::from([(
+                        "Authorization".to_string(),
+                        format!("Bearer {}", current_access_token()?),
+                    )]))
+                }),
+        )
+        .build();
+    ```
+
+Static `headers` and dynamic provider headers can be combined; provider headers override static headers with the same name.
+
 ## Lifecycle
 
 === "Python"

--- a/python/mcp-compressor/mcp_compressor/client.py
+++ b/python/mcp-compressor/mcp_compressor/client.py
@@ -71,7 +71,7 @@ def _backend_from_value(name: str, value: ServerConfig) -> BackendConfig:
             command_or_url=str(value["command"]),
             args=[str(arg) for arg in value.get("args", [])],
         )
-    msg = f"Unsupported server config for {name!r}"
+    msg = f"server {name!r} must define command or url"
     raise ValueError(msg)
 
 

--- a/python/mcp-compressor/mcp_compressor/client.py
+++ b/python/mcp-compressor/mcp_compressor/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -11,12 +12,12 @@ from mcp_compressor.core import (
     CompressedSession,
     CompressedSessionConfig,
     generate_client_artifacts,
-    normalize_sdk_servers,
     start_compressed_session,
     start_compressed_session_from_mcp_config,
 )
 
 CompressorMode = Literal["compressed", "cli", "bash", "python", "typescript"]
+AuthProvider = Callable[[], Mapping[str, str]]
 ServerConfig = dict[str, Any] | str | BackendConfig
 ServersInput = dict[str, ServerConfig] | ServerConfig | str
 
@@ -56,8 +57,8 @@ def _backend_from_value(name: str, value: ServerConfig) -> BackendConfig:
         return BackendConfig(name=name, command_or_url=value)
     if "url" in value:
         args: list[str] = []
-        headers = value.get("headers")
-        if isinstance(headers, dict):
+        headers = _resolve_headers(value)
+        if headers:
             for key, header_value in headers.items():
                 args.extend(["-H", f"{key}={header_value}"])
             if "--auth" not in value.get("args", []):
@@ -74,6 +75,26 @@ def _backend_from_value(name: str, value: ServerConfig) -> BackendConfig:
     raise ValueError(msg)
 
 
+def _resolve_headers(value: dict[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    raw_headers = value.get("headers")
+    if isinstance(raw_headers, dict):
+        headers.update({str(key): str(header_value) for key, header_value in raw_headers.items()})
+    provider = value.get("auth_provider")
+    if provider is None:
+        provider = value.get("authProvider")
+    if provider is not None:
+        if not callable(provider):
+            msg = "auth_provider must be callable"
+            raise TypeError(msg)
+        provided = provider()
+        if not isinstance(provided, Mapping):
+            msg = "auth_provider must return a mapping of header names to values"
+            raise TypeError(msg)
+        headers.update({str(key): str(header_value) for key, header_value in provided.items()})
+    return headers
+
+
 def _resolve_backends(servers: ServersInput) -> tuple[list[BackendConfig] | None, str | None]:
     if isinstance(servers, str):
         stripped = servers.strip()
@@ -82,7 +103,7 @@ def _resolve_backends(servers: ServersInput) -> tuple[list[BackendConfig] | None
         return [BackendConfig(name="default", command_or_url=servers)], None
     if isinstance(servers, BackendConfig):
         return [servers], None
-    return normalize_sdk_servers(servers), None
+    return [_backend_from_value(name, value) for name, value in servers.items()], None
 
 
 class CompressorProxy:

--- a/python/mcp-compressor/tests/test_core.py
+++ b/python/mcp-compressor/tests/test_core.py
@@ -235,6 +235,39 @@ def test_high_level_compressor_client_exposes_cli_and_bash_modes(monkeypatch) ->
         assert "alpha_echo" in host.custom_commands
 
 
+def test_high_level_compressor_client_supports_dynamic_auth_provider() -> None:
+    from mcp_compressor import normalize_servers
+
+    calls = 0
+
+    def auth_provider() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {"Authorization": f"Bearer token-{calls}"}
+
+    backends = normalize_servers(
+        {
+            "remote": {
+                "url": "https://example.test/mcp",
+                "headers": {"X-Static": "yes"},
+                "auth_provider": auth_provider,
+            }
+        }
+    )
+
+    assert calls == 1
+    assert backends is not None
+    assert backends[0].command_or_url == "https://example.test/mcp"
+    assert backends[0].args == [
+        "-H",
+        "X-Static=yes",
+        "-H",
+        "Authorization=Bearer token-1",
+        "--auth",
+        "explicit-headers",
+    ]
+
+
 def test_high_level_compressor_client_supports_remote_config_shape() -> None:
     from mcp_compressor import normalize_servers
 

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -8,7 +8,12 @@ import type { BackendConfig as LegacyBackendConfig, JsonConfigServerEntry } from
 import type { CompressedSession, CompressedSessionInfo } from "./rust_core.js";
 
 export type NativeCompressorMode = "compressed" | "cli" | "bash" | "python" | "typescript";
-export type NativeServerConfig = LegacyBackendConfig | JsonConfigServerEntry | string;
+export type AuthProvider = () => Record<string, string> | Promise<Record<string, string>>;
+export type NativeServerObjectConfig = (LegacyBackendConfig | JsonConfigServerEntry) & {
+  authProvider?: AuthProvider;
+  auth_provider?: AuthProvider;
+};
+export type NativeServerConfig = NativeServerObjectConfig | string;
 export type NativeServersInput = Record<string, NativeServerConfig> | LegacyBackendConfig | string;
 
 export interface CompressorClientOptions {
@@ -53,7 +58,32 @@ export interface NormalizedBackendConfig {
   args?: string[];
 }
 
-export function normalizeServers(servers: NativeServersInput): NormalizedBackendConfig[] | string {
+async function resolveAuthHeaders(
+  config: Record<string, unknown>,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {};
+  const rawHeaders = config.headers;
+  if (rawHeaders && typeof rawHeaders === "object" && !Array.isArray(rawHeaders)) {
+    for (const [key, value] of Object.entries(rawHeaders as Record<string, unknown>)) {
+      headers[key] = String(value);
+    }
+  }
+  const provider = config.authProvider ?? config.auth_provider;
+  if (provider !== undefined) {
+    if (typeof provider !== "function") {
+      throw new TypeError("authProvider must be a function");
+    }
+    const provided = await (provider as AuthProvider)();
+    for (const [key, value] of Object.entries(provided)) {
+      headers[key] = String(value);
+    }
+  }
+  return headers;
+}
+
+export async function normalizeServers(
+  servers: NativeServersInput,
+): Promise<NormalizedBackendConfig[] | string> {
   if (typeof servers === "string") {
     const trimmed = servers.trim();
     if (trimmed.startsWith("{")) {
@@ -62,9 +92,20 @@ export function normalizeServers(servers: NativeServersInput): NormalizedBackend
     return [{ name: "default", commandOrUrl: servers }];
   }
   if (isLegacyBackendConfig(servers)) {
-    return [legacyBackendToNative("default", servers)];
+    return [await legacyBackendToNative("default", servers)];
   }
-  return normalizeSdkServers(servers);
+  const materialized: Record<string, unknown> = {};
+  for (const [name, config] of Object.entries(servers as Record<string, NativeServerConfig>)) {
+    if (typeof config === "object" && config !== null && "url" in config) {
+      materialized[name] = {
+        ...config,
+        headers: await resolveAuthHeaders(config as Record<string, unknown>),
+      };
+    } else {
+      materialized[name] = config;
+    }
+  }
+  return normalizeSdkServers(materialized);
 }
 
 function isLegacyBackendConfig(value: unknown): value is LegacyBackendConfig {
@@ -73,16 +114,17 @@ function isLegacyBackendConfig(value: unknown): value is LegacyBackendConfig {
   );
 }
 
-function legacyBackendToNative(
+async function legacyBackendToNative(
   name: string,
   backend: LegacyBackendConfig,
-): NormalizedBackendConfig {
+): Promise<NormalizedBackendConfig> {
   if (backend.type === "stdio") {
     return { name, commandOrUrl: backend.command, args: backend.args ?? [] };
   }
   const args: string[] = [];
-  if (backend.headers) {
-    for (const [key, value] of Object.entries(backend.headers)) {
+  const headers = await resolveAuthHeaders(backend as unknown as Record<string, unknown>);
+  if (Object.keys(headers).length > 0) {
+    for (const [key, value] of Object.entries(headers)) {
       args.push("-H", `${key}=${value}`);
     }
     args.push("--auth", "explicit-headers");
@@ -230,7 +272,7 @@ export class CompressorClient {
     if (this.session) {
       return new CompressorProxy(this.session, this.defaultServer());
     }
-    const normalized = normalizeServers(this.options.servers);
+    const normalized = await normalizeServers(this.options.servers);
     const config = {
       compressionLevel: this.options.compressionLevel ?? "medium",
       serverName: this.options.serverName ?? null,
@@ -252,8 +294,14 @@ export class CompressorClient {
   }
 
   private defaultServer(): string | null {
-    const normalized = normalizeServers(this.options.servers);
-    if (typeof normalized === "string") return null;
-    return normalized.length === 1 ? normalized[0]!.name : null;
+    const servers = this.options.servers;
+    if (typeof servers === "string") {
+      return servers.trim().startsWith("{") ? null : "default";
+    }
+    if (isLegacyBackendConfig(servers)) {
+      return "default";
+    }
+    const names = Object.keys(servers as Record<string, NativeServerConfig>);
+    return names.length === 1 ? names[0]! : null;
   }
 }

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -620,8 +620,38 @@ describe("Rust native core wrapper", () => {
     }
   });
 
-  it("normalizes high-level native server config", () => {
-    const normalized = normalizeServers({
+  it("normalizes dynamic auth providers before starting native sessions", async () => {
+    let calls = 0;
+    const normalized = await normalizeServers({
+      remote: {
+        url: "https://example.test/mcp",
+        headers: { "X-Static": "yes" },
+        authProvider: async () => {
+          calls += 1;
+          return { Authorization: `Bearer token-${calls}` };
+        },
+      },
+    });
+
+    expect(calls).toBe(1);
+    expect(normalized).toEqual([
+      {
+        name: "remote",
+        commandOrUrl: "https://example.test/mcp",
+        args: [
+          "-H",
+          "Authorization=Bearer token-1",
+          "-H",
+          "X-Static=yes",
+          "--auth",
+          "explicit-headers",
+        ],
+      },
+    ]);
+  });
+
+  it("normalizes high-level native server config", async () => {
+    const normalized = await normalizeServers({
       remote: {
         url: "https://example.test/mcp",
         headers: { Authorization: "Bearer token" },


### PR DESCRIPTION
## Summary
- add SDK-only dynamic auth provider support for Rust, Python, and TypeScript clients
- materialize provider-returned headers into backend remote HTTP config when a compressed session is opened
- support static headers plus provider headers; provider values override by header key
- document SDK usage for dynamic bearer-token injection

## Notes
This matches the SDK consumption pattern enabled on main by custom fetch support, but exposes a language-neutral auth-provider API instead of a TS-specific fetch hook. The provider is evaluated when the SDK opens the compressed session; a future transport-level wrapper can extend this to per-request refresh without changing the public API.

## Validation
- `cargo test -p mcp-compressor-core sdk::tests::server_config_auth_provider_materializes_headers -- --nocapture`
- `cargo check -p mcp-compressor-core`
- `cd python/mcp-compressor && uv run maturin develop && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests/test_core.py::test_high_level_compressor_client_supports_dynamic_auth_provider tests/test_core.py::test_high_level_compressor_client_supports_remote_config_shape`
- `cd typescript && bun run build:native && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "normalizes" && bun run typecheck && bun run lint && bun run format:check`
- `make docs-test`
- `make check`