### PR TITLE
feat: refresh sdk auth providers per request

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/mod.rs
+++ b/crates/mcp-compressor-core/src/ffi/mod.rs
@@ -27,5 +27,6 @@ pub use pure::{
 };
 pub use session::{
     normalize_sdk_servers,
-    start_compressed_session, start_compressed_session_from_mcp_config, FfiCompressedSession,
+    start_compressed_session, start_compressed_session_from_mcp_config,
+    start_compressed_session_with_backend_configs, FfiCompressedSession,
 };

--- a/crates/mcp-compressor-core/src/ffi/session.rs
+++ b/crates/mcp-compressor-core/src/ffi/session.rs
@@ -126,6 +126,17 @@ pub async fn start_compressed_session(
     config: FfiCompressedSessionConfig,
     backends: Vec<FfiBackendConfig>,
 ) -> Result<FfiCompressedSession, Error> {
+    start_compressed_session_with_backend_configs(
+        config,
+        backends.into_iter().map(Into::into).collect(),
+    )
+    .await
+}
+
+pub async fn start_compressed_session_with_backend_configs(
+    config: FfiCompressedSessionConfig,
+    backends: Vec<crate::server::BackendServerConfig>,
+) -> Result<FfiCompressedSession, Error> {
     let server = CompressedServer::connect_multi_stdio(
         CompressedServerConfig {
             level: config.compression_level.parse()?,
@@ -136,7 +147,7 @@ pub async fn start_compressed_session(
             transform_mode: parse_ffi_transform_mode(config.transform_mode.as_deref())?,
             ..CompressedServerConfig::default()
         },
-        backends.into_iter().map(Into::into).collect(),
+        backends,
     )
     .await?;
     compressed_session_from_server(server).await

--- a/crates/mcp-compressor-core/tests/fixtures/rotating_auth_proxy.py
+++ b/crates/mcp-compressor-core/tests/fixtures/rotating_auth_proxy.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import http.server
+import os
+import sys
+import threading
+import urllib.error
+import urllib.request
+
+TARGET_URL = os.environ["MCP_COMPRESSOR_AUTH_PROXY_TARGET"].rstrip("/")
+EXPECTED_START = int(os.environ.get("MCP_COMPRESSOR_AUTH_PROXY_EXPECTED_START", "1"))
+ALLOW_INITIAL_REPEATS = int(os.environ.get("MCP_COMPRESSOR_AUTH_PROXY_ALLOW_INITIAL_REPEATS", "0"))
+ALLOW_ANY_REPEATS = int(os.environ.get("MCP_COMPRESSOR_AUTH_PROXY_ALLOW_ANY_REPEATS", "0"))
+DEBUG = os.environ.get("MCP_COMPRESSOR_AUTH_PROXY_DEBUG") == "1"
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    counter = 0
+    last_token = EXPECTED_START - 1
+    initial_repeats = 0
+    any_repeats = 0
+    lock = threading.Lock()
+
+    def do_POST(self) -> None:
+        self._proxy()
+
+    def do_GET(self) -> None:
+        self._proxy()
+
+    def do_DELETE(self) -> None:
+        self._proxy()
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def _proxy(self) -> None:  # noqa: C901
+        actual = self.headers.get("Authorization")
+        if DEBUG:
+            print(
+                f"AUTH_PROXY_REQUEST method={self.command} path={self.path} auth={actual}", file=sys.stderr, flush=True
+            )
+        if actual is None or not actual.startswith("Bearer token-"):
+            self.send_response(401)
+            self.end_headers()
+            self.wfile.write(f"expected rotating bearer token, got {actual}".encode())
+            return
+        try:
+            token_number = int(actual.rsplit("-", 1)[1])
+        except ValueError:
+            self.send_response(401)
+            self.end_headers()
+            self.wfile.write(f"invalid rotating bearer token: {actual}".encode())
+            return
+        with Handler.lock:
+            Handler.counter += 1
+            if token_number == Handler.last_token and Handler.counter <= ALLOW_ANY_REPEATS + 1:
+                Handler.any_repeats += 1
+            elif (
+                token_number == EXPECTED_START
+                and Handler.last_token == EXPECTED_START
+                and Handler.initial_repeats < ALLOW_INITIAL_REPEATS
+            ):
+                Handler.initial_repeats += 1
+            elif token_number < EXPECTED_START or token_number <= Handler.last_token:
+                self.send_response(401)
+                self.end_headers()
+                self.wfile.write(
+                    f"expected token number > {Handler.last_token} and >= {EXPECTED_START}, got {token_number}".encode()
+                )
+                return
+            else:
+                Handler.last_token = token_number
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length else None
+        target = f"{TARGET_URL}{self.path}"
+        headers = {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in {"host", "content-length", "authorization"}
+        }
+        if DEBUG:
+            print(f"AUTH_PROXY_FORWARD target={target}", file=sys.stderr, flush=True)
+        request = urllib.request.Request(target, data=body, headers=headers, method=self.command)  # noqa: S310
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - local test proxy
+                payload = response.read()
+                if DEBUG:
+                    print(
+                        f"AUTH_PROXY_RESPONSE status={response.status} bytes={len(payload)}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                self.send_response(response.status)
+                for key, value in response.headers.items():
+                    if key.lower() not in {"transfer-encoding", "connection", "content-length"}:
+                        self.send_header(key, value)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+        except urllib.error.HTTPError as error:
+            payload = error.read()
+            if DEBUG:
+                print(
+                    f"AUTH_PROXY_HTTP_ERROR status={error.code} bytes={len(payload)} body={payload.decode(errors='replace')}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            self.send_response(error.code)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except Exception as error:
+            if DEBUG:
+                print(f"AUTH_PROXY_FORWARD_ERROR {type(error).__name__}: {error}", file=sys.stderr, flush=True)
+            self.send_response(502)
+            self.end_headers()
+            self.wfile.write(str(error).encode())
+
+
+def main() -> None:
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    print(f"AUTH_PROXY_URL=http://127.0.0.1:{server.server_port}", file=sys.stderr, flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -1,3 +1,7 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use mcp_compressor_core::server::{BackendAuthMode, BackendServerConfig};
 use napi::Error as NapiError;
 use napi_derive::napi;
 use serde::Deserialize;
@@ -19,6 +23,24 @@ fn napi_error(error: impl std::fmt::Display) -> NapiError {
 
 fn parse_json<T: for<'de> Deserialize<'de>>(value: &str) -> napi::Result<T> {
     serde_json::from_str(value).map_err(napi_error)
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderBackendConfig {
+    name: String,
+    command_or_url: String,
+    #[serde(default)]
+    args: Vec<String>,
+    provider_index: Option<usize>,
+}
+
+type HeaderStore = Arc<RwLock<BTreeMap<String, String>>>;
+
+fn headers_from_store(store: HeaderStore) -> Result<BTreeMap<String, String>, mcp_compressor_core::Error> {
+    store
+        .read()
+        .map(|headers| headers.clone())
+        .map_err(|error| mcp_compressor_core::Error::Config(format!("auth header store poisoned: {error}")))
 }
 
 #[napi]
@@ -100,6 +122,7 @@ pub fn clear_oauth_credentials_json(target: Option<String>) -> napi::Result<Stri
 #[napi]
 pub struct NativeCompressedSession {
     inner: FfiCompressedSession,
+    auth_header_stores: Vec<HeaderStore>,
 }
 
 #[napi]
@@ -111,6 +134,24 @@ impl NativeCompressedSession {
 
     #[napi]
     pub fn close(&mut self) {}
+
+    #[napi]
+    pub fn update_auth_provider_headers_json(
+        &self,
+        provider_index: u32,
+        headers_json: String,
+    ) -> napi::Result<()> {
+        let headers = parse_json::<BTreeMap<String, String>>(&headers_json)?;
+        let store = self
+            .auth_header_stores
+            .get(provider_index as usize)
+            .ok_or_else(|| napi_error(format!("auth provider index out of range: {provider_index}")))?;
+        let mut guard = store
+            .write()
+            .map_err(|error| napi_error(format!("auth header store poisoned: {error}")))?;
+        *guard = headers;
+        Ok(())
+    }
 }
 
 #[napi]
@@ -121,7 +162,49 @@ pub async fn start_compressed_session_json(
     let config = parse_json::<FfiCompressedSessionConfig>(&config_json)?;
     let backends = parse_json::<Vec<FfiBackendConfig>>(&backends_json)?;
     let inner = start_compressed_session(config, backends).await.map_err(napi_error)?;
-    Ok(NativeCompressedSession { inner })
+    Ok(NativeCompressedSession {
+        inner,
+        auth_header_stores: Vec::new(),
+    })
+}
+
+#[napi]
+pub async fn start_compressed_session_with_provider_backends_json(
+    config_json: String,
+    backends_json: String,
+    providers_json: String,
+) -> napi::Result<NativeCompressedSession> {
+    let config = parse_json::<FfiCompressedSessionConfig>(&config_json)?;
+    let backends = parse_json::<Vec<ProviderBackendConfig>>(&backends_json)?;
+    let providers = parse_json::<Vec<BTreeMap<String, String>>>(&providers_json)?
+        .into_iter()
+        .map(|headers| Arc::new(RwLock::new(headers)))
+        .collect::<Vec<_>>();
+    let mut backend_configs = Vec::new();
+    for backend in backends {
+        let mut config = BackendServerConfig::new(backend.name, backend.command_or_url, backend.args);
+        if let Some(index) = backend.provider_index {
+            let store = Arc::clone(
+                providers
+                    .get(index)
+                    .ok_or_else(|| napi_error(format!("auth provider index out of range: {index}")))?,
+            );
+            config = config
+                .with_header_provider(Arc::new(move || headers_from_store(Arc::clone(&store))))
+                .with_auth_mode(BackendAuthMode::ExplicitHeaders);
+        }
+        backend_configs.push(config);
+    }
+    let inner = mcp_compressor_core::ffi::start_compressed_session_with_backend_configs(
+        config,
+        backend_configs,
+    )
+    .await
+    .map_err(napi_error)?;
+    Ok(NativeCompressedSession {
+        inner,
+        auth_header_stores: providers,
+    })
 }
 
 #[napi]
@@ -133,5 +216,8 @@ pub async fn start_compressed_session_from_mcp_config_json(
     let inner = start_compressed_session_from_mcp_config(config, &mcp_config_json)
         .await
         .map_err(napi_error)?;
-    Ok(NativeCompressedSession { inner })
+    Ok(NativeCompressedSession {
+        inner,
+        auth_header_stores: Vec::new(),
+    })
 }

--- a/crates/mcp-compressor-python/src/lib.rs
+++ b/crates/mcp-compressor-python/src/lib.rs
@@ -1,5 +1,10 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use mcp_compressor_core::server::{BackendAuthMode, BackendServerConfig};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -18,6 +23,37 @@ fn py_value_error(error: impl std::fmt::Display) -> PyErr {
 
 fn parse_json<T: for<'de> Deserialize<'de>>(value: &str) -> PyResult<T> {
     serde_json::from_str(value).map_err(py_value_error)
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderBackendConfig {
+    name: String,
+    command_or_url: String,
+    #[serde(default)]
+    args: Vec<String>,
+    provider_index: Option<usize>,
+}
+
+fn provider_headers_from_python(provider: &Py<PyAny>) -> Result<BTreeMap<String, String>, mcp_compressor_core::Error> {
+    Python::attach(|py| {
+        let value = provider
+            .call0(py)
+            .map_err(|error| mcp_compressor_core::Error::Config(error.to_string()))?;
+        let dict = value
+            .downcast_bound::<PyDict>(py)
+            .map_err(|_| mcp_compressor_core::Error::Config("auth_provider must return a dict".to_string()))?;
+        let mut headers = BTreeMap::new();
+        for (key, value) in dict.iter() {
+            headers.insert(
+                key.extract::<String>()
+                    .map_err(|error| mcp_compressor_core::Error::Config(error.to_string()))?,
+                value
+                    .extract::<String>()
+                    .map_err(|error| mcp_compressor_core::Error::Config(error.to_string()))?,
+            );
+        }
+        Ok(headers)
+    })
 }
 
 #[pyfunction]
@@ -107,6 +143,43 @@ fn start_compressed_session_json(
 }
 
 #[pyfunction]
+fn start_compressed_session_with_provider_backends_json(
+    py: Python<'_>,
+    config_json: &str,
+    backends_json: &str,
+    providers: Vec<Py<PyAny>>,
+) -> PyResult<PyCompressedSession> {
+    let config = parse_json::<FfiCompressedSessionConfig>(config_json)?;
+    let backends = parse_json::<Vec<ProviderBackendConfig>>(backends_json)?;
+    let mut backend_configs = Vec::new();
+    for backend in backends {
+        let mut config = BackendServerConfig::new(backend.name, backend.command_or_url, backend.args);
+        if let Some(index) = backend.provider_index {
+            let provider = Python::attach(|py| {
+                providers
+                    .get(index)
+                    .ok_or_else(|| py_value_error(format!("auth provider index out of range: {index}")))
+                    .map(|provider| provider.clone_ref(py))
+            })?;
+            config = config
+                .with_header_provider(Arc::new(move || provider_headers_from_python(&provider)))
+                .with_auth_mode(BackendAuthMode::ExplicitHeaders);
+        }
+        backend_configs.push(config);
+    }
+    let runtime = tokio::runtime::Runtime::new().map_err(py_value_error)?;
+    let inner = py
+        .detach(|| {
+            runtime.block_on(mcp_compressor_core::ffi::start_compressed_session_with_backend_configs(
+                config,
+                backend_configs,
+            ))
+        })
+        .map_err(py_value_error)?;
+    Ok(PyCompressedSession { inner, runtime })
+}
+
+#[pyfunction]
 fn start_compressed_session_from_mcp_config_json(
     config_json: &str,
     mcp_config_json: &str,
@@ -139,6 +212,7 @@ fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(normalize_servers_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_mcp_config_json, module)?)?;
     module.add_function(wrap_pyfunction!(start_compressed_session_json, module)?)?;
+    module.add_function(wrap_pyfunction!(start_compressed_session_with_provider_backends_json, module)?)?;
     module.add_function(wrap_pyfunction!(start_compressed_session_from_mcp_config_json, module)?)?;
     module.add_function(wrap_pyfunction!(list_oauth_credentials_json, module)?)?;
     module.add_function(wrap_pyfunction!(clear_oauth_credentials_json, module)?)?;

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -4,12 +4,7 @@ This page is a human-oriented map of the main SDK objects. Generated API referen
 
 ## Auth provider semantics
 
-Python, TypeScript, and Rust SDK clients support dynamic auth providers for remote HTTP backend servers.
-
-- Rust providers are evaluated by the remote HTTP transport for each backend request.
-- Python and TypeScript providers are currently evaluated when a compressed session is opened. To use a refreshed token in those bindings, close the current proxy/session and reconnect.
-
-The Python and TypeScript public APIs are intentionally compatible with future per-request binding-level provider registries.
+Python, TypeScript, and Rust SDK clients support dynamic auth providers for remote HTTP backend servers. Providers are evaluated by the remote HTTP transport for each backend request, so long-lived sessions can attach freshly rotated bearer tokens without reconnecting.
 
 ## Shared concepts
 

--- a/docs/usage/auth-and-remote.md
+++ b/docs/usage/auth-and-remote.md
@@ -69,7 +69,7 @@ Python and TypeScript also expose OAuth store helper APIs for applications that 
 
 ## SDK auth providers
 
-When your application already owns token refresh, prefer SDK auth providers over embedding static headers in config. Rust SDK auth providers are evaluated for each remote backend request. Python and TypeScript SDK auth providers are currently evaluated when a compressed session is opened.
+When your application already owns token refresh, prefer SDK auth providers over embedding static headers in config. SDK auth providers are evaluated for each remote backend request in Rust, Python, and TypeScript.
 
 === "Python"
 
@@ -135,7 +135,7 @@ When your application already owns token refresh, prefer SDK auth providers over
         .build();
     ```
 
-For Python and TypeScript long-lived sessions, close and reconnect to pick up refreshed credentials. Rust SDK sessions can refresh per request through `ServerConfig::auth_provider(...)`. Python and TypeScript per-request provider registries are planned as binding-level follow-ups.
+Long-lived SDK sessions can refresh per request by returning the latest headers from the provider callback.
 
 ## Explicit headers
 

--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -170,15 +170,7 @@ The SDKs expose the same main compression options as the CLI.
 
 ## Dynamic auth providers
 
-SDK clients can supply auth header providers for remote HTTP MCP servers. The provider is evaluated when the SDK opens a compressed session and its returned headers are forwarded to the backend. This is intended for agent runtimes that already manage access tokens and need to inject the current bearer token without shelling out to the CLI.
-
-For long-lived sessions, recreate the compressed session to pick up a refreshed token:
-
-1. refresh or rotate the token in your application,
-2. close the current proxy/session,
-3. call `connect()` again.
-
-Rust SDK auth providers are evaluated by the remote HTTP transport for each backend request. Python and TypeScript SDK auth providers are currently evaluated when the compressed session is opened; close and reconnect those sessions to pick up a refreshed token until their binding-level provider registries are wired to the transport layer.
+SDK clients can supply auth header providers for remote HTTP MCP servers. Providers are evaluated by the remote HTTP transport for each backend request in Rust, Python, and TypeScript. Use them when your application owns token refresh and needs the latest bearer token attached to every backend MCP request without shelling out to the CLI.
 
 === "Python"
 

--- a/python/mcp-compressor/mcp_compressor/client.py
+++ b/python/mcp-compressor/mcp_compressor/client.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
-from urllib import request
+from urllib import error, request
 
 from mcp_compressor.core import (
     BackendConfig,
@@ -14,6 +14,7 @@ from mcp_compressor.core import (
     generate_client_artifacts,
     start_compressed_session,
     start_compressed_session_from_mcp_config,
+    start_compressed_session_with_auth_providers,
 )
 
 CompressorMode = Literal["compressed", "cli", "bash", "python", "typescript"]
@@ -50,14 +51,40 @@ class JustBashProvider:
     tools: list[JustBashCommand]
 
 
-def _backend_from_value(name: str, value: ServerConfig) -> BackendConfig:
+def _provider_from_value(value: ServerConfig) -> AuthProvider | None:
+    if not isinstance(value, dict):
+        return None
+    provider = value.get("auth_provider")
+    if provider is None:
+        provider = value.get("authProvider")
+    if provider is None:
+        return None
+    if not callable(provider):
+        msg = "auth_provider must be callable"
+        raise TypeError(msg)
+    return provider
+
+
+def _backend_provider_payload(name: str, value: ServerConfig, provider_index: int | None) -> dict[str, Any]:
+    backend = _backend_from_value(name, value, resolve_provider=provider_index is not None)
+    payload = {
+        "name": backend.name,
+        "command_or_url": backend.command_or_url,
+        "args": backend.args or [],
+    }
+    if provider_index is not None:
+        payload["provider_index"] = provider_index
+    return payload
+
+
+def _backend_from_value(name: str, value: ServerConfig, *, resolve_provider: bool = True) -> BackendConfig:
     if isinstance(value, BackendConfig):
         return value
     if isinstance(value, str):
         return BackendConfig(name=name, command_or_url=value)
     if "url" in value:
         args: list[str] = []
-        headers = _resolve_headers(value)
+        headers = _resolve_headers(value) if resolve_provider else _resolve_headers(value, include_provider=False)
         if headers:
             for key, header_value in headers.items():
                 args.extend(["-H", f"{key}={header_value}"])
@@ -75,7 +102,7 @@ def _backend_from_value(name: str, value: ServerConfig) -> BackendConfig:
     raise ValueError(msg)
 
 
-def _resolve_headers(value: dict[str, Any]) -> dict[str, str]:
+def _resolve_headers(value: dict[str, Any], *, include_provider: bool = True) -> dict[str, str]:
     headers: dict[str, str] = {}
     raw_headers = value.get("headers")
     if isinstance(raw_headers, dict):
@@ -83,7 +110,7 @@ def _resolve_headers(value: dict[str, Any]) -> dict[str, str]:
     provider = value.get("auth_provider")
     if provider is None:
         provider = value.get("authProvider")
-    if provider is not None:
+    if include_provider and provider is not None:
         if not callable(provider):
             msg = "auth_provider must be callable"
             raise TypeError(msg)
@@ -93,6 +120,28 @@ def _resolve_headers(value: dict[str, Any]) -> dict[str, str]:
             raise TypeError(msg)
         headers.update({str(key): str(header_value) for key, header_value in provided.items()})
     return headers
+
+
+def _resolve_provider_backends(
+    servers: ServersInput,
+) -> tuple[list[dict[str, Any]] | None, list[AuthProvider], str | None]:
+    if isinstance(servers, str):
+        stripped = servers.strip()
+        if stripped.startswith("{"):
+            return None, [], servers
+        return [{"name": "default", "command_or_url": servers, "args": []}], [], None
+    if isinstance(servers, BackendConfig):
+        return [servers.to_json_dict()], [], None
+    payloads: list[dict[str, Any]] = []
+    providers: list[AuthProvider] = []
+    for name, value in servers.items():
+        provider = _provider_from_value(value)
+        provider_index = None
+        if provider is not None:
+            provider_index = len(providers)
+            providers.append(provider)
+        payloads.append(_backend_provider_payload(name, value, provider_index))
+    return payloads, providers, None
 
 
 def _resolve_backends(servers: ServersInput) -> tuple[list[BackendConfig] | None, str | None]:
@@ -181,8 +230,13 @@ class CompressorProxy:
             },
             method="POST",
         )
-        with request.urlopen(req, timeout=30) as response:  # noqa: S310 - local Rust proxy
-            return ProxyResponse(response.read().decode())
+        try:
+            with request.urlopen(req, timeout=30) as response:  # noqa: S310 - local Rust proxy
+                return ProxyResponse(response.read().decode())
+        except error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            msg = f"Proxy invocation failed: HTTP {exc.code}: {detail}"
+            raise RuntimeError(msg) from exc
 
     def schema(self, tool: str, *, server: str | None = None) -> dict[str, Any]:
         scoped_tools = self._session.info().get("backend_tools_by_server", [])
@@ -253,10 +307,15 @@ class CompressorClient:
     def connect(self) -> CompressorProxy:
         if self._session is not None:
             return CompressorProxy(self._session, self._default_server())
-        backends, mcp_config_json = _resolve_backends(self._servers)
+        provider_backends, providers, mcp_config_json = _resolve_provider_backends(self._servers)
         if mcp_config_json is not None:
             self._session = start_compressed_session_from_mcp_config(self._config, mcp_config_json)
+        elif providers:
+            self._session = start_compressed_session_with_auth_providers(
+                self._config, provider_backends or [], providers
+            )
         else:
+            backends, _ = _resolve_backends(self._servers)
             self._session = start_compressed_session(self._config, backends or [])
         return CompressorProxy(self._session, self._default_server())
 

--- a/python/mcp-compressor/mcp_compressor/core.py
+++ b/python/mcp-compressor/mcp_compressor/core.py
@@ -125,6 +125,20 @@ def start_compressed_session(
     return CompressedSession(native_session)
 
 
+def start_compressed_session_with_auth_providers(
+    config: CompressedSessionConfig,
+    backends: list[dict[str, Any]],
+    providers: list[Any],
+) -> CompressedSession:
+    """Start a Rust-backed compressed session with per-request auth providers."""
+    native_session = _native.start_compressed_session_with_provider_backends_json(
+        _json_dumps(config.to_json_dict()),
+        _json_dumps(backends),
+        providers,
+    )
+    return CompressedSession(native_session)
+
+
 def start_compressed_session_from_mcp_config(
     config: CompressedSessionConfig,
     mcp_config_json: str,

--- a/python/mcp-compressor/tests/test_public_sdk_workflow.py
+++ b/python/mcp-compressor/tests/test_public_sdk_workflow.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from mcp_compressor import CompressorClient
@@ -9,6 +13,73 @@ from mcp_compressor import CompressorClient
 ROOT = Path(__file__).resolve().parents[3]
 FIXTURE = ROOT / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
 PYTHON = os.environ.get("PYTHON", sys.executable)
+
+
+@contextmanager
+def _streamable_http_upstream() -> Iterator[str]:
+    command = [
+        "cargo",
+        "run",
+        "-q",
+        "-p",
+        "mcp-compressor-core",
+        "--bin",
+        "mcp-compressor",
+        "--",
+        "--compression",
+        "max",
+        "--server-name",
+        "upstream",
+        "--transport",
+        "streamable-http",
+        "--port",
+        "0",
+        "--",
+        PYTHON,
+        str(FIXTURE),
+    ]
+    process = subprocess.Popen(command, stderr=subprocess.PIPE, text=True)  # noqa: S603 - trusted test command
+    try:
+        assert process.stderr is not None
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            line = process.stderr.readline()
+            if "Streamable HTTP MCP server listening on " in line:
+                yield line.rsplit(" ", 1)[1].strip()
+                return
+            if process.poll() is not None:
+                raise AssertionError(f"upstream exited early with {process.returncode}")
+        raise AssertionError("timed out waiting for upstream URL")
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+
+
+@contextmanager
+def _rotating_auth_proxy(target_url: str, *, expected_start: int = 1) -> Iterator[str]:
+    proxy = ROOT / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "rotating_auth_proxy.py"
+    env = {
+        **os.environ,
+        "MCP_COMPRESSOR_AUTH_PROXY_TARGET": target_url,
+        "MCP_COMPRESSOR_AUTH_PROXY_EXPECTED_START": str(expected_start),
+    }
+    process = subprocess.Popen(  # noqa: S603 - trusted test command
+        [PYTHON, str(proxy)], stderr=subprocess.PIPE, text=True, env=env
+    )
+    try:
+        assert process.stderr is not None
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            line = process.stderr.readline()
+            if line.startswith("AUTH_PROXY_URL="):
+                yield line.split("=", 1)[1].strip()
+                return
+            if process.poll() is not None:
+                raise AssertionError(f"auth proxy exited early with {process.returncode}")
+        raise AssertionError("timed out waiting for auth proxy URL")
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
 
 
 def test_public_python_sdk_quickstart_flow() -> None:
@@ -25,6 +96,42 @@ def test_public_python_sdk_quickstart_flow() -> None:
 
         response = proxy.invoke("echo", {"message": "public-python"})
         assert response == "alpha:public-python"
+
+
+def test_public_python_sdk_auth_provider_refreshes_per_remote_request() -> None:
+    calls = 0
+
+    def auth_provider() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {"Authorization": f"Bearer token-{calls}"}
+
+    with (
+        _streamable_http_upstream() as upstream_url,
+        _rotating_auth_proxy(upstream_url, expected_start=2) as proxy_url,
+        CompressorClient(
+            servers={"remote": {"url": proxy_url, "auth_provider": auth_provider}},
+            compression_level="max",
+        ) as proxy,
+    ):
+        first = proxy.invoke_wrapper(
+            "remote_invoke_tool",
+            {
+                "tool_name": "upstream_invoke_tool",
+                "tool_input": {"tool_name": "echo", "tool_input": {"message": "one"}},
+            },
+        ).text
+        second = proxy.invoke_wrapper(
+            "remote_invoke_tool",
+            {
+                "tool_name": "upstream_invoke_tool",
+                "tool_input": {"tool_name": "echo", "tool_input": {"message": "two"}},
+            },
+        ).text
+
+    assert first == "alpha:one"
+    assert second == "alpha:two"
+    assert calls >= 2
 
 
 def test_public_python_sdk_schema_lookup_supports_multi_server() -> None:

--- a/typescript/src/native.ts
+++ b/typescript/src/native.ts
@@ -20,6 +20,11 @@ export interface NativeCore {
     configJson: string,
     backendsJson: string,
   ): Promise<NativeCompressedSession>;
+  startCompressedSessionWithProviderBackendsJson(
+    configJson: string,
+    backendsJson: string,
+    providersJson: string,
+  ): Promise<NativeCompressedSession>;
   startCompressedSessionFromMcpConfigJson(
     configJson: string,
     mcpConfigJson: string,
@@ -29,6 +34,7 @@ export interface NativeCore {
 export interface NativeCompressedSession {
   infoJson(): string;
   close(): void;
+  updateAuthProviderHeadersJson(providerIndex: number, headersJson: string): void;
 }
 
 const require = createRequire(import.meta.url);

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -2,6 +2,7 @@ import {
   generateClientArtifacts,
   normalizeSdkServers,
   startCompressedSession,
+  startCompressedSessionWithAuthProviders,
   startCompressedSessionFromMcpConfig,
 } from "./rust_core.js";
 import type { BackendConfig as LegacyBackendConfig, JsonConfigServerEntry } from "./types.js";
@@ -58,8 +59,20 @@ export interface NormalizedBackendConfig {
   args?: string[];
 }
 
+function providerFromConfig(config: Record<string, unknown>): AuthProvider | undefined {
+  const provider = config.authProvider ?? config.auth_provider;
+  if (provider === undefined) {
+    return undefined;
+  }
+  if (typeof provider !== "function") {
+    throw new TypeError("authProvider must be a function");
+  }
+  return provider as AuthProvider;
+}
+
 async function resolveAuthHeaders(
   config: Record<string, unknown>,
+  options: { includeProvider?: boolean } = {},
 ): Promise<Record<string, string>> {
   const headers: Record<string, string> = {};
   const rawHeaders = config.headers;
@@ -68,17 +81,63 @@ async function resolveAuthHeaders(
       headers[key] = String(value);
     }
   }
-  const provider = config.authProvider ?? config.auth_provider;
-  if (provider !== undefined) {
-    if (typeof provider !== "function") {
-      throw new TypeError("authProvider must be a function");
-    }
-    const provided = await (provider as AuthProvider)();
+  const provider = providerFromConfig(config);
+  if ((options.includeProvider ?? true) && provider !== undefined) {
+    const provided = await provider();
     for (const [key, value] of Object.entries(provided)) {
       headers[key] = String(value);
     }
   }
   return headers;
+}
+
+interface ProviderMaterializedBackend extends NormalizedBackendConfig {
+  providerIndex?: number;
+}
+
+async function normalizeServersWithProviders(
+  servers: NativeServersInput,
+): Promise<{ backends: ProviderMaterializedBackend[]; providers: AuthProvider[] } | string> {
+  if (typeof servers === "string") {
+    const trimmed = servers.trim();
+    if (trimmed.startsWith("{")) {
+      return servers;
+    }
+    return { backends: [{ name: "default", commandOrUrl: servers }], providers: [] };
+  }
+  if (isLegacyBackendConfig(servers)) {
+    return {
+      backends: [await legacyBackendToNative("default", servers, { includeProvider: false })],
+      providers: [],
+    };
+  }
+  const backends: ProviderMaterializedBackend[] = [];
+  const providers: AuthProvider[] = [];
+  for (const [name, config] of Object.entries(servers as Record<string, NativeServerConfig>)) {
+    if (typeof config === "object" && config !== null && "url" in config) {
+      const provider = providerFromConfig(config as Record<string, unknown>);
+      const backend: ProviderMaterializedBackend = await sdkObjectToNative(
+        name,
+        config as Record<string, unknown>,
+        { includeProvider: true },
+      );
+      if (provider !== undefined) {
+        backend.providerIndex = providers.length;
+        providers.push(provider);
+      }
+      backends.push(backend);
+    } else if (typeof config === "object" && config !== null && "command" in config) {
+      backends.push(
+        await sdkObjectToNative(name, config as Record<string, unknown>, {
+          includeProvider: false,
+        }),
+      );
+    } else {
+      const normalized = normalizeSdkServers({ [name]: config });
+      backends.push(normalized[0]!);
+    }
+  }
+  return { backends, providers };
 }
 
 export async function normalizeServers(
@@ -114,15 +173,48 @@ function isLegacyBackendConfig(value: unknown): value is LegacyBackendConfig {
   );
 }
 
+async function sdkObjectToNative(
+  name: string,
+  config: Record<string, unknown>,
+  options: { includeProvider?: boolean } = {},
+): Promise<NormalizedBackendConfig> {
+  if ("url" in config) {
+    const args: string[] = [];
+    const headers = await resolveAuthHeaders(config, options);
+    for (const [key, value] of Object.entries(headers)) {
+      args.push("-H", `${key}=${value}`);
+    }
+    if (
+      Object.keys(headers).length > 0 &&
+      !(Array.isArray(config.args) && config.args.includes("--auth"))
+    ) {
+      args.push("--auth", "explicit-headers");
+    }
+    if (Array.isArray(config.args)) {
+      args.push(...config.args.map(String));
+    }
+    return { name, commandOrUrl: String(config.url), args };
+  }
+  if ("command" in config) {
+    return {
+      name,
+      commandOrUrl: String(config.command),
+      args: Array.isArray(config.args) ? config.args.map(String) : [],
+    };
+  }
+  throw new Error(`server ${name} must define command or url`);
+}
+
 async function legacyBackendToNative(
   name: string,
   backend: LegacyBackendConfig,
+  options: { includeProvider?: boolean } = {},
 ): Promise<NormalizedBackendConfig> {
   if (backend.type === "stdio") {
     return { name, commandOrUrl: backend.command, args: backend.args ?? [] };
   }
   const args: string[] = [];
-  const headers = await resolveAuthHeaders(backend as unknown as Record<string, unknown>);
+  const headers = await resolveAuthHeaders(backend as unknown as Record<string, unknown>, options);
   if (Object.keys(headers).length > 0) {
     for (const [key, value] of Object.entries(headers)) {
       args.push("-H", `${key}=${value}`);
@@ -145,7 +237,21 @@ export class CompressorProxy {
   constructor(
     private readonly session: CompressedSession,
     private readonly defaultServer: string | null,
+    private readonly authProviders: AuthProvider[] = [],
   ) {}
+
+  private async refreshAuthProviders(): Promise<void> {
+    await Promise.all(
+      this.authProviders.map(async (provider, index) => {
+        const headers = await provider();
+        const materialized: Record<string, string> = {};
+        for (const [key, value] of Object.entries(headers)) {
+          materialized[key] = String(value);
+        }
+        this.session.updateAuthProviderHeaders(index, materialized);
+      }),
+    );
+  }
 
   info(): CompressedSessionInfo {
     return this.session.info();
@@ -192,6 +298,7 @@ export class CompressorProxy {
     if (this.closed) {
       throw new Error("Compressor proxy is closed");
     }
+    await this.refreshAuthProviders();
     const response = await fetch(`${this.bridgeUrl}/exec`, {
       method: "POST",
       headers: {
@@ -263,6 +370,7 @@ export class CompressorProxy {
 export class CompressorClient {
   private session: CompressedSession | null = null;
   private readonly mode: NativeCompressorMode;
+  private authProviders: AuthProvider[] = [];
 
   constructor(private readonly options: CompressorClientOptions) {
     this.mode = options.mode ?? "compressed";
@@ -270,9 +378,9 @@ export class CompressorClient {
 
   async connect(): Promise<CompressorProxy> {
     if (this.session) {
-      return new CompressorProxy(this.session, this.defaultServer());
+      return new CompressorProxy(this.session, this.defaultServer(), this.authProviders);
     }
-    const normalized = await normalizeServers(this.options.servers);
+    const normalized = await normalizeServersWithProviders(this.options.servers);
     const config = {
       compressionLevel: this.options.compressionLevel ?? "medium",
       serverName: this.options.serverName ?? null,
@@ -281,11 +389,18 @@ export class CompressorClient {
       toonify: this.options.toonify ?? false,
       transformMode: transformMode(this.mode),
     };
+    this.authProviders = typeof normalized === "string" ? [] : normalized.providers;
     this.session =
       typeof normalized === "string"
         ? await startCompressedSessionFromMcpConfig(config, normalized)
-        : await startCompressedSession(config, normalized);
-    return new CompressorProxy(this.session, this.defaultServer());
+        : normalized.providers.length > 0
+          ? await startCompressedSessionWithAuthProviders(
+              config,
+              normalized.backends,
+              normalized.providers,
+            )
+          : await startCompressedSession(config, normalized.backends);
+    return new CompressorProxy(this.session, this.defaultServer(), this.authProviders);
   }
 
   async close(): Promise<void> {

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -129,6 +129,10 @@ export class CompressedSession {
   close(): void {
     this.nativeSession.close();
   }
+
+  updateAuthProviderHeaders(providerIndex: number, headers: Record<string, string>): void {
+    this.nativeSession.updateAuthProviderHeadersJson(providerIndex, stringify(headers));
+  }
 }
 
 function toNativeSessionConfig(config: CompressedSessionConfig): Record<string, unknown> {
@@ -157,6 +161,28 @@ export async function startCompressedSession(
   const session = await loadNativeCore().startCompressedSessionJson(
     stringify(toNativeSessionConfig(config)),
     stringify(backends.map(toNativeBackendConfig)),
+  );
+  return new CompressedSession(session);
+}
+
+export interface ProviderBackendConfig extends BackendConfig {
+  providerIndex?: number;
+}
+
+export async function startCompressedSessionWithAuthProviders(
+  config: CompressedSessionConfig,
+  backends: ProviderBackendConfig[],
+  providers: Array<() => Record<string, string> | Promise<Record<string, string>>>,
+): Promise<CompressedSession> {
+  const nativeBackends = backends.map((backend) => ({
+    ...toNativeBackendConfig(backend),
+    provider_index: backend.providerIndex ?? null,
+  }));
+  const initialHeaders = await Promise.all(providers.map((provider) => provider()));
+  const session = await loadNativeCore().startCompressedSessionWithProviderBackendsJson(
+    stringify(toNativeSessionConfig(config)),
+    stringify(nativeBackends),
+    stringify(initialHeaders),
   );
   return new CompressedSession(session);
 }

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -163,6 +163,58 @@ async function startRemoteAlphaUpstream(): Promise<{
   return { url, child };
 }
 
+async function startRotatingAuthProxy(
+  targetUrl: string,
+  expectedStart = 1,
+  allowInitialRepeats = 0,
+  allowAnyRepeats = 0,
+): Promise<{
+  url: string;
+  child: ChildProcessWithoutNullStreams;
+  stderr: () => string;
+}> {
+  const child = spawn(
+    process.env.PYTHON ?? join(process.cwd(), "..", ".venv", "bin", "python"),
+    [fixturePath("rotating_auth_proxy.py")],
+    {
+      cwd: join(process.cwd(), ".."),
+      env: {
+        ...process.env,
+        MCP_COMPRESSOR_AUTH_PROXY_TARGET: targetUrl,
+        MCP_COMPRESSOR_AUTH_PROXY_EXPECTED_START: String(expectedStart),
+        MCP_COMPRESSOR_AUTH_PROXY_ALLOW_INITIAL_REPEATS: String(allowInitialRepeats),
+        MCP_COMPRESSOR_AUTH_PROXY_ALLOW_ANY_REPEATS: String(allowAnyRepeats),
+      },
+    },
+  );
+
+  let stderr = "";
+  const url = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`timed out waiting for rotating auth proxy URL\nstderr:\n${stderr}`));
+    }, 30_000);
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+      const match = /AUTH_PROXY_URL=(http:\/\/127\.0\.0\.1:\d+)/.exec(String(chunk));
+      if (match) {
+        clearTimeout(timeout);
+        resolve(match[1]!);
+      }
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`rotating auth proxy exited before ready: ${code}`));
+    });
+  });
+
+  return { url, child, stderr: () => stderr };
+}
+
 async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
   if (child.killed || child.exitCode !== null) {
     return;
@@ -212,6 +264,51 @@ describe("Public TypeScript SDK workflow", () => {
     } finally {
       proxy.close();
       client.close();
+    }
+  });
+
+  it("refreshes authProvider headers for each remote backend request", async () => {
+    const upstream = await startRemoteAlphaUpstream();
+    const authProxy = await startRotatingAuthProxy(upstream.url, 1, 10, 10);
+    let calls = 0;
+    const client = new CompressorClient({
+      servers: {
+        remote: {
+          url: authProxy.url,
+          authProvider: async () => {
+            calls += 1;
+            return { Authorization: `Bearer token-${calls}` };
+          },
+        },
+      },
+      compressionLevel: "max",
+    });
+
+    try {
+      const proxy = await client.connect();
+      try {
+        const first = await proxy.invokeWrapper("remote_invoke_tool", {
+          tool_name: "alpha_invoke_tool",
+          tool_input: { tool_name: "echo", tool_input: { message: "one" } },
+        });
+        const second = await proxy.invokeWrapper("remote_invoke_tool", {
+          tool_name: "alpha_invoke_tool",
+          tool_input: { tool_name: "echo", tool_input: { message: "two" } },
+        });
+        expect(first.text).toBe("alpha:one");
+        expect(second.text).toBe("alpha:two");
+      } finally {
+        proxy.close();
+        await client.close();
+      }
+      expect(calls).toBeGreaterThanOrEqual(2);
+    } catch (error) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}\nAuth proxy stderr:\n${authProxy.stderr()}`,
+      );
+    } finally {
+      await stopChild(authProxy.child);
+      await stopChild(upstream.child);
     }
   });
 


### PR DESCRIPTION
## Summary
- wire Python auth_provider callbacks through to Rust transport-level dynamic headers
- wire TypeScript authProvider support through session-owned native header stores refreshed before proxy invocations
- add rotating-auth local proxy fixture and Python/TypeScript public SDK e2e coverage
- update docs to state SDK auth providers are evaluated per backend request in Rust, Python, and TypeScript

## Notes
- Rust core per-request transport support landed in #142.
- Python can call its provider directly from the Rust transport while releasing the GIL during startup.
- TypeScript uses a safer SDK-owned refresh model: the SDK awaits async authProvider callbacks and updates native header stores before proxy invocations, avoiding napi callback deadlocks during native transport startup.

## Tests
- cargo check -p mcp-compressor-core
- cargo check -p mcp-compressor-python
- cargo check -p mcp-compressor-node
- PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core server::dynamic_http_client::tests::dynamic_provider_is_called_for_each_post_request -- --nocapture
- cd python/mcp-compressor && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests/test_public_sdk_workflow.py::test_public_python_sdk_auth_provider_refreshes_per_remote_request
- cd python/mcp-compressor && uv run ruff check mcp_compressor tests && uv run ruff format --check mcp_compressor tests && uv run ty check --project . --python .venv mcp_compressor tests
- cd typescript && bun run build:native && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "refreshes authProvider"
- cd typescript && bun run typecheck && bun run lint && bun run format:check
- make docs-test
- make check