### PR TITLE
feat: align rust and python sdk ergonomics

### DIFF
--- a/crates/mcp-compressor-core/src/sdk.rs
+++ b/crates/mcp-compressor-core/src/sdk.rs
@@ -1,6 +1,8 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+use async_trait::async_trait;
 
 use serde_json::{json, Value};
 
@@ -308,16 +310,24 @@ impl CompressorProxy {
         input: Value,
     ) -> Result<String, Error> {
         let wrapper = self.invoke_wrapper(server)?;
+        self.invoke_wrapper_tool(
+            &wrapper,
+            json!({
+                "tool_name": tool_name,
+                "tool_input": input,
+            }),
+        )
+        .await
+    }
+
+    async fn invoke_wrapper_tool(&self, wrapper: &str, input: Value) -> Result<String, Error> {
         let client = reqwest::Client::new();
         let response = client
             .post(self.proxy.exec_url())
             .header("Authorization", format!("Bearer {}", self.token()))
             .json(&json!({
                 "tool": wrapper,
-                "input": {
-                    "tool_name": tool_name,
-                    "tool_input": input,
-                }
+                "input": input
             }))
             .send()
             .await
@@ -336,12 +346,46 @@ impl CompressorProxy {
         }
     }
 
+    pub fn executable_tools(&self) -> BTreeMap<String, Box<dyn ExecutableTool + '_>> {
+        self.frontend_tools
+            .iter()
+            .map(|tool| {
+                (
+                    tool.name.clone(),
+                    Box::new(ProxyExecutableTool { proxy: self, tool: tool.clone() })
+                        as Box<dyn ExecutableTool>,
+                )
+            })
+            .collect()
+    }
+
+    pub fn write_cli_client(
+        &self,
+        output_dir: impl AsRef<Path>,
+        name: Option<&str>,
+    ) -> Result<GeneratedClient, Error> {
+        self.write_client(GeneratedClientKind::Cli, output_dir, name)
+    }
+
+    pub fn write_code_client(
+        &self,
+        language: CodeLanguage,
+        output_dir: impl AsRef<Path>,
+        name: Option<&str>,
+    ) -> Result<GeneratedClient, Error> {
+        let kind = match language {
+            CodeLanguage::Python => GeneratedClientKind::Python,
+            CodeLanguage::TypeScript => GeneratedClientKind::TypeScript,
+        };
+        self.write_client(kind, output_dir, name.into())
+    }
+
     pub fn write_client(
         &self,
         kind: GeneratedClientKind,
         output_dir: impl AsRef<Path>,
         name: Option<&str>,
-    ) -> Result<Vec<PathBuf>, Error> {
+    ) -> Result<GeneratedClient, Error> {
         let generator_config = GeneratorConfig {
             cli_name: name
                 .or(self.default_server.as_deref())
@@ -353,11 +397,18 @@ impl CompressorProxy {
             session_pid: 0,
             output_dir: output_dir.as_ref().to_path_buf(),
         };
-        match kind {
+        let files = match kind {
             GeneratedClientKind::Cli => CliGenerator.generate(&generator_config),
             GeneratedClientKind::Python => PythonGenerator.generate(&generator_config),
             GeneratedClientKind::TypeScript => TypeScriptGenerator.generate(&generator_config),
-        }
+        }?;
+        let environment = kind.environment(&generator_config);
+        Ok(GeneratedClient {
+            kind,
+            output_dir: generator_config.output_dir,
+            files,
+            environment,
+        })
     }
 
     fn invoke_wrapper(&self, server: Option<&str>) -> Result<String, Error> {
@@ -386,11 +437,69 @@ impl CompressorProxy {
     }
 }
 
+#[async_trait]
+pub trait ExecutableTool: Send + Sync {
+    fn name(&self) -> &str;
+    fn description(&self) -> Option<&str>;
+    fn input_schema(&self) -> &Value;
+    async fn execute(&self, input: Value) -> Result<String, Error>;
+}
+
+struct ProxyExecutableTool<'a> {
+    proxy: &'a CompressorProxy,
+    tool: Tool,
+}
+
+#[async_trait]
+impl ExecutableTool for ProxyExecutableTool<'_> {
+    fn name(&self) -> &str {
+        &self.tool.name
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.tool.description.as_deref()
+    }
+
+    fn input_schema(&self) -> &Value {
+        &self.tool.input_schema
+    }
+
+    async fn execute(&self, input: Value) -> Result<String, Error> {
+        self.proxy.invoke_wrapper_tool(&self.tool.name, input).await
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodeLanguage {
+    Python,
+    TypeScript,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedClient {
+    pub kind: GeneratedClientKind,
+    pub output_dir: PathBuf,
+    pub files: Vec<PathBuf>,
+    pub environment: HashMap<String, String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GeneratedClientKind {
     Cli,
     Python,
     TypeScript,
+}
+
+impl GeneratedClientKind {
+    fn environment(self, config: &GeneratorConfig) -> HashMap<String, String> {
+        match self {
+            GeneratedClientKind::Python => HashMap::from([(
+                "PYTHONPATH".to_string(),
+                config.output_dir.to_string_lossy().to_string(),
+            )]),
+            GeneratedClientKind::Cli | GeneratedClientKind::TypeScript => HashMap::new(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -452,6 +561,17 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result, "alpha:rust-sdk");
+
+        let executable = proxy.executable_tools();
+        let invoke = executable.get("alpha_invoke_tool").unwrap();
+        let executable_result = invoke
+            .execute(json!({
+                "tool_name": "echo",
+                "tool_input": { "message": "executable-rust" }
+            }))
+            .await
+            .unwrap();
+        assert_eq!(executable_result, "alpha:executable-rust");
     }
 
     #[tokio::test]
@@ -491,10 +611,18 @@ mod tests {
             .build();
         let proxy = client.connect().await.unwrap();
         let tempdir = tempfile::tempdir().unwrap();
-        let paths = proxy
-            .write_client(GeneratedClientKind::Python, tempdir.path(), Some("alpha"))
+        let generated = proxy
+            .write_code_client(CodeLanguage::Python, tempdir.path(), Some("alpha"))
             .unwrap();
-        assert!(paths.iter().any(|path| path.ends_with("alpha.py")));
+        assert_eq!(generated.kind, GeneratedClientKind::Python);
+        assert!(generated.files.iter().any(|path| path.ends_with("alpha.py")));
+        assert_eq!(
+            generated.environment.get("PYTHONPATH"),
+            Some(&tempdir.path().to_string_lossy().to_string())
+        );
+
+        let cli = proxy.write_cli_client(tempdir.path(), Some("alpha")).unwrap();
+        assert_eq!(cli.kind, GeneratedClientKind::Cli);
     }
 
     #[tokio::test]

--- a/docs/usage/generated-clients.md
+++ b/docs/usage/generated-clients.md
@@ -73,8 +73,9 @@ The Atlassian examples use OAuth. The first run opens a browser if no stored cre
 
     with CompressorClient(servers=servers, compression_level="max") as proxy:
         proxy.write_client("cli", "./bin", name="atlassian")
-        proxy.write_client("python", "./generated-py", name="atlassian")
-        proxy.write_client("typescript", "./generated-ts", name="atlassian")
+        python_client = proxy.write_code_client("python", "./generated-py", name="atlassian")
+        typescript_client = proxy.write_code_client("typescript", "./generated-ts", name="atlassian")
+        print(python_client.environment)  # {"PYTHONPATH": "./generated-py"}
     ```
 
 === "TypeScript"
@@ -108,11 +109,12 @@ The Atlassian examples use OAuth. The first run opens a browser if no stored cre
 === "Rust"
 
     ```rust
-    use mcp_compressor::sdk::GeneratedClientKind;
+    use mcp_compressor::sdk::CodeLanguage;
 
-    proxy.write_client(GeneratedClientKind::Cli, "./bin", Some("atlassian"))?;
-    proxy.write_client(GeneratedClientKind::Python, "./generated-py", Some("atlassian"))?;
-    proxy.write_client(GeneratedClientKind::TypeScript, "./generated-ts", Some("atlassian"))?;
+    proxy.write_cli_client("./bin", Some("atlassian"))?;
+    let python_client = proxy.write_code_client(CodeLanguage::Python, "./generated-py", Some("atlassian"))?;
+    let typescript_client = proxy.write_code_client(CodeLanguage::TypeScript, "./generated-ts", Some("atlassian"))?;
+    println!("{:?}", python_client.environment); // {"PYTHONPATH": "./generated-py"}
     ```
 
 ## What the generated clients look like

--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -101,29 +101,45 @@ When more than one backend server is configured, specify the server when invokin
 
 ## Executable tools for agent frameworks
 
-TypeScript applications often need framework-ready tool objects rather than direct `proxy.invoke(...)` calls. Use `proxy.toExecutableTools()` as the framework-neutral primitive, then adapt it to the framework you use.
+Applications often need framework-ready callable tool objects rather than direct `proxy.invoke(...)` calls. Use executable tools as the framework-neutral primitive, then adapt them to the framework you use.
 
-```ts
-import { CompressorClient, toAISDKTools, toMastraTools } from "@atlassian/mcp-compressor";
-import { tool } from "ai";
+=== "Python"
 
-const proxy = await new CompressorClient({ servers }).connect();
+    ```python
+    from mcp_compressor import CompressorClient, to_ai_sdk_tools, to_mastra_tools
 
-const executableTools = proxy.toExecutableTools();
-const aiSdkTools = toAISDKTools(executableTools, { tool });
-const mastraTools = toMastraTools(executableTools);
-```
+    with CompressorClient(servers=servers) as proxy:
+        executable_tools = proxy.to_executable_tools()
+        ai_sdk_tools = to_ai_sdk_tools(executable_tools)
+        mastra_tools = to_mastra_tools(executable_tools)
+    ```
 
-The executable tool shape is intentionally simple:
+=== "TypeScript"
 
-```ts
-{
-  name: string;
-  description?: string;
-  inputSchema: Record<string, unknown>;
-  execute(input?: Record<string, unknown>): Promise<string>;
-}
-```
+    ```ts
+    import { CompressorClient, toAISDKTools, toMastraTools } from "@atlassian/mcp-compressor";
+    import { tool } from "ai";
+
+    const proxy = await new CompressorClient({ servers }).connect();
+
+    const executableTools = proxy.toExecutableTools();
+    const aiSdkTools = toAISDKTools(executableTools, { tool });
+    const mastraTools = toMastraTools(executableTools);
+    ```
+
+=== "Rust"
+
+    ```rust
+    let tools = proxy.executable_tools();
+    let result = tools["alpha_invoke_tool"]
+        .execute(json!({
+            "tool_name": "echo",
+            "tool_input": { "message": "hello" }
+        }))
+        .await?;
+    ```
+
+The executable tool shape is intentionally simple: name, description, input schema, and an execute function.
 
 ## Compression options
 

--- a/python/mcp-compressor/mcp_compressor/__init__.py
+++ b/python/mcp-compressor/mcp_compressor/__init__.py
@@ -1,8 +1,11 @@
 """Rust-backed Python API for mcp-compressor."""
 
+from mcp_compressor.adapters import to_ai_sdk_tools, to_mastra_tools
 from mcp_compressor.client import (
     CompressorClient,
     CompressorProxy,
+    ExecutableTool,
+    GeneratedCodeClient,
     JustBashCommand,
     JustBashProvider,
     ProxyResponse,
@@ -35,6 +38,8 @@ __all__ = [
     "CompressedSessionConfig",
     "CompressorClient",
     "CompressorProxy",
+    "ExecutableTool",
+    "GeneratedCodeClient",
     "JustBashCallableCommand",
     "JustBashCommand",
     "JustBashProvider",
@@ -52,4 +57,6 @@ __all__ = [
     "parse_tool_argv",
     "start_compressed_session",
     "start_compressed_session_from_mcp_config",
+    "to_ai_sdk_tools",
+    "to_mastra_tools",
 ]

--- a/python/mcp-compressor/mcp_compressor/adapters.py
+++ b/python/mcp-compressor/mcp_compressor/adapters.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, TypeVar
+
+from mcp_compressor.client import ExecutableTool
+
+TTool = TypeVar("TTool")
+ToolFactory = Callable[[dict[str, Any]], TTool]
+
+
+def to_ai_sdk_tools(
+    tools: Mapping[str, ExecutableTool],
+    *,
+    tool: ToolFactory | None = None,
+) -> dict[str, Any]:
+    """Convert executable tools into AI-SDK-style tool definitions.
+
+    The optional ``tool`` factory mirrors the TypeScript adapter: pass a framework helper
+    if you want framework-specific wrappers, or omit it to get plain structural objects.
+    """
+    result: dict[str, Any] = {}
+    for name, executable in tools.items():
+        definition = {
+            "description": executable.description,
+            "input_schema": executable.input_schema,
+            "execute": executable.execute,
+        }
+        result[name] = tool(definition) if tool else definition
+    return result
+
+
+def to_mastra_tools(tools: Mapping[str, ExecutableTool]) -> dict[str, dict[str, Any]]:
+    """Convert executable tools into a Mastra-like structural tool map."""
+    return {
+        name: {
+            "description": executable.description,
+            "input_schema": executable.input_schema,
+            "execute": executable.execute,
+        }
+        for name, executable in tools.items()
+    }

--- a/python/mcp-compressor/mcp_compressor/client.py
+++ b/python/mcp-compressor/mcp_compressor/client.py
@@ -36,6 +36,22 @@ class ProxyResponse:
 
 
 @dataclass(frozen=True)
+class ExecutableTool:
+    name: str
+    description: str | None
+    input_schema: dict[str, Any]
+    execute: Callable[[dict[str, Any] | None], str]
+
+
+@dataclass(frozen=True)
+class GeneratedCodeClient:
+    language: Literal["python", "typescript"]
+    output_dir: Path
+    files: list[Path]
+    environment: dict[str, str]
+
+
+@dataclass(frozen=True)
 class JustBashCommand:
     command_name: str
     backend_tool_name: str
@@ -205,6 +221,23 @@ class CompressorProxy:
         self._closed = True
         self._session.close()
 
+    def to_executable_tools(self) -> dict[str, ExecutableTool]:
+        def make_execute(wrapper_name: str) -> Callable[[dict[str, Any] | None], str]:
+            def execute(input: dict[str, Any] | None = None) -> str:
+                return self.invoke_wrapper(wrapper_name, input or {}).text
+
+            return execute
+
+        return {
+            tool.name: ExecutableTool(
+                name=tool.name,
+                description=tool.description,
+                input_schema=tool.input_schema,
+                execute=make_execute(tool.name),
+            )
+            for tool in self.tools
+        }
+
     def write_client(self, kind: str, output_dir: str | Path, *, name: str | None = None) -> list[Path]:
         info = self._session.info()
         return generate_client_artifacts(
@@ -214,6 +247,23 @@ class CompressorProxy:
             token=str(info["token"]),
             tools=list(info.get("backend_tools", info["frontend_tools"])),
             output_dir=output_dir,
+        )
+
+    def write_code_client(
+        self,
+        language: Literal["python", "typescript"],
+        output_dir: str | Path,
+        *,
+        name: str | None = None,
+    ) -> GeneratedCodeClient:
+        output_path = Path(output_dir)
+        files = self.write_client(language, output_path, name=name)
+        environment = {"PYTHONPATH": str(output_path)} if language == "python" else {}
+        return GeneratedCodeClient(
+            language=language,
+            output_dir=output_path,
+            files=files,
+            environment=environment,
         )
 
     def invoke_wrapper(self, wrapper_tool: str, tool_input: dict[str, Any]) -> ProxyResponse:

--- a/python/mcp-compressor/tests/test_public_sdk_workflow.py
+++ b/python/mcp-compressor/tests/test_public_sdk_workflow.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from mcp_compressor import CompressorClient
+from mcp_compressor import CompressorClient, to_ai_sdk_tools, to_mastra_tools
 
 ROOT = Path(__file__).resolve().parents[3]
 FIXTURE = ROOT / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
@@ -97,6 +97,25 @@ def test_public_python_sdk_quickstart_flow() -> None:
         response = proxy.invoke("echo", {"message": "public-python"})
         assert response == "alpha:public-python"
 
+        executable_tools = proxy.to_executable_tools()
+        assert (
+            executable_tools["alpha_invoke_tool"].execute(
+                {"tool_name": "echo", "tool_input": {"message": "executable-python"}}
+            )
+            == "alpha:executable-python"
+        )
+
+        mastra_tools = to_mastra_tools(executable_tools)
+        assert (
+            mastra_tools["alpha_invoke_tool"]["execute"](
+                {"tool_name": "echo", "tool_input": {"message": "mastra-python"}}
+            )
+            == "alpha:mastra-python"
+        )
+
+        wrapped = to_ai_sdk_tools(executable_tools, tool=lambda definition: {**definition, "wrapped": True})
+        assert wrapped["alpha_invoke_tool"]["wrapped"] is True
+
 
 def test_public_python_sdk_auth_provider_refreshes_per_remote_request() -> None:
     calls = 0
@@ -132,6 +151,22 @@ def test_public_python_sdk_auth_provider_refreshes_per_remote_request() -> None:
     assert first == "alpha:one"
     assert second == "alpha:two"
     assert calls >= 2
+
+
+def test_public_python_sdk_write_code_client_returns_environment(tmp_path: Path) -> None:
+    with CompressorClient(
+        servers={"alpha": {"command": PYTHON, "args": [str(FIXTURE)]}},
+        compression_level="max",
+    ) as proxy:
+        generated = proxy.write_code_client("python", tmp_path / "py", name="alpha")
+        assert generated.language == "python"
+        assert generated.environment == {"PYTHONPATH": str(tmp_path / "py")}
+        assert any(path.name == "alpha.py" for path in generated.files)
+
+        ts_generated = proxy.write_code_client("typescript", tmp_path / "ts", name="alpha")
+        assert ts_generated.language == "typescript"
+        assert ts_generated.environment == {}
+        assert any(path.name == "alpha.ts" for path in ts_generated.files)
 
 
 def test_public_python_sdk_schema_lookup_supports_multi_server() -> None:


### PR DESCRIPTION
## Summary
- add Rust SDK executable tools, structured generated-client results, and ergonomic CLI/Code Mode writers
- add Python SDK executable tools, adapter helpers, and structured Code Mode writer
- export the new Python public SDK helpers
- update docs so Python, TypeScript, and Rust share the same mental model

## Design notes
- Aligns the three SDKs around: CompressorClient -> CompressorProxy -> invoke/schema/executable tools/generate clients.
- Python and TypeScript now both expose framework-neutral executable tool adapters.
- Rust now has equivalent generation ergonomics instead of only lower-level generator access.

## Tests
- cargo test -p mcp-compressor-core sdk:: -- --nocapture
- cargo check -p mcp-compressor-core
- cd python/mcp-compressor && uv run maturin develop
- cd python/mcp-compressor && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests/test_public_sdk_workflow.py::test_public_python_sdk_quickstart_flow tests/test_public_sdk_workflow.py::test_public_python_sdk_write_code_client_returns_environment
- cd python/mcp-compressor && uv run ruff check mcp_compressor tests && uv run ruff format --check mcp_compressor tests && uv run ty check --project . --python .venv mcp_compressor tests
- make docs-test
- make check