### PR TITLE
Clean up root project metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,5 +217,6 @@ __marimo__/
 typescript/node_modules/
 typescript/dist/
 typescript/dist-test/
+typescript/native/
 typescript/*.tsbuildinfo
 typescript/package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ If you are proposing a new feature:
 # Get Started!
 
 Ready to contribute? Here's how to set up `mcp-compressor` for local development.
-Please note this documentation assumes you already have `uv` and `Git` installed and ready to go.
+Please note this documentation assumes you already have `uv`, `Git`, Rust/Cargo, and Bun installed and ready to go.
 
 1. Fork the `mcp-compressor` repo on GitHub.
 
@@ -64,16 +64,17 @@ cd <directory_in_which_repo_should_be_created>
 git clone git@github.com:YOUR_NAME/mcp-compressor.git
 ```
 
-3. Now we need to install the environment. Navigate into the directory
+3. Now install the repository dependencies. Navigate into the directory:
 
 ```bash
 cd mcp-compressor
 ```
 
-Then, install and activate the environment with:
+Install the Python environment and TypeScript dependencies with:
 
 ```bash
 uv sync
+cd typescript && bun install --frozen-lockfile && cd ..
 ```
 
 4. Install pre-commit to run linters/formatters at commit time:
@@ -90,31 +91,34 @@ git checkout -b name-of-your-bugfix-or-feature
 
 Now you can make your changes locally.
 
-6. Don't forget to add test cases for your added functionality to the `tests` directory.
+6. Don't forget to add test cases for your added functionality in the relevant package test directory (`tests/`, `crates/mcp-compressor-core/tests/`, or `typescript/tests/`).
 
-7. When you're done making changes, check that your changes pass the formatting tests.
+7. When you're done making changes, run the relevant checks. For the full workspace:
 
 ```bash
 make check
-```
-
-Now, validate that all unit tests are passing:
-
-```bash
 make test
 ```
 
-9. Before raising a pull request you should also run tox.
-   This will run the tests across different versions of Python:
+For targeted checks while iterating:
+
+```bash
+uv run pytest -q tests/test_main.py
+cargo test -p mcp-compressor-core
+cd typescript && bun run check:ci
+```
+
+8. Before raising a pull request that affects Python compatibility, you can also run tox.
+   This runs the Python tests across supported Python versions:
 
 ```bash
 tox
 ```
 
-This requires you to have multiple versions of python installed.
-This step is also triggered in the CI/CD pipeline, so you could also choose to skip this step locally.
+This requires you to have multiple supported Python versions installed.
+This step is also triggered in CI, so you can skip it locally when CI coverage is enough.
 
-10. Commit your changes and push your branch to GitHub:
+9. Commit your changes and push your branch to GitHub:
 
 ```bash
 git add .
@@ -122,7 +126,7 @@ git commit -m "Your detailed description of your changes."
 git push origin name-of-your-bugfix-or-feature
 ```
 
-11. Submit a pull request through the GitHub website.
+10. Submit a pull request through the GitHub website.
 
 # Pull Request Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,28 @@ install: ## Install the virtual environment and install the pre-commit hooks
 	@uv run pre-commit install
 
 .PHONY: check
-check: ## Run code quality tools.
-	@echo "🚀 Checking lock file consistency with 'pyproject.toml'"
+check: ## Run Python, Rust, and TypeScript checks.
+	@echo "🚀 Checking Python lock file consistency with 'pyproject.toml'"
 	@uv lock --locked
-	@echo "🚀 Linting code: Running pre-commit"
+	@echo "🚀 Running Python pre-commit checks"
 	@uv run pre-commit run -a
-	@echo "🚀 Static type checking: Running ty"
+	@echo "🚀 Static type checking Python: Running ty"
 	@uv run ty check
-	@echo "🚀 Checking for obsolete dependencies: Running deptry"
+	@echo "🚀 Checking Python dependencies: Running deptry"
 	@uv run deptry .
+	@echo "🚀 Checking Rust core"
+	@cargo check -p mcp-compressor-core --features python,node
+	@echo "🚀 Checking TypeScript package"
+	@cd typescript && bun run check:ci
 
 .PHONY: test
-test: ## Test the code with pytest
-	@echo "🚀 Testing code: Running pytest"
+test: ## Test Python, Rust, and TypeScript packages
+	@echo "🚀 Testing Python package"
 	@uv run python -m pytest --doctest-modules
+	@echo "🚀 Testing Rust core"
+	@cargo test -p mcp-compressor-core
+	@echo "🚀 Testing TypeScript package"
+	@cd typescript && bun run test
 
 .PHONY: build
 build: clean-build ## Build wheel file

--- a/THIRD_PARTY_NOTICE.md
+++ b/THIRD_PARTY_NOTICE.md
@@ -1,68 +1,69 @@
-# Notice of included third-party dependencies
+# Third-party notices
 
-mcp-compressor depends on the open source code described below. Each listed dependency may also have additional
-third-party, open source dependencies.
+mcp-compressor is a multi-language project made up of:
 
----
+- a Python package published as `mcp-compressor`
+- a TypeScript package published as `@atlassian/mcp-compressor`
+- a shared Rust core crate in `crates/mcp-compressor-core`
 
-**loguru (https://github.com/Delgan/loguru)**
+This notice summarizes the direct third-party dependencies used by those package surfaces. Each dependency may include additional transitive dependencies with their own license terms; consult the relevant lockfiles (`uv.lock`, `typescript/bun.lock`, and `Cargo.lock`) for the complete resolved dependency graph used for builds.
 
-Copyright © 2017 Delgan (Github user)
+The mcp-compressor source code is licensed under the repository `LICENSE` file.
 
-License: MIT
+## Python package direct dependencies
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Declared in `pyproject.toml`:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+- `anyio`
+- `cryptography`
+- `keyring`
+- `py-key-value-aio`
+- `fastmcp`
+- `loguru`
+- `loguru-logging-intercept`
+- `mcp`
+- `pydantic`
+- `psutil`
+- `starlette`
+- `toons`
+- `typer`
+- `uvicorn`
+- `click`
+- `just-bash`
+- `httpx`
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+## TypeScript package direct dependencies
 
----
+Declared in `typescript/package.json`:
 
-**fastmcp (GitHub - PrefectHQ/fastmcp: 🚀 The fast, Pythonic way to build MCP servers and clients.)**
+- `@modelcontextprotocol/sdk`
+- `@toon-format/toon`
+- `commander`
+- `fastmcp`
+- `zod`
+- `just-bash` (optional peer dependency)
 
-Copyright © 2025 Jeremiah Lowin
+## Rust core direct dependencies
 
-License: Apache 2.0 (Apache License, Version 2.0 | Apache Software Foundation )
+Declared in `crates/mcp-compressor-core/Cargo.toml`:
 
----
+- `serde`
+- `serde_json`
+- `thiserror`
+- `rand`
+- `tokio`
+- `rmcp`
+- `axum`
+- `async-trait`
+- `dirs`
+- `reqwest`
+- `clap`
+- `open`
+- `toon-format`
+- `pyo3` (optional Python binding feature)
+- `napi` (optional Node.js binding feature)
+- `napi-derive` (optional Node.js binding feature)
 
-**loguru-logging-intercept (https://github.com/MatthewScholefield/loguru-logging-intercept)**
+## Development and documentation tooling
 
-Copyright © 2021 Matthew D. Scholefield
-
-License: MIT
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-**mcp (https://github.com/modelcontextprotocol/python-sdk)**
-
-Copyright © 2024 Anthropic, PBC
-
-License: MIT
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-**typer (https://github.com/fastapi/typer)**
-
-Copyright © 2019 Sebastián Ramírez
-
-License: MIT
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The repository also uses third-party development tools for tests, linting, formatting, documentation, and packaging. These are declared in the package manager manifests and lockfiles for each ecosystem.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ packages = ["mcp_compressor"]
 
 [tool.ty.environment]
 python = "./.venv"
-python-version = "3.10"
+python-version = "3.11"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 skipsdist = true
-envlist = py310, py311, py312, py313, py314
+envlist = py311, py312, py313, py314
 
 [gh-actions]
 python =
-    3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313


### PR DESCRIPTION
## Summary
- rewrite THIRD_PARTY_NOTICE.md for the current Python, TypeScript, and Rust package surfaces
- update CONTRIBUTING.md setup and testing guidance for uv, Cargo, and Bun workflows
- broaden Makefile check/test targets to include Rust core and TypeScript package checks
- align Python tooling metadata with the supported >=3.11 range
- ignore generated TypeScript native build output

## Testing
- git diff --check
- git check-ignore for generated TypeScript native outputs