### PR TITLE
feat: add typescript executable tool adapters

### DIFF
--- a/docs/usage/generated-clients.md
+++ b/docs/usage/generated-clients.md
@@ -85,8 +85,21 @@ The Atlassian examples use OAuth. The first run opens a browser if no stored cre
     const proxy = await new CompressorClient({ servers, compressionLevel: "max" }).connect();
     try {
       proxy.writeClient("cli", "./bin", { name: "atlassian" });
-      proxy.writeClient("python", "./generated-py", { name: "atlassian" });
-      proxy.writeClient("typescript", "./generated-ts", { name: "atlassian" });
+
+      const pythonClient = proxy.writeCodeClient({
+        language: "python",
+        outputDir: "./generated-py",
+        name: "atlassian",
+      });
+
+      const typescriptClient = proxy.writeCodeClient({
+        language: "typescript",
+        outputDir: "./generated-ts",
+        name: "atlassian",
+      });
+
+      console.log(pythonClient.environment); // { PYTHONPATH: "./generated-py" }
+      console.log(typescriptClient.files);
     } finally {
       proxy.close();
     }

--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -99,6 +99,32 @@ When more than one backend server is configured, specify the server when invokin
         .await?;
     ```
 
+## Executable tools for agent frameworks
+
+TypeScript applications often need framework-ready tool objects rather than direct `proxy.invoke(...)` calls. Use `proxy.toExecutableTools()` as the framework-neutral primitive, then adapt it to the framework you use.
+
+```ts
+import { CompressorClient, toAISDKTools, toMastraTools } from "@atlassian/mcp-compressor";
+import { tool } from "ai";
+
+const proxy = await new CompressorClient({ servers }).connect();
+
+const executableTools = proxy.toExecutableTools();
+const aiSdkTools = toAISDKTools(executableTools, { tool });
+const mastraTools = toMastraTools(executableTools);
+```
+
+The executable tool shape is intentionally simple:
+
+```ts
+{
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  execute(input?: Record<string, unknown>): Promise<string>;
+}
+```
+
 ## Compression options
 
 The SDKs expose the same main compression options as the CLI.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -39,6 +39,10 @@
     "./rust-core": {
       "import": "./dist/rust_core.js",
       "types": "./dist/rust_core.d.ts"
+    },
+    "./adapters": {
+      "import": "./dist/adapters.js",
+      "types": "./dist/adapters.d.ts"
     }
   },
   "bin": {

--- a/typescript/src/adapters.ts
+++ b/typescript/src/adapters.ts
@@ -1,0 +1,44 @@
+export interface ExecutableTool {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  execute(input?: Record<string, unknown>): Promise<string>;
+}
+
+export interface AISDKToolFactory<TTool = unknown> {
+  (options: {
+    description?: string;
+    inputSchema: Record<string, unknown>;
+    execute: (input: Record<string, unknown>) => Promise<string>;
+  }): TTool;
+}
+
+export function toAISDKTools<TTool = unknown>(
+  tools: Record<string, ExecutableTool>,
+  options: { tool?: AISDKToolFactory<TTool> } = {},
+): Record<string, TTool | Omit<ExecutableTool, "name">> {
+  const result: Record<string, TTool | Omit<ExecutableTool, "name">> = {};
+  for (const [name, executable] of Object.entries(tools)) {
+    const definition = {
+      description: executable.description,
+      inputSchema: executable.inputSchema,
+      execute: (input: Record<string, unknown>) => executable.execute(input),
+    };
+    result[name] = options.tool ? options.tool(definition) : definition;
+  }
+  return result;
+}
+
+export function toMastraTools(
+  tools: Record<string, ExecutableTool>,
+): Record<string, Omit<ExecutableTool, "name">> {
+  const result: Record<string, Omit<ExecutableTool, "name">> = {};
+  for (const [name, executable] of Object.entries(tools)) {
+    result[name] = {
+      description: executable.description,
+      inputSchema: executable.inputSchema,
+      execute: (input: Record<string, unknown> = {}) => executable.execute(input),
+    };
+  }
+  return result;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -2,8 +2,25 @@ export { VERSION } from "./version.js";
 export * from "./errors.js";
 export * from "./rust_core.js";
 export * from "./just_bash_host.js";
+export * from "./adapters.js";
+export {
+  interpolateString,
+  interpolateRecord,
+  interpolateMCPConfig,
+  parseServerConfigJson,
+  normalizeConfigServer,
+} from "./config.js";
+export type {
+  BackendConfig,
+  HttpBackendConfig,
+  JsonConfigServerEntry,
+  MCPConfigShape,
+  SseBackendConfig,
+  StdioBackendConfig,
+} from "./types.js";
 export {
   type GeneratedClientKind,
+  type GeneratedCodeClient,
   type JustBashCommand,
   type JustBashProvider,
   type CompressorClientOptions,

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -1,3 +1,5 @@
+import type { ExecutableTool } from "./adapters.js";
+
 import {
   generateClientArtifacts,
   normalizeSdkServers,
@@ -57,6 +59,13 @@ export interface NormalizedBackendConfig {
   name: string;
   commandOrUrl: string;
   args?: string[];
+}
+
+export interface GeneratedCodeClient {
+  language: "python" | "typescript";
+  outputDir: string;
+  files: string[];
+  environment: Record<string, string>;
 }
 
 function providerFromConfig(config: Record<string, unknown>): AuthProvider | undefined {
@@ -346,6 +355,20 @@ export class CompressorProxy {
     this.session.close();
   }
 
+  toExecutableTools(): Record<string, ExecutableTool> {
+    const result: Record<string, ExecutableTool> = {};
+    for (const tool of this.tools) {
+      result[tool.name] = {
+        name: tool.name,
+        description: tool.description ?? undefined,
+        inputSchema: tool.inputSchema,
+        execute: async (input: Record<string, unknown> = {}) =>
+          (await this.invokeWrapper(tool.name, input)).text,
+      };
+    }
+    return result;
+  }
+
   writeClient(
     kind: GeneratedClientKind,
     outputDir: string,
@@ -364,6 +387,20 @@ export class CompressorProxy {
       outputDir,
       sessionPid: 0,
     });
+  }
+
+  writeCodeClient(options: {
+    language: "python" | "typescript";
+    outputDir: string;
+    name?: string;
+  }): GeneratedCodeClient {
+    const files = this.writeClient(options.language, options.outputDir, { name: options.name });
+    return {
+      language: options.language,
+      outputDir: options.outputDir,
+      files,
+      environment: options.language === "python" ? { PYTHONPATH: options.outputDir } : {},
+    };
   }
 }
 

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -7,7 +7,17 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { CompressorClient, installJustBashCommands, normalizeServers } from "../src/index.js";
+import {
+  CompressorClient,
+  installJustBashCommands,
+  interpolateRecord,
+  interpolateString,
+  normalizeServers,
+  toAISDKTools,
+  toMastraTools,
+  type BackendConfig,
+  type JsonConfigServerEntry,
+} from "../src/index.js";
 
 import {
   compressToolListing,
@@ -331,6 +341,27 @@ describe("Public TypeScript SDK workflow", () => {
       expect(schema.properties).toHaveProperty("message");
       const response = await proxy.invoke("echo", { message: "public-ts" });
       expect(response).toBe("alpha:public-ts");
+
+      const executableTools = proxy.toExecutableTools();
+      await expect(
+        executableTools.alpha_invoke_tool?.execute({
+          tool_name: "echo",
+          tool_input: { message: "executable" },
+        }),
+      ).resolves.toBe("alpha:executable");
+
+      const mastraTools = toMastraTools(executableTools);
+      await expect(
+        mastraTools.alpha_invoke_tool?.execute({
+          tool_name: "echo",
+          tool_input: { message: "mastra" },
+        }),
+      ).resolves.toBe("alpha:mastra");
+
+      const aiTools = toAISDKTools(executableTools, {
+        tool: (definition) => ({ ...definition, wrapped: true }),
+      });
+      expect(aiTools.alpha_invoke_tool).toMatchObject({ wrapped: true });
     } finally {
       proxy.close();
       client.close();
@@ -339,6 +370,21 @@ describe("Public TypeScript SDK workflow", () => {
 });
 
 describe("Rust native core wrapper", () => {
+  it("exports public config helpers and types from package root", () => {
+    process.env.MCP_COMPRESSOR_TEST_TOKEN = "root-token";
+    try {
+      expect(interpolateString("Bearer ${MCP_COMPRESSOR_TEST_TOKEN}")).toBe("Bearer root-token");
+      expect(interpolateRecord({ Authorization: "Bearer $MCP_COMPRESSOR_TEST_TOKEN" })).toEqual({
+        Authorization: "Bearer root-token",
+      });
+      const backend: BackendConfig = { type: "stdio", command: "python", args: ["server.py"] };
+      const entry: JsonConfigServerEntry = { command: backend.command, args: backend.args };
+      expect(entry.command).toBe("python");
+    } finally {
+      delete process.env.MCP_COMPRESSOR_TEST_TOKEN;
+    }
+  });
+
   it("compresses tool listings through the native addon", () => {
     expect(compressToolListing("high", [sampleTool])).toBe("<tool>echo(message)</tool>");
   });
@@ -519,8 +565,20 @@ describe("Rust native core wrapper", () => {
     const proxy = await client.connect();
     try {
       const cliPaths = proxy.writeClient("cli", join(outputDir, "bin"), { name: "alpha" });
-      const pythonPaths = proxy.writeClient("python", join(outputDir, "py"), { name: "alpha" });
-      const tsPaths = proxy.writeClient("typescript", join(outputDir, "ts"), { name: "alpha" });
+      const pythonClient = proxy.writeCodeClient({
+        language: "python",
+        outputDir: join(outputDir, "py"),
+        name: "alpha",
+      });
+      const typescriptClient = proxy.writeCodeClient({
+        language: "typescript",
+        outputDir: join(outputDir, "ts"),
+        name: "alpha",
+      });
+      const pythonPaths = pythonClient.files;
+      const tsPaths = typescriptClient.files;
+      expect(pythonClient.environment).toEqual({ PYTHONPATH: join(outputDir, "py") });
+      expect(typescriptClient.environment).toEqual({});
       const cliPath = cliPaths.find((path) => path.endsWith("alpha"));
       const pythonPath = pythonPaths.find((path) => path.endsWith("alpha.py"));
       const tsPath = tsPaths.find((path) => path.endsWith("alpha.ts"));

--- a/typescript/tests/subpath_exports.test.ts
+++ b/typescript/tests/subpath_exports.test.ts
@@ -21,6 +21,7 @@ const pkgJson = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8"
 test("package.json exports declares the lightweight sub-paths", () => {
   expect(Object.keys(pkgJson.exports).sort()).toEqual([
     ".",
+    "./adapters",
     "./config",
     "./errors",
     "./rust-core",


### PR DESCRIPTION
## Summary
- export public config helpers and MCP config types from the TypeScript package root
- add framework-neutral executable tools via proxy.toExecutableTools()
- add dependency-light adapter helpers for AI SDK-style and Mastra-style tool maps
- add structured Code Mode generation via proxy.writeCodeClient(...)
- document the new APIs and add TypeScript e2e coverage

## Design notes
- This intentionally avoids restoring Alta-specific legacy APIs like client.getTools(), serverOptions, or initializePythonMode().
- Consumers can migrate by composing clean primitives: connect -> toExecutableTools -> framework adapter, or connect -> writeCodeClient.

## Tests
- cd typescript && bun run format
- cd typescript && bun run build:native
- cd typescript && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "documented CompressorClient quickstart|exports public config|generates client artifacts"
- cd typescript && bun run typecheck && bun run lint && bun run format:check
- make docs-test
- make check