### PR TITLE
docs: update third-party dependency notice

### DIFF
--- a/THIRD_PARTY_NOTICE.md
+++ b/THIRD_PARTY_NOTICE.md
@@ -1,13 +1,15 @@
 # Notice of included third-party dependencies
 
 mcp-compressor depends on the open source code described below. Each listed dependency may also have additional
-third-party, open source dependencies.
+third-party, open source dependencies. This notice lists key direct dependencies across the Python, TypeScript,
+and Rust package surfaces; consult `uv.lock`, `typescript/bun.lock`, and `Cargo.lock` for the complete resolved
+transitive dependency graph used for a specific build.
 
 ---
 
-**loguru (https://github.com/Delgan/loguru)**
+**rmcp (https://github.com/modelcontextprotocol/rust-sdk)**
 
-Copyright © 2017 Delgan (Github user)
+Copyright © Model Context Protocol contributors
 
 License: MIT
 
@@ -19,50 +21,156 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---
 
-**fastmcp (GitHub - PrefectHQ/fastmcp: 🚀 The fast, Pythonic way to build MCP servers and clients.)**
+**tokio (https://github.com/tokio-rs/tokio)**
+
+Copyright © Tokio contributors
+
+License: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+**serde and serde_json (https://github.com/serde-rs/serde)**
+
+Copyright © Serde contributors
+
+License: MIT OR Apache-2.0
+
+---
+
+**axum (https://github.com/tokio-rs/axum)**
+
+Copyright © axum contributors
+
+License: MIT
+
+---
+
+**reqwest (https://github.com/seanmonstar/reqwest)**
+
+Copyright © reqwest contributors
+
+License: MIT OR Apache-2.0
+
+---
+
+**clap (https://github.com/clap-rs/clap)**
+
+Copyright © clap contributors
+
+License: MIT OR Apache-2.0
+
+---
+
+**toon-format (https://github.com/toon-format/toon)**
+
+Copyright © TOON format contributors
+
+License: MIT
+
+---
+
+**PyO3 (https://github.com/PyO3/pyo3)**
+
+Copyright © PyO3 contributors
+
+License: MIT OR Apache-2.0
+
+---
+
+**napi-rs (https://github.com/napi-rs/napi-rs)**
+
+Copyright © napi-rs contributors
+
+License: MIT
+
+---
+
+**maturin (https://github.com/PyO3/maturin)**
+
+Copyright © maturin contributors
+
+License: MIT OR Apache-2.0
+
+---
+
+**commander (https://github.com/tj/commander.js)**
+
+Copyright © TJ Holowaychuk and commander contributors
+
+License: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+**just-bash (https://www.npmjs.com/package/just-bash)**
+
+Copyright © just-bash contributors
+
+License: MIT
+
+---
+
+**zod (https://github.com/colinhacks/zod)**
+
+Copyright © Colin McDonnell and Zod contributors
+
+License: MIT
+
+---
+
+**typescript (https://github.com/microsoft/TypeScript)**
+
+Copyright © Microsoft Corporation
+
+License: Apache-2.0
+
+---
+
+**vitest (https://github.com/vitest-dev/vitest)**
+
+Copyright © Vitest contributors
+
+License: MIT
+
+---
+
+**pytest (https://github.com/pytest-dev/pytest)**
+
+Copyright © pytest contributors
+
+License: MIT
+
+---
+
+**ruff (https://github.com/astral-sh/ruff)**
+
+Copyright © Astral Software Inc. and Ruff contributors
+
+License: MIT
+
+---
+
+**ty (https://github.com/astral-sh/ty)**
+
+Copyright © Astral Software Inc. and ty contributors
+
+License: MIT
+
+---
+
+**fastmcp (https://github.com/jlowin/fastmcp)**
 
 Copyright © 2025 Jeremiah Lowin
 
-License: Apache 2.0 (Apache License, Version 2.0 | Apache Software Foundation )
-
----
-
-**loguru-logging-intercept (https://github.com/MatthewScholefield/loguru-logging-intercept)**
-
-Copyright © 2021 Matthew D. Scholefield
-
-License: MIT
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-**mcp (https://github.com/modelcontextprotocol/python-sdk)**
-
-Copyright © 2024 Anthropic, PBC
-
-License: MIT
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-**typer (https://github.com/fastapi/typer)**
-
-Copyright © 2019 Sebastián Ramírez
-
-License: MIT
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+License: Apache-2.0


### PR DESCRIPTION
## Summary
- rewrite THIRD_PARTY_NOTICE.md in the existing dependency-notice format
- include key direct dependencies across Rust, Python, and TypeScript package surfaces
- point readers to Cargo.lock, uv.lock, and typescript/bun.lock for full transitive dependency graphs

## Validation
- make docs-test
- make check
- git diff --check
