### PR TITLE
Convert Python prerelease tags for Rust and TypeScript releases

### DIFF
--- a/scripts/prepare_rust_crate_release.py
+++ b/scripts/prepare_rust_crate_release.py
@@ -14,6 +14,9 @@ import re
 from pathlib import Path
 
 SEMVER_RE = re.compile(r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+PEP440_PRERELEASE_RE = re.compile(
+    r"^(?P<base>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))(?P<kind>a|b|rc)(?P<num>0|[1-9]\d*)$"
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_MANIFEST = ROOT / "crates" / "mcp-compressor" / "Cargo.toml"
@@ -24,9 +27,14 @@ LOCKFILE = ROOT / "Cargo.lock"
 def version_from_tag(tag: str) -> str:
     version = tag.removeprefix("refs/tags/")
     version = version.removeprefix("v")
-    if not SEMVER_RE.match(version):
-        raise SystemExit(f"Tag {tag!r} is not a supported semver tag such as v1.2.3")
-    return version
+    if SEMVER_RE.match(version):
+        return version
+    if match := PEP440_PRERELEASE_RE.match(version):
+        prerelease = {"a": "alpha", "b": "beta", "rc": "rc"}[match.group("kind")]
+        return f"{match.group('base')}-{prerelease}.{match.group('num')}"
+    raise SystemExit(
+        f"Tag {tag!r} is not a supported SemVer tag such as v1.2.3 or Python prerelease tag such as v0.15.0a2"
+    )
 
 
 def replace_regex_once(path: Path, pattern: str, replacement: str) -> None:

--- a/scripts/prepare_typescript_release.py
+++ b/scripts/prepare_typescript_release.py
@@ -7,15 +7,23 @@ import re
 from pathlib import Path
 
 SEMVER_RE = re.compile(r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+PEP440_PRERELEASE_RE = re.compile(
+    r"^(?P<base>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))(?P<kind>a|b|rc)(?P<num>0|[1-9]\d*)$"
+)
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_JSON = ROOT / "typescript" / "package.json"
 
 
 def version_from_tag(tag: str) -> str:
     version = tag.removeprefix("refs/tags/").removeprefix("v")
-    if not SEMVER_RE.match(version):
-        raise SystemExit(f"Tag {tag!r} is not a supported semver tag such as v1.2.3")
-    return version
+    if SEMVER_RE.match(version):
+        return version
+    if match := PEP440_PRERELEASE_RE.match(version):
+        prerelease = {"a": "alpha", "b": "beta", "rc": "rc"}[match.group("kind")]
+        return f"{match.group('base')}-{prerelease}.{match.group('num')}"
+    raise SystemExit(
+        f"Tag {tag!r} is not a supported SemVer tag such as v1.2.3 or Python prerelease tag such as v0.15.0a2"
+    )
 
 
 def main() -> None:

--- a/tests/test_release_version_scripts.py
+++ b/tests/test_release_version_scripts.py
@@ -30,6 +30,9 @@ def test_typescript_release_script_accepts_semver_tags() -> None:
 
     assert script.version_from_tag("v1.2.3") == "1.2.3"
     assert script.version_from_tag("refs/tags/v1.2.3-alpha.1") == "1.2.3-alpha.1"
+    assert script.version_from_tag("v0.15.0a2") == "0.15.0-alpha.2"
+    assert script.version_from_tag("v0.15.0b3") == "0.15.0-beta.3"
+    assert script.version_from_tag("v0.15.0rc4") == "0.15.0-rc.4"
 
 
 def test_rust_release_script_accepts_semver_tags() -> None:
@@ -37,3 +40,6 @@ def test_rust_release_script_accepts_semver_tags() -> None:
 
     assert script.version_from_tag("v1.2.3") == "1.2.3"
     assert script.version_from_tag("refs/tags/v1.2.3-alpha.1") == "1.2.3-alpha.1"
+    assert script.version_from_tag("v0.15.0a2") == "0.15.0-alpha.2"
+    assert script.version_from_tag("v0.15.0b3") == "0.15.0-beta.3"
+    assert script.version_from_tag("v0.15.0rc4") == "0.15.0-rc.4"


### PR DESCRIPTION
## Summary
- allow Rust and TypeScript release scripts to accept Python-style prerelease tags like v0.15.0a2
- convert those tags to SemVer-compatible versions like 0.15.0-alpha.2 for Cargo and npm
- add release-script tests covering Python, TypeScript, and Rust tag handling

## Validation
- uv run pytest -q tests/test_release_version_scripts.py
- make check