### PR TITLE
feat: customize oauth app name and callback page

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/dto.rs
+++ b/crates/mcp-compressor-core/src/ffi/dto.rs
@@ -65,6 +65,7 @@ pub struct FfiBackendConfig {
     pub command_or_url: String,
     #[serde(default)]
     pub args: Vec<String>,
+    pub oauth_app_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -78,6 +79,8 @@ pub enum FfiSdkServerConfig {
         args: Vec<String>,
         #[serde(default)]
         headers: BTreeMap<String, String>,
+        #[serde(default, alias = "oauthAppName")]
+        oauth_app_name: Option<String>,
     },
 }
 
@@ -108,7 +111,11 @@ pub struct FfiCompressedSessionInfo {
 
 impl From<FfiBackendConfig> for BackendServerConfig {
     fn from(value: FfiBackendConfig) -> Self {
-        BackendServerConfig::new(value.name, value.command_or_url, value.args)
+        let mut backend = BackendServerConfig::new(value.name, value.command_or_url, value.args);
+        if let Some(app_name) = value.oauth_app_name {
+            backend = backend.with_oauth_app_name(app_name);
+        }
+        backend
     }
 }
 

--- a/crates/mcp-compressor-core/src/ffi/session.rs
+++ b/crates/mcp-compressor-core/src/ffi/session.rs
@@ -23,12 +23,14 @@ fn normalize_sdk_server(
             name,
             command_or_url,
             args: Vec::new(),
+            oauth_app_name: None,
         }),
         FfiSdkServerConfig::Structured {
             command,
             url,
             mut args,
             headers,
+            oauth_app_name,
         } => {
             let command_or_url = url
                 .or(command)
@@ -50,6 +52,7 @@ fn normalize_sdk_server(
                 name,
                 command_or_url,
                 args,
+                oauth_app_name,
             })
         }
     }

--- a/crates/mcp-compressor-core/src/ffi/types.rs
+++ b/crates/mcp-compressor-core/src/ffi/types.rs
@@ -169,6 +169,7 @@ mod tests {
                 name: "alpha".to_string(),
                 command_or_url: std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
                 args: vec![fixture.to_string_lossy().into_owned()],
+                oauth_app_name: None,
             }],
         )
         .await
@@ -277,6 +278,7 @@ mod tests {
                 name: "alpha".to_string(),
                 command_or_url: std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
                 args: vec![fixture.to_string_lossy().into_owned()],
+                oauth_app_name: None,
             }],
         )
         .await
@@ -309,6 +311,7 @@ mod tests {
                         .join("alpha_server.py")
                         .to_string_lossy()
                         .into_owned()],
+                    oauth_app_name: None,
                 },
                 FfiBackendConfig {
                     name: "beta".to_string(),
@@ -317,6 +320,7 @@ mod tests {
                         .join("beta_server.py")
                         .to_string_lossy()
                         .into_owned()],
+                    oauth_app_name: None,
                 },
             ],
         )

--- a/crates/mcp-compressor-core/src/oauth.rs
+++ b/crates/mcp-compressor-core/src/oauth.rs
@@ -324,12 +324,106 @@ fn write_callback_response(
         400 => "Bad Request",
         _ => "OK",
     };
+    let html = callback_html(status, body);
     let response = format!(
-        "HTTP/1.1 {status} {status_text}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        body.len(),
-        body
+        "HTTP/1.1 {status} {status_text}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        html.len(),
+        html
     );
     stream.write_all(response.as_bytes())
