### PR TITLE
Fix CodeQL cutover findings

### DIFF
--- a/.github/workflows/atlassian-mcp-integration.yml
+++ b/.github/workflows/atlassian-mcp-integration.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   atlassian-mcp-real-world:
     name: atlassian-mcp-real-world

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -15,6 +15,9 @@ on:
     branches:
       - rust-core-migration-trunk
 
+permissions:
+  contents: read
+
 jobs:
   rust-cli-binary:
     name: Rust CLI binary (${{ matrix.os }})

--- a/crates/mcp-compressor-core/src/sdk.rs
+++ b/crates/mcp-compressor-core/src/sdk.rs
@@ -336,9 +336,14 @@ impl CompressorProxy {
     }
 
     async fn invoke_wrapper_tool(&self, wrapper: &str, input: Value) -> Result<String, Error> {
+        let exec_url = self.proxy.exec_url();
+        ensure_loopback_proxy_url(&exec_url)?;
         let client = reqwest::Client::new();
         let response = client
-            .post(self.proxy.exec_url())
+            // codeql[rust/cleartext-transmission]
+            // This session token is sent only to the local loopback proxy after
+            // ensure_loopback_proxy_url rejects non-loopback and non-http URLs.
+            .post(exec_url)
             .header("Authorization", format!("Bearer {}", self.token()))
             .json(&json!({
                 "tool": wrapper,
@@ -452,6 +457,29 @@ impl CompressorProxy {
     }
 }
 
+fn ensure_loopback_proxy_url(url: &str) -> Result<(), Error> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|error| Error::Config(format!("invalid proxy URL {url:?}: {error}")))?;
+    if parsed.scheme() != "http" {
+        return Err(Error::Config(format!(
+            "refusing to send proxy session token to non-http URL: {url}"
+        )));
+    }
+    let Some(host) = parsed.host_str() else {
+        return Err(Error::Config(format!("proxy URL has no host: {url}")));
+    };
+    let is_loopback_ip = host
+        .parse::<std::net::IpAddr>()
+        .map(|addr| addr.is_loopback())
+        .unwrap_or(false);
+    if host != "localhost" && !is_loopback_ip {
+        return Err(Error::Config(format!(
+            "refusing to send proxy session token to non-loopback URL: {url}"
+        )));
+    }
+    Ok(())
+}
+
 #[async_trait]
 pub trait ExecutableTool: Send + Sync {
     fn name(&self) -> &str;
@@ -544,6 +572,14 @@ mod tests {
             }
             FfiSdkServerConfig::CommandOrUrl(_) => panic!("expected structured config"),
         }
+    }
+
+    #[test]
+    fn loopback_proxy_url_guard_allows_only_local_http_urls() {
+        assert!(ensure_loopback_proxy_url("http://127.0.0.1:1234/exec").is_ok());
+        assert!(ensure_loopback_proxy_url("http://localhost:1234/exec").is_ok());
+        assert!(ensure_loopback_proxy_url("https://127.0.0.1:1234/exec").is_err());
+        assert!(ensure_loopback_proxy_url("http://example.com:1234/exec").is_err());
     }
 
     #[test]

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -120,6 +120,8 @@ pub fn clear_oauth_credentials_json(target: Option<String>) -> napi::Result<Stri
 }
 
 #[napi]
+// codeql[cpp/access-invalid-pointer]: This exported napi class contains only Rust-owned fields.
+// napi-rs generates the JS wrapper; this line does not dereference raw pointers.
 pub struct NativeCompressedSession {
     inner: FfiCompressedSession,
     auth_header_stores: Vec<HeaderStore>,


### PR DESCRIPTION
## Summary
- add explicit read-only permissions to CI workflows flagged by CodeQL
- guard SDK proxy token forwarding so session bearer tokens are only sent to local loopback HTTP proxy URLs
- document/suppress a napi-rs false positive where CodeQL flags the exported session class despite only Rust-owned fields being stored

## Validation
- PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core sdk::tests:: -- --nocapture
- cargo check -p mcp-compressor-node
- make check