### PR TITLE
ci: allow dirty rust crate publish workspace

### DIFF
--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -49,10 +49,10 @@ jobs:
         run: cargo check -p mcp-compressor --locked
 
       - name: Package core crate
-        run: cargo package -p mcp-compressor-core --locked
+        run: cargo package -p mcp-compressor-core --locked --allow-dirty
 
       - name: Publish core crate dry-run
-        run: cargo publish -p mcp-compressor-core --locked --dry-run
+        run: cargo publish -p mcp-compressor-core --locked --dry-run --allow-dirty
 
       - name: Stop before publish in validation mode
         if: github.event_name == 'workflow_dispatch' && inputs.publish != true
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'release' || inputs.publish == true
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p mcp-compressor-core --locked
+        run: cargo publish -p mcp-compressor-core --locked --allow-dirty
 
       - name: Wait for core crate in crates.io index
         if: github.event_name == 'release' || inputs.publish == true
@@ -83,14 +83,14 @@ jobs:
 
       - name: Package public crate
         if: github.event_name == 'release' || inputs.publish == true
-        run: cargo package -p mcp-compressor --locked
+        run: cargo package -p mcp-compressor --locked --allow-dirty
 
       - name: Publish public crate dry-run
         if: github.event_name == 'release' || inputs.publish == true
-        run: cargo publish -p mcp-compressor --locked --dry-run
+        run: cargo publish -p mcp-compressor --locked --dry-run --allow-dirty
 
       - name: Publish public crate
         if: github.event_name == 'release' || inputs.publish == true
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p mcp-compressor --locked
+        run: cargo publish -p mcp-compressor --locked --allow-dirty


### PR DESCRIPTION
## Summary
- add --allow-dirty to Rust crate package/publish steps
- needed because the release workflow intentionally patches Cargo.toml/Cargo.lock versions from the release tag before publishing

## Validation
- parsed .github/workflows/publish-rust-crate.yml as YAML
- make check