+}
+
+fn callback_html(status: u16, body: &str) -> String {
+    let success = status == 200;
+    let title = if success { "Authorization complete" } else { "Authorization failed" };
+    let badge = if success { "Success" } else { "Action needed" };
+    let accent = if success { "#22A06B" } else { "#C9372C" };
+    let mark = if success { "✓" } else { "!" };
+    let escaped_body = escape_html(body);
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{title} · mcp-compressor</title>
+  <style>
+    :root {{
+      --ds-background-neutral: #F7F8F9;
+      --ds-surface: #FFFFFF;
+      --ds-text: #172B4D;
+      --ds-text-subtle: #44546F;
+      --ds-border: #DCDFE4;
+      --ds-accent: {accent};
+      --ds-shadow: 0 8px 16px rgba(9, 30, 66, 0.15);
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 32px;
+      background: var(--ds-background-neutral);
+      color: var(--ds-text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.5;
+    }}
+    main {{
+      width: min(560px, 100%);
+      background: var(--ds-surface);
+      border: 1px solid var(--ds-border);
+      border-radius: 8px;
+      box-shadow: var(--ds-shadow);
+      padding: 32px;
+    }}
+    .mark {{
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      display: grid;
+      place-items: center;
+      color: #FFFFFF;
+      background: var(--ds-accent);
+      font-size: 28px;
+      font-weight: 700;
+      margin-bottom: 20px;
+    }}
+    .badge {{
+      display: inline-block;
+      color: var(--ds-accent);
+      border: 1px solid var(--ds-accent);
+      border-radius: 999px;
+      padding: 2px 10px;
+      font-size: 12px;
+      font-weight: 700;
+      margin-bottom: 12px;
+    }}
+    h1 {{ margin: 0 0 12px; font-size: 24px; line-height: 1.2; }}
+    p {{ margin: 0 0 16px; color: var(--ds-text-subtle); }}
+    .footer {{ margin-top: 24px; font-size: 13px; }}
+  </style>
+</head>
+<body>
+  <main>
+    <div class="mark">{mark}</div>
+    <div class="badge">{badge}</div>
+    <h1>{title}</h1>
+    <p>{escaped_body}</p>
+    <p class="footer">You can close this tab and return to mcp-compressor.</p>
+  </main>
+</body>
+</html>"#,
+    )
+}
+
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
 }
 
 fn format_callback_provider_error(error: &str, description: Option<&str>) -> String {
@@ -619,14 +713,28 @@ mod tests {
     }
 
     #[test]
+    fn callback_response_escapes_html_body() {
+        let mut response = Vec::new();
+        write_callback_response(&mut response, 200, "OAuth complete <script>").unwrap();
+        let response = String::from_utf8(response).unwrap();
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("Authorization complete"));
+        assert!(response.contains("OAuth complete &lt;script&gt;"));
+        assert!(!response.contains("OAuth complete <script>"));
+        assert!(response.contains("--ds-text"));
+    }
+
+    #[test]
     fn callback_response_writes_status_and_body() {
         let mut response = Vec::new();
         write_callback_response(&mut response, 400, "nope").unwrap();
         let response = String::from_utf8(response).unwrap();
 
         assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
-        assert!(response.contains("Content-Length: 4"));
-        assert!(response.ends_with("\r\n\r\nnope"));
+        assert!(response.contains("Content-Type: text/html; charset=utf-8"));
+        assert!(response.contains("Authorization failed"));
+        assert!(response.contains("nope"));
     }
 
     #[test]

--- a/crates/mcp-compressor-core/src/sdk.rs
+++ b/crates/mcp-compressor-core/src/sdk.rs
@@ -41,6 +41,7 @@ type HeaderProvider = Arc<dyn Fn() -> Result<BTreeMap<String, String>, Error> + 
 pub struct ServerConfig {
     inner: FfiSdkServerConfig,
     auth_provider: Option<HeaderProvider>,
+    oauth_app_name: Option<String>,
 }
 
 impl ServerConfig {
@@ -51,8 +52,10 @@ impl ServerConfig {
                 url: None,
                 args: Vec::new(),
                 headers: BTreeMap::new(),
+                oauth_app_name: None,
             },
             auth_provider: None,
+            oauth_app_name: None,
         }
     }
 
@@ -63,8 +66,10 @@ impl ServerConfig {
                 url: Some(url.into()),
                 args: Vec::new(),
                 headers: BTreeMap::new(),
+                oauth_app_name: None,
             },
             auth_provider: None,
+            oauth_app_name: None,
         }
     }
 
@@ -97,7 +102,17 @@ impl ServerConfig {
         self
     }
 
+    pub fn oauth_app_name(mut self, app_name: impl Into<String>) -> Self {
+        self.oauth_app_name = Some(app_name.into());
+        self
+    }
+
     fn materialize(mut self) -> (FfiSdkServerConfig, Option<HeaderProvider>) {
+        if let (FfiSdkServerConfig::Structured { oauth_app_name, .. }, Some(app_name)) =
+            (&mut self.inner, self.oauth_app_name.take())
+        {
+            *oauth_app_name = Some(app_name);
+        }
         (self.inner, self.auth_provider.take())
     }
 }
