### PR TITLE
feat: compress local typescript tools

### DIFF
--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -143,6 +143,37 @@ Applications often need framework-ready callable tool objects rather than direct
 
 The executable tool shape is intentionally simple: name, description, input schema, and an execute function.
 
+## Compress local TypeScript tools
+
+For TypeScript applications that already have in-process tools, such as AI SDK tools, you can compress those tools without starting an MCP server or proxy. This returns the same `ExecutableTool` shape used by the rest of the TypeScript SDK.
+
+=== "TypeScript"
+
+    ```ts
+    import { compressTools, toAISDKTools } from "@atlassian/mcp-compressor";
+    import { tool } from "ai";
+
+    const rawTools = {
+      weather: {
+        description: "Get weather for a city.",
+        inputSchema: {
+          type: "object",
+          properties: { city: { type: "string" } },
+          required: ["city"],
+        },
+        execute: async ({ city }: { city: string }) => ({ city, temperature: 72 }),
+      },
+    };
+
+    const compressed = compressTools(rawTools, {
+      compressionLevel: "medium",
+    });
+
+    const aiTools = toAISDKTools(compressed, { tool });
+    ```
+
+    If your framework uses a non-JSON-schema object, pass `schemaAdapter` to convert it before compression.
+
 ## Compression options
 
 The SDKs expose the same main compression options as the CLI.

