### PR TITLE
Tag TypeScript prerelease publishes

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -125,8 +125,10 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name || inputs.tag }}"
           VERSION="$(python scripts/prepare_typescript_release.py "$TAG")"
+          DIST_TAG="$(python scripts/prepare_typescript_release.py "$TAG" --print-npm-dist-tag)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Publishing TypeScript package at version $VERSION"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing TypeScript package at version $VERSION with npm tag $DIST_TAG"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -186,7 +188,7 @@ jobs:
 
       - name: Publish to Artifactory npm-public
         if: github.event_name == 'release' || inputs.publish == true
-        run: npm publish /tmp/mcp-compressor-typescript-package.tgz --access public --userconfig "${{ github.workspace }}/.npmrc-public"
+        run: npm publish /tmp/mcp-compressor-typescript-package.tgz --access public --tag "${{ steps.version.outputs.dist_tag }}" --userconfig "${{ github.workspace }}/.npmrc-public"
 
   publish-rust-crate:
     name: Publish Rust crates

--- a/scripts/prepare_typescript_release.py
+++ b/scripts/prepare_typescript_release.py
@@ -26,11 +26,19 @@ def version_from_tag(tag: str) -> str:
     )
 
 
+def npm_dist_tag_for_version(version: str) -> str:
+    return "next" if "-" in version else "latest"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("tag")
+    parser.add_argument("--print-npm-dist-tag", action="store_true")
     args = parser.parse_args()
     version = version_from_tag(args.tag)
+    if args.print_npm_dist_tag:
+        print(npm_dist_tag_for_version(version))
+        return
     data = json.loads(PACKAGE_JSON.read_text())
     data["version"] = version
     PACKAGE_JSON.write_text(json.dumps(data, indent=2) + "\n")

--- a/tests/test_release_version_scripts.py
+++ b/tests/test_release_version_scripts.py
@@ -33,6 +33,8 @@ def test_typescript_release_script_accepts_semver_tags() -> None:
     assert script.version_from_tag("v0.15.0a2") == "0.15.0-alpha.2"
     assert script.version_from_tag("v0.15.0b3") == "0.15.0-beta.3"
     assert script.version_from_tag("v0.15.0rc4") == "0.15.0-rc.4"
+    assert script.npm_dist_tag_for_version("1.2.3") == "latest"
+    assert script.npm_dist_tag_for_version("1.2.3-alpha.1") == "next"
 
 
 def test_rust_release_script_accepts_semver_tags() -> None:


### PR DESCRIPTION
## Summary
- compute npm dist-tag from the TypeScript package version during release publishing
- publish prerelease versions with --tag next and stable versions with --tag latest
- add release script tests for npm dist-tag selection

## Validation
- YAML parse for .github/workflows/on-release-main.yml
- uv run pytest -q tests/test_release_version_scripts.py
- make check