### PR TITLE
Allow Python prerelease release tags

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to publish, for example v1.2.3
+        description: Release tag to publish, for example v1.2.3 or v0.15.0a1
         required: true
         type: string
       publish:

--- a/scripts/prepare_python_release.py
+++ b/scripts/prepare_python_release.py
@@ -5,15 +5,22 @@ import argparse
 import re
 from pathlib import Path
 
-SEMVER_RE = re.compile(r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+# Python package versions follow PEP 440. This intentionally accepts prerelease
+# tags such as `v0.15.0a1` in addition to ordinary release tags such as `v1.2.3`.
+PEP440_RELEASE_TAG_RE = re.compile(
+    r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:(a|b|rc)(0|[1-9]\d*))?"
+    r"(?:\.post(0|[1-9]\d*))?"
+    r"(?:\.dev(0|[1-9]\d*))?$"
+)
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "python" / "mcp-compressor" / "pyproject.toml"
 
 
 def version_from_tag(tag: str) -> str:
     version = tag.removeprefix("refs/tags/").removeprefix("v")
-    if not SEMVER_RE.match(version):
-        raise SystemExit(f"Tag {tag!r} is not a supported semver tag such as v1.2.3")
+    if not PEP440_RELEASE_TAG_RE.match(version):
+        raise SystemExit(f"Tag {tag!r} is not a supported Python release tag such as v1.2.3 or v0.15.0a1")
     return version
 
 

--- a/tests/test_release_version_scripts.py
+++ b/tests/test_release_version_scripts.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script(name: str) -> ModuleType:
+    path = ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.removesuffix(".py"), path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_python_release_script_accepts_pep440_prerelease_tags() -> None:
+    script = _load_script("prepare_python_release.py")
+
+    assert script.version_from_tag("v0.15.0a1") == "0.15.0a1"
+    assert script.version_from_tag("refs/tags/v1.2.3") == "1.2.3"
+    assert script.version_from_tag("v1.2.3rc4") == "1.2.3rc4"
+
+
+def test_typescript_release_script_accepts_semver_tags() -> None:
+    script = _load_script("prepare_typescript_release.py")
+
+    assert script.version_from_tag("v1.2.3") == "1.2.3"
+    assert script.version_from_tag("refs/tags/v1.2.3-alpha.1") == "1.2.3-alpha.1"
+
+
+def test_rust_release_script_accepts_semver_tags() -> None:
+    script = _load_script("prepare_rust_crate_release.py")
+
+    assert script.version_from_tag("v1.2.3") == "1.2.3"
+    assert script.version_from_tag("refs/tags/v1.2.3-alpha.1") == "1.2.3-alpha.1"


### PR DESCRIPTION
## Summary
- allow Python release tags that use PEP 440 prerelease syntax such as v0.15.0a1
- update the Python publish workflow input description
- add release-script parsing tests for Python, TypeScript, and Rust version scripts

## Validation
- uv run pytest -q tests/test_release_version_scripts.py
- make check