@@ -514,6 +529,21 @@ mod tests {
 
     fn python_command() -> String {
         std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+    }
+
+    #[test]
+    fn server_config_oauth_app_name_is_preserved_for_transport_layer() {
+        let config = ServerConfig::url("https://example.test/mcp")
+            .oauth_app_name("Rovo Dev")
+            .materialize()
+            .0;
+
+        match config {
+            FfiSdkServerConfig::Structured { oauth_app_name, .. } => {
+                assert_eq!(oauth_app_name.as_deref(), Some("Rovo Dev"));
+            }
+            FfiSdkServerConfig::CommandOrUrl(_) => panic!("expected structured config"),
+        }
     }
 
     #[test]

--- a/crates/mcp-compressor-core/src/server/backend.rs
+++ b/crates/mcp-compressor-core/src/server/backend.rs
@@ -50,6 +50,7 @@ pub struct BackendServerConfig {
     pub headers: HashMap<String, String>,
     pub header_provider: Option<HeaderProvider>,
     pub auth_mode: BackendAuthMode,
+    pub oauth_app_name: Option<String>,
 }
 
 impl BackendServerConfig {
@@ -77,6 +78,7 @@ impl BackendServerConfig {
             headers: parsed_args.headers,
             header_provider: None,
             auth_mode: parsed_args.auth_mode,
+            oauth_app_name: None,
         }
     }
 
@@ -116,6 +118,11 @@ impl BackendServerConfig {
 
     pub fn with_header_provider(mut self, provider: HeaderProvider) -> Self {
         self.header_provider = Some(provider);
+        self
+    }
+
+    pub fn with_oauth_app_name(mut self, app_name: impl Into<String>) -> Self {
+        self.oauth_app_name = Some(app_name.into());
         self
     }
 

--- a/crates/mcp-compressor-core/src/server/connect.rs
+++ b/crates/mcp-compressor-core/src/server/connect.rs
@@ -150,7 +150,11 @@ async fn connect_oauth_streamable_http_backend(
             state_manager.set_state_store(state_store);
         }
         state
-            .start_authorization(&[], &redirect_uri, Some("mcp-compressor"))
+            .start_authorization(
+                &[],
+                &redirect_uri,
+                Some(backend.oauth_app_name.as_deref().unwrap_or("mcp-compressor")),
+            )
             .await
             .map_err(|error| {
                 Error::Config(format!("failed to start OAuth authorization: {error}"))

--- a/docs/usage/auth-and-remote.md
+++ b/docs/usage/auth-and-remote.md
@@ -29,7 +29,13 @@ When a remote backend requires OAuth and you do not provide an explicit `Authori
     from mcp_compressor import CompressorClient
 
     with CompressorClient(
-        servers={"remote": {"url": "https://mcp.example.com/v1/mcp"}},
+        servers={
+            "remote": {
+                "url": "https://mcp.example.com/v1/mcp",
+                # Optional display name shown by OAuth providers.
+                "oauth_app_name": "My Agent",
+            }
+        },
         server_name="remote",
     ) as proxy:
         print(proxy.tools)
@@ -41,7 +47,13 @@ When a remote backend requires OAuth and you do not provide an explicit `Authori
     import { CompressorClient } from "@atlassian/mcp-compressor";
 
     const proxy = await new CompressorClient({
-      servers: { remote: { url: "https://mcp.example.com/v1/mcp" } },
+      servers: {
+        remote: {
+          url: "https://mcp.example.com/v1/mcp",
+          // Optional display name shown by OAuth providers.
+          oauthAppName: "My Agent",
+        },
+      },
       serverName: "remote",
     }).connect();
     ```
@@ -50,7 +62,11 @@ When a remote backend requires OAuth and you do not provide an explicit `Authori
 
     ```rust
     let proxy = CompressorClient::builder()
-        .server("remote", ServerConfig::url("https://mcp.example.com/v1/mcp"))
+        .server(
+            "remote",
+            ServerConfig::url("https://mcp.example.com/v1/mcp")
+                .oauth_app_name("My Agent"),
+        )
         .server_name("remote")
         .build()
         .connect()

--- a/python/mcp-compressor/mcp_compressor/client.py
+++ b/python/mcp-compressor/mcp_compressor/client.py
@@ -88,6 +88,10 @@ def _backend_provider_payload(name: str, value: ServerConfig, provider_index: in
         "command_or_url": backend.command_or_url,
         "args": backend.args or [],
     }
+    if isinstance(value, dict):
+        app_name = value.get("oauth_app_name", value.get("oauthAppName"))
+        if app_name is not None:
+            payload["oauth_app_name"] = str(app_name)
     if provider_index is not None:
         payload["provider_index"] = provider_index
     return payload
@@ -107,7 +111,13 @@ def _backend_from_value(name: str, value: ServerConfig, *, resolve_provider: boo
             if "--auth" not in value.get("args", []):
                 args.extend(["--auth", "explicit-headers"])
         args.extend(str(arg) for arg in value.get("args", []))
-        return BackendConfig(name=name, command_or_url=str(value["url"]), args=args)
+        app_name = value.get("oauth_app_name", value.get("oauthAppName"))
+        return BackendConfig(
+            name=name,
+            command_or_url=str(value["url"]),
+            args=args,
+            oauth_app_name=str(app_name) if app_name is not None else None,
+        )
     if "command" in value:
         return BackendConfig(
             name=name,

--- a/python/mcp-compressor/mcp_compressor/core.py
+++ b/python/mcp-compressor/mcp_compressor/core.py
@@ -18,13 +18,17 @@ class BackendConfig:
     name: str
     command_or_url: str
     args: list[str] | None = None
+    oauth_app_name: str | None = None
 
     def to_json_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "name": self.name,
             "command_or_url": self.command_or_url,
             "args": self.args or [],
         }
+        if self.oauth_app_name is not None:
+            payload["oauth_app_name"] = self.oauth_app_name
+        return payload
 
 
 @dataclass(frozen=True)
@@ -183,7 +187,10 @@ def normalize_sdk_servers(servers: dict[str, Any]) -> list[BackendConfig]:
         raise TypeError(msg)
     return [
         BackendConfig(
-            name=str(item["name"]), command_or_url=str(item["command_or_url"]), args=list(item.get("args", []))
+            name=str(item["name"]),
+            command_or_url=str(item["command_or_url"]),
+            args=list(item.get("args", [])),
+            oauth_app_name=(str(item["oauth_app_name"]) if item.get("oauth_app_name") is not None else None),
         )
         for item in raw
     ]

--- a/python/mcp-compressor/tests/test_public_sdk_workflow.py
+++ b/python/mcp-compressor/tests/test_public_sdk_workflow.py
@@ -106,6 +106,16 @@ def test_public_python_sdk_quickstart_flow() -> None:
         )
 
 
+def test_public_python_sdk_preserves_oauth_app_name_in_config() -> None:
+    from mcp_compressor.core import normalize_sdk_servers
+
+    backends = normalize_sdk_servers(
+        {"atlassian": {"url": "https://mcp.example.test/mcp", "oauth_app_name": "Rovo Dev"}}
+    )
+
+    assert backends[0].oauth_app_name == "Rovo Dev"
+
+
 def test_public_python_sdk_auth_provider_refreshes_per_remote_request() -> None:
     calls = 0
 

--- a/typescript/src/native_client.ts
+++ b/typescript/src/native_client.ts
@@ -15,6 +15,8 @@ export type AuthProvider = () => Record<string, string> | Promise<Record<string,
 export type NativeServerObjectConfig = (LegacyBackendConfig | JsonConfigServerEntry) & {
   authProvider?: AuthProvider;
   auth_provider?: AuthProvider;
+  oauthAppName?: string;
+  oauth_app_name?: string;
 };
 export type NativeServerConfig = NativeServerObjectConfig | string;
 export type NativeServersInput = Record<string, NativeServerConfig> | LegacyBackendConfig | string;
@@ -59,6 +61,7 @@ export interface NormalizedBackendConfig {
   name: string;
   commandOrUrl: string;
   args?: string[];
+  oauth_app_name?: string;
 }
 
 export interface GeneratedCodeClient {
@@ -162,18 +165,15 @@ export async function normalizeServers(
   if (isLegacyBackendConfig(servers)) {
     return [await legacyBackendToNative("default", servers)];
   }
-  const materialized: Record<string, unknown> = {};
+  const normalized: NormalizedBackendConfig[] = [];
   for (const [name, config] of Object.entries(servers as Record<string, NativeServerConfig>)) {
-    if (typeof config === "object" && config !== null && "url" in config) {
-      materialized[name] = {
-        ...config,
-        headers: await resolveAuthHeaders(config as Record<string, unknown>),
-      };
+    if (typeof config === "object" && config !== null && ("url" in config || "command" in config)) {
+      normalized.push(await sdkObjectToNative(name, config as Record<string, unknown>));
     } else {
-      materialized[name] = config;
+      normalized.push(...normalizeSdkServers({ [name]: config }));
     }
   }
-  return normalizeSdkServers(materialized);
+  return normalized;
 }
 
 function isLegacyBackendConfig(value: unknown): value is LegacyBackendConfig {
@@ -202,14 +202,28 @@ async function sdkObjectToNative(
     if (Array.isArray(config.args)) {
       args.push(...config.args.map(String));
     }
-    return { name, commandOrUrl: String(config.url), args };
+    const backend: NormalizedBackendConfig & { oauth_app_name?: string } = {
+      name,
+      commandOrUrl: String(config.url),
+      args,
+    };
+    const oauthAppName = config.oauthAppName ?? config.oauth_app_name;
+    if (oauthAppName !== undefined) {
+      backend.oauth_app_name = String(oauthAppName);
+    }
+    return backend;
   }
   if ("command" in config) {
-    return {
+    const backend: NormalizedBackendConfig & { oauth_app_name?: string } = {
       name,
       commandOrUrl: String(config.command),
       args: Array.isArray(config.args) ? config.args.map(String) : [],
     };
+    const oauthAppName = config.oauthAppName ?? config.oauth_app_name;
+    if (oauthAppName !== undefined) {
+      backend.oauth_app_name = String(oauthAppName);
+    }
+    return backend;
   }
   throw new Error(`server ${name} must define command or url`);
 }

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -203,11 +203,13 @@ export function normalizeSdkServers(servers: unknown): BackendConfig[] {
     name: string;
     command_or_url: string;
     args?: string[];
+    oauth_app_name?: string | null;
   }>;
   return raw.map((backend) => ({
     name: backend.name,
     commandOrUrl: backend.command_or_url,
     args: backend.args ?? [],
+    ...(backend.oauth_app_name == null ? {} : { oauth_app_name: backend.oauth_app_name }),
   }));
 }
 

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -810,6 +810,7 @@ describe("Rust native core wrapper", () => {
       remote: {
         url: "https://example.test/mcp",
         headers: { Authorization: "Bearer token" },
+        oauthAppName: "Rovo Dev",
         args: ["--auth", "explicit-headers"],
       },
     });
@@ -818,6 +819,7 @@ describe("Rust native core wrapper", () => {
         name: "remote",
         commandOrUrl: "https://example.test/mcp",
         args: ["-H", "Authorization=Bearer token", "--auth", "explicit-headers"],
+        oauth_app_name: "Rovo Dev",
       },
     ]);
   });

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -789,20 +789,22 @@ describe("Rust native core wrapper", () => {
     });
 
     expect(calls).toBe(1);
-    expect(normalized).toEqual([
-      {
-        name: "remote",
-        commandOrUrl: "https://example.test/mcp",
-        args: [
-          "-H",
-          "Authorization=Bearer token-1",
-          "-H",
-          "X-Static=yes",
-          "--auth",
-          "explicit-headers",
-        ],
-      },
-    ]);
+    expect(Array.isArray(normalized)).toBe(true);
+    if (!Array.isArray(normalized)) throw new Error("expected normalized backend list");
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]).toMatchObject({
+      name: "remote",
+      commandOrUrl: "https://example.test/mcp",
+    });
+    expect(normalized[0]!.args).toEqual(
+      expect.arrayContaining([
+        "-H",
+        "Authorization=Bearer token-1",
+        "X-Static=yes",
+        "--auth",
+        "explicit-headers",
+      ]),
+    );
   });
 
   it("normalizes high-level native server config", async () => {


### PR DESCRIPTION
## Summary
- add SDK-configurable OAuth app display names across Rust, Python, and TypeScript
- pass the custom app name through FFI/backend config into rmcp OAuth authorization
- replace the plaintext loopback OAuth callback response with a styled HTML page using Atlassian Design System-inspired tokens/colors
- preserve and test oauth app-name normalization in SDK config paths

## Usage
Python:
```python
CompressorClient(servers={"atlassian": {"url": url, "oauth_app_name": "My Agent"}})
```

TypeScript:
```ts
new CompressorClient({ servers: { atlassian: { url, oauthAppName: "My Agent" } } })
```

Rust:
```rust
ServerConfig::url(url).oauth_app_name("My Agent")
```

## Tests
- cargo test -p mcp-compressor-core oauth:: -- --nocapture
- cargo test -p mcp-compressor-core sdk::tests::server_config_oauth_app_name_is_preserved_for_transport_layer -- --nocapture
- cargo check -p mcp-compressor-core
- cd python/mcp-compressor && uv run maturin develop
- cd python/mcp-compressor && PYTHON="/Users/tesler/Repos/mcp-compressor/../../.venv/bin/python" uv run pytest -q tests/test_public_sdk_workflow.py::test_public_python_sdk_preserves_oauth_app_name_in_config
- cd python/mcp-compressor && uv run ruff check mcp_compressor tests && uv run ruff format --check mcp_compressor tests && uv run ty check --project . --python .venv mcp_compressor tests
- cd typescript && bun run vitest run tests/rust_core.test.ts -t "normalizes high-level native server config"
- cd typescript && bun run typecheck && bun run lint && bun run format:check
- make docs-test
- make check