### PR TITLE
docs: clarify SDK auth provider semantics

### DIFF
--- a/crates/mcp-compressor-core/src/sdk.rs
+++ b/crates/mcp-compressor-core/src/sdk.rs
@@ -416,6 +416,52 @@ mod tests {
         );
     }
 
+    #[test]
+    fn auth_provider_is_evaluated_each_time_config_is_materialized() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let first_calls = Arc::clone(&calls);
+        let first = ServerConfig::url("https://example.test/mcp")
+            .auth_provider(move || {
+                let call = first_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                Ok(BTreeMap::from([(
+                    "Authorization".to_string(),
+                    format!("Bearer token-{call}"),
+                )]))
+            })
+            .materialize()
+            .unwrap();
+        let second_calls = Arc::clone(&calls);
+        let second = ServerConfig::url("https://example.test/mcp")
+            .auth_provider(move || {
+                let call = second_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                Ok(BTreeMap::from([(
+                    "Authorization".to_string(),
+                    format!("Bearer token-{call}"),
+                )]))
+            })
+            .materialize()
+            .unwrap();
+
+        let first_backend = normalize_sdk_servers(FfiSdkServersConfig::from_iter([(
+            "remote".to_string(),
+            first,
+        )]))
+        .unwrap();
+        let second_backend = normalize_sdk_servers(FfiSdkServersConfig::from_iter([(
+            "remote".to_string(),
+            second,
+        )]))
+        .unwrap();
+
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert!(first_backend[0]
+            .args
+            .contains(&"Authorization=Bearer token-1".to_string()));
+        assert!(second_backend[0]
+            .args
+            .contains(&"Authorization=Bearer token-2".to_string()));
+    }
+
     #[tokio::test]
     async fn compressor_client_invokes_single_server_without_compressor_subprocess() {
         let client = CompressorClient::builder()

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -2,6 +2,12 @@
 
 This page is a human-oriented map of the main SDK objects. Generated API references can be added once the migration package layout is finalized.
 
+## Auth provider semantics
+
+Python, TypeScript, and Rust SDK clients support dynamic auth providers for remote HTTP backend servers. These providers are evaluated when a compressed session is opened. To use a refreshed token, close the current proxy/session and reconnect.
+
+This current session-start behavior is intentionally conservative and keeps the public API compatible with a future per-request transport-level refresh implementation.
+
 ## Shared concepts
 
 | Concept | Python | TypeScript | Rust |

--- a/docs/usage/auth-and-remote.md
+++ b/docs/usage/auth-and-remote.md
@@ -67,6 +67,76 @@ mcp-compressor clear-oauth remote
 
 Python and TypeScript also expose OAuth store helper APIs for applications that need to list or clear stored credentials.
 
+## SDK auth providers
+
+When your application already owns token refresh, prefer SDK auth providers over embedding static headers in config. Auth providers are currently evaluated when a compressed session is opened.
+
+=== "Python"
+
+    ```python
+    from mcp_compressor import CompressorClient
+
+    client = CompressorClient(
+        servers={
+            "remote": {
+                "url": "https://mcp.example.com/v1/mcp",
+                "auth_provider": lambda: {"Authorization": f"Bearer {token_store.current()}"},
+            }
+        }
+    )
+
+    proxy = client.connect()
+
+    # Later, after refreshing the token:
+    proxy.close()
+    proxy = client.connect()
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+
+    const client = new CompressorClient({
+      servers: {
+        remote: {
+          url: "https://mcp.example.com/v1/mcp",
+          authProvider: async () => ({
+            Authorization: `Bearer ${await tokenStore.current()}`,
+          }),
+        },
+      },
+    });
+
+    let proxy = await client.connect();
+
+    // Later, after refreshing the token:
+    proxy.close();
+    proxy = await client.connect();
+    ```
+
+=== "Rust"
+
+    ```rust
+    use std::collections::BTreeMap;
+    use mcp_compressor::sdk::{CompressorClient, ServerConfig};
+
+    let client = CompressorClient::builder()
+        .server(
+            "remote",
+            ServerConfig::url("https://mcp.example.com/v1/mcp")
+                .auth_provider(|| {
+                    Ok(BTreeMap::from([(
+                        "Authorization".to_string(),
+                        format!("Bearer {}", token_store_current()?),
+                    )]))
+                }),
+        )
+        .build();
+    ```
+
+For long-lived sessions, close and reconnect to pick up refreshed credentials. Per-request token refresh is planned as a transport-level enhancement.
+
 ## Explicit headers
 
 Use explicit headers when you already have a token or need non-interactive CI.

--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -170,7 +170,15 @@ The SDKs expose the same main compression options as the CLI.
 
 ## Dynamic auth providers
 
-SDK clients can supply dynamic auth header providers for remote HTTP MCP servers. The provider is evaluated when the SDK opens the compressed session and its returned headers are forwarded to the backend. This is intended for agent runtimes that already manage access tokens and need to inject the current bearer token without shelling out to the CLI.
+SDK clients can supply auth header providers for remote HTTP MCP servers. The provider is evaluated when the SDK opens a compressed session and its returned headers are forwarded to the backend. This is intended for agent runtimes that already manage access tokens and need to inject the current bearer token without shelling out to the CLI.
+
+For long-lived sessions, recreate the compressed session to pick up a refreshed token:
+
+1. refresh or rotate the token in your application,
+2. close the current proxy/session,
+3. call `connect()` again.
+
+The public `auth_provider` / `authProvider` API is intentionally compatible with a future per-request transport implementation, but the current implementation is **session-start auth**, not per-request auth.
 
 === "Python"
 

--- a/python/mcp-compressor/tests/test_core.py
+++ b/python/mcp-compressor/tests/test_core.py
@@ -235,7 +235,7 @@ def test_high_level_compressor_client_exposes_cli_and_bash_modes(monkeypatch) ->
         assert "alpha_echo" in host.custom_commands
 
 
-def test_high_level_compressor_client_supports_dynamic_auth_provider() -> None:
+def test_high_level_compressor_client_calls_auth_provider_each_time_servers_are_resolved() -> None:
     from mcp_compressor import normalize_servers
 
     calls = 0

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -620,7 +620,7 @@ describe("Rust native core wrapper", () => {
     }
   });
 
-  it("normalizes dynamic auth providers before starting native sessions", async () => {
+  it("calls authProvider each time servers are normalized", async () => {
     let calls = 0;
     const normalized = await normalizeServers({
       remote: {


### PR DESCRIPTION
## Summary
- clarify that SDK auth providers are evaluated when a compressed session is opened
- document reconnecting to pick up refreshed tokens in Python, TypeScript, and Rust
- add an SDK reference note that per-request token refresh is future transport-level work
- rename Python/TypeScript tests to reflect current session-start normalization behavior
- add a Rust regression test showing auth provider materialization happens each time config is materialized

## Validation
- `cargo test -p mcp-compressor-core sdk::tests::auth_provider -- --nocapture`
- `cargo check -p mcp-compressor-core`
- `cd python/mcp-compressor && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests/test_core.py::test_high_level_compressor_client_calls_auth_provider_each_time_servers_are_resolved`
- `cd typescript && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "calls authProvider" && bun run typecheck && bun run lint && bun run format:check`
- `make docs-test`
- `make check`