### PR TITLE
fix: report stopped proxy cleanly in generated cli

### DIFF
--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -84,7 +84,7 @@ HELP
       exit 0
     fi
     python3 - "$BRIDGE" "$TOKEN" "{tool_name}" "$@" <<'PY'
-import json, sys, urllib.request
+import json, sys, urllib.error, urllib.request
 bridge, token, tool_name, *argv = sys.argv[1:]
 tool_input = {{}}
 index = 0
@@ -110,8 +110,20 @@ req = urllib.request.Request(
     headers={{"Content-Type": "application/json", "Authorization": "Bearer " + token}},
     method="POST",
 )
-with urllib.request.urlopen(req, timeout=30) as resp:
-    sys.stdout.write(resp.read().decode())
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        sys.stdout.write(resp.read().decode())
+except urllib.error.HTTPError as exc:
+    message = exc.read().decode(errors="replace") or exc.reason
+    print(f"mcp-compressor proxy returned HTTP {{exc.code}}: {{message}}", file=sys.stderr)
+    raise SystemExit(1)
+except urllib.error.URLError as exc:
+    print(
+        "mcp-compressor proxy is not running; restart the mcp-compressor CLI-mode process and try again.",
+        file=sys.stderr,
+    )
+    print(f"details: {{exc.reason}}", file=sys.stderr)
+    raise SystemExit(1)
 PY
     ;;
 "#,

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -107,6 +107,34 @@ async fn generated_cli_script_invokes_real_proxy_and_backend() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn generated_cli_script_reports_stopped_proxy_without_traceback() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let (config, proxy) = running_proxy_config(tempdir.path()).await;
+    let mut config = config;
+    config.tools = real_backend_tools().await;
+    let paths = CliGenerator.generate(&config).unwrap();
+    let script = paths
+        .iter()
+        .find(|path| path.file_name().unwrap() == "alpha")
+        .unwrap();
+
+    drop(proxy);
+
+    let output = Command::new(script)
+        .args(["echo", "--message", "hello"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mcp-compressor proxy is not running"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("Traceback"), "stderr: {stderr}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_python_module_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let (config, _proxy) = running_proxy_config(tempdir.path()).await;


### PR DESCRIPTION
## Summary
- catch generated CLI proxy connection failures and print a concise message instead of a Python traceback
- keep HTTP error bodies visible for proxy-side errors
- add a regression test that drops the proxy before invoking a generated CLI command

## Tests
- cargo test -p mcp-compressor-core --test generated_clients generated_cli_script_reports_stopped_proxy_without_traceback -- --nocapture
- cargo test -p mcp-compressor-core client_gen::cli -- --nocapture
- cargo check -p mcp-compressor-core
- make check