--- a/typescript/src/adapters.ts
+++ b/typescript/src/adapters.ts
@@ -1,8 +1,8 @@
-export interface ExecutableTool {
+export interface ExecutableTool<TResult = string> {
   name: string;
   description?: string;
   inputSchema: Record<string, unknown>;
-  execute(input?: Record<string, unknown>): Promise<string>;
+  execute(input?: Record<string, unknown>): Promise<TResult>;
 }
 
 export interface AISDKToolFactory<TTool = unknown> {
@@ -14,10 +14,10 @@ export interface AISDKToolFactory<TTool = unknown> {
 }
 
 export function toAISDKTools<TTool = unknown>(
-  tools: Record<string, ExecutableTool>,
+  tools: Record<string, ExecutableTool<string>>,
   options: { tool?: AISDKToolFactory<TTool> } = {},
-): Record<string, TTool | Omit<ExecutableTool, "name">> {
-  const result: Record<string, TTool | Omit<ExecutableTool, "name">> = {};
+): Record<string, TTool | Omit<ExecutableTool<string>, "name">> {
+  const result: Record<string, TTool | Omit<ExecutableTool<string>, "name">> = {};
   for (const [name, executable] of Object.entries(tools)) {
     const definition = {
       description: executable.description,
@@ -30,9 +30,9 @@ export function toAISDKTools<TTool = unknown>(
 }
 
 export function toMastraTools(
-  tools: Record<string, ExecutableTool>,
-): Record<string, Omit<ExecutableTool, "name">> {
-  const result: Record<string, Omit<ExecutableTool, "name">> = {};
+  tools: Record<string, ExecutableTool<string>>,
+): Record<string, Omit<ExecutableTool<string>, "name">> {
+  const result: Record<string, Omit<ExecutableTool<string>, "name">> = {};
   for (const [name, executable] of Object.entries(tools)) {
     result[name] = {
       description: executable.description,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -3,6 +3,7 @@ export * from "./errors.js";
 export * from "./rust_core.js";
 export * from "./just_bash_host.js";
 export * from "./adapters.js";
+export * from "./local_tools.js";
 export {
   interpolateString,
   interpolateRecord,

--- a/typescript/src/local_tools.ts
+++ b/typescript/src/local_tools.ts
@@ -1,0 +1,109 @@
+import { compressToolListing, formatToolSchemaResponse, type ToolSpec } from "./rust_core.js";
+import type { CompressionLevel } from "./types.js";
+import type { ExecutableTool } from "./adapters.js";
+
+export interface LocalTool<TInput = Record<string, unknown>, TResult = unknown> {
+  description?: string;
+  inputSchema: unknown;
+  execute: (input: TInput) => TResult | Promise<TResult>;
+}
+
+export interface CompressToolsOptions {
+  compressionLevel?: CompressionLevel;
+  namePrefix?: string;
+  toonify?: boolean;
+  schemaAdapter?: (schema: unknown) => Record<string, unknown>;
+}
+
+function wrapperName(prefix: string | undefined, name: string): string {
+  return prefix ? `${prefix}_${name}` : name;
+}
+
+function asJsonSchema(
+  schema: unknown,
+  adapter: ((schema: unknown) => Record<string, unknown>) | undefined,
+): Record<string, unknown> {
+  if (schema && typeof schema === "object" && !Array.isArray(schema)) {
+    return schema as Record<string, unknown>;
+  }
+  if (adapter) {
+    return adapter(schema);
+  }
+  throw new Error(
+    "Tool inputSchema must be a JSON schema object or schemaAdapter must be provided",
+  );
+}
+
+function normalizeResult(value: unknown, toonify: boolean): string {
+  if (typeof value === "string") return value;
+  const json = JSON.stringify(value);
+  if (!toonify) return json;
+  // Keep local compression dependency-light for now. Runtime MCP proxy paths use
+  // Rust TOON support; local in-process tools return JSON-compatible strings.
+  return json;
+}
+
+export function compressTools(
+  tools: Record<string, LocalTool>,
+  options: CompressToolsOptions = {},
+): Record<string, ExecutableTool> {
+  const compressionLevel = options.compressionLevel ?? "medium";
+  const specs: ToolSpec[] = Object.entries(tools).map(([name, tool]) => ({
+    name,
+    description: tool.description,
+    inputSchema: asJsonSchema(tool.inputSchema, options.schemaAdapter),
+  }));
+  const specByName = new Map(specs.map((spec) => [spec.name, spec]));
+  const toolByName = new Map(Object.entries(tools));
+  const listing = compressToolListing(compressionLevel, specs);
+  const result: Record<string, ExecutableTool> = {};
+
+  if (compressionLevel === "max") {
+    result[wrapperName(options.namePrefix, "list_tools")] = {
+      name: wrapperName(options.namePrefix, "list_tools"),
+      description: "List backend tools available through this compressed toolset.",
+      inputSchema: { type: "object", properties: {} },
+      execute: async () => listing,
+    };
+  }
+
+  result[wrapperName(options.namePrefix, "get_tool_schema")] = {
+    name: wrapperName(options.namePrefix, "get_tool_schema"),
+    description: `Get the complete schema and description for one tool. Available tools:\n${listing}`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        tool_name: { type: "string", description: "Name of the tool" },
+      },
+      required: ["tool_name"],
+    },
+    execute: async (input = {}) => {
+      const toolName = String(input.tool_name ?? "");
+      const spec = specByName.get(toolName);
+      if (!spec) throw new Error(`Tool not found: ${toolName}`);
+      return formatToolSchemaResponse(spec);
+    },
+  };
+
+  result[wrapperName(options.namePrefix, "invoke_tool")] = {
+    name: wrapperName(options.namePrefix, "invoke_tool"),
+    description: "Invoke one tool by name with JSON input.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tool_name: { type: "string", description: "Name of the tool" },
+        tool_input: { type: "object", description: "JSON input for the tool" },
+      },
+      required: ["tool_name", "tool_input"],
+    },
+    execute: async (input = {}) => {
+      const toolName = String(input.tool_name ?? "");
+      const tool = toolByName.get(toolName);
+      if (!tool) throw new Error(`Tool not found: ${toolName}`);
+      const output = await tool.execute((input.tool_input ?? {}) as never);
+      return normalizeResult(output, options.toonify ?? false);
+    },
+  };
+
+  return result;
+}

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   CompressorClient,
+  compressTools,
   installJustBashCommands,
   interpolateRecord,
   interpolateString,
@@ -370,6 +371,100 @@ describe("Public TypeScript SDK workflow", () => {
       proxy.close();
       client.close();
     }
+  });
+});
+
+describe("local TypeScript tool compression", () => {
+  it("compresses local tools into schema and invoke wrappers", async () => {
+    const tools = compressTools(
+      {
+        weather: {
+          description: "Get weather for a city.\n\nIncludes current temperature.",
+          inputSchema: {
+            type: "object",
+            properties: { city: { type: "string" } },
+            required: ["city"],
+          },
+          execute: async (input) => ({ city: String(input.city), temperature: 72 }),
+        },
+      },
+      { compressionLevel: "medium" },
+    );
+
+    expect(Object.keys(tools).sort()).toEqual(["get_tool_schema", "invoke_tool"]);
+    expect(tools.get_tool_schema?.description).toContain("weather(city)");
+    expect(tools.get_tool_schema?.description).toContain("Get weather for a city");
+    expect(tools.get_tool_schema?.description).not.toContain("Includes current temperature.");
+
+    await expect(tools.get_tool_schema?.execute({ tool_name: "weather" })).resolves.toContain(
+      "temperature",
+    );
+    await expect(
+      tools.invoke_tool?.execute({ tool_name: "weather", tool_input: { city: "Sydney" } }),
+    ).resolves.toBe('{"city":"Sydney","temperature":72}');
+  });
+
+  it("supports max compression, prefixes, and AI SDK adapters", async () => {
+    const tools = compressTools(
+      {
+        echo: {
+          description: "Echo a message.",
+          inputSchema: {
+            type: "object",
+            properties: { message: { type: "string" } },
+            required: ["message"],
+          },
+          execute: (input) => `echo:${String(input.message)}`,
+        },
+      },
+      { compressionLevel: "max", namePrefix: "local" },
+    );
+
+    expect(Object.keys(tools).sort()).toEqual([
+      "local_get_tool_schema",
+      "local_invoke_tool",
+      "local_list_tools",
+    ]);
+    await expect(tools.local_list_tools?.execute()).resolves.toBe("");
+    await expect(
+      tools.local_invoke_tool?.execute({ tool_name: "echo", tool_input: { message: "hi" } }),
+    ).resolves.toBe("echo:hi");
+
+    const aiTools = toAISDKTools(tools, { tool: (definition) => ({ ...definition, ai: true }) });
+    expect(aiTools.local_invoke_tool).toMatchObject({ ai: true });
+  });
+
+  it("accepts schema adapters for non-JSON schema objects", async () => {
+    const tools = compressTools(
+      {
+        adapted: {
+          description: "Adapted schema tool.",
+          inputSchema: "schema-token",
+          execute: (input) => String(input.value),
+        },
+      },
+      {
+        schemaAdapter: () => ({
+          type: "object",
+          properties: { value: { type: "string" } },
+          required: ["value"],
+        }),
+      },
+    );
+
+    await expect(
+      tools.invoke_tool?.execute({ tool_name: "adapted", tool_input: { value: "ok" } }),
+    ).resolves.toBe("ok");
+  });
+
+  it("reports missing tools clearly", async () => {
+    const tools = compressTools({});
+    await expect(tools.get_tool_schema?.execute({ tool_name: "missing" })).rejects.toThrow(
+      "Tool not found: missing",
+    );
+    await expect(
+      tools.invoke_tool?.execute({ tool_name: "missing", tool_input: {} }),
+    ).rejects.toThrow("Tool not found: missing");
   });
 });
 


### PR DESCRIPTION
## Summary
- add compressTools for in-process TypeScript tool compression
- return compressed get_tool_schema/invoke_tool/list_tools wrappers without starting an MCP server or proxy
- support optional prefixes, compression levels, and schema adapters
- keep AI SDK and Mastra adapters working with compressed local tools
- document local TypeScript tool compression for AI SDK-style tools

## Validation
- cd typescript && bun run format
- cd typescript && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "local TypeScript tool compression"
- cd typescript && bun run typecheck && bun run lint && bun run format:check
- make docs-test
- make check
