### PR TITLE
Use Artifactory npm-public registry

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -184,7 +184,7 @@ jobs:
         if: github.event_name == 'release' || inputs.publish == true
         working-directory: .
         run: |
-          printf '\n@atlassian:registry=https://packages.atlassian.com/api/npm/npm-public/\n' >> "${{ github.workspace }}/.npmrc-public"
+          printf '\n@atlassian:registry=https://packages.atlassian.com/artifactory/api/npm/npm-public/\n' >> "${{ github.workspace }}/.npmrc-public"
 
       - name: Publish to Artifactory npm-public
         if: github.event_name == 'release' || inputs.publish == true

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -180,12 +180,6 @@ jobs:
         with:
           output-modes: npm
 
-      - name: Set publish registry
-        if: github.event_name == 'release' || inputs.publish == true
-        working-directory: .
-        run: |
-          printf '\n@atlassian:registry=https://packages.atlassian.com/artifactory/api/npm/npm-public/\n' >> "${{ github.workspace }}/.npmrc-public"
-
       - name: Publish to Artifactory npm-public
         if: github.event_name == 'release' || inputs.publish == true
         run: npm publish /tmp/mcp-compressor-typescript-package.tgz --access public --tag "${{ steps.version.outputs.dist_tag }}" --userconfig "${{ github.workspace }}/.npmrc-public"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -65,7 +65,7 @@
     "check:ci": "bun run lint && bun run format:check && bun run typecheck && vitest run --exclude tests/e2e.test.ts"
   },
   "publishConfig": {
-    "registry": "https://packages.atlassian.com/api/npm/npm-public/"
+    "registry": "https://packages.atlassian.com/artifactory/api/npm/npm-public/"
   },
   "dependencies": {
     "commander": "^14.0.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -65,7 +65,7 @@
     "check:ci": "bun run lint && bun run format:check && bun run typecheck && vitest run --exclude tests/e2e.test.ts"
   },
   "publishConfig": {
-    "registry": "https://packages.atlassian.com/artifactory/api/npm/npm-public/"
+    "registry": "https://packages.atlassian.com/api/npm/npm-public/"
   },
   "dependencies": {
     "commander": "^14.0.3",


### PR DESCRIPTION
## Summary
- update TypeScript publishConfig and release workflow npmrc to use the documented Artifactory npm-public endpoint: https://packages.atlassian.com/artifactory/api/npm/npm-public/
- this matches internal publishing guidance and the successful publish log format

## Validation
- YAML parse for .github/workflows/on-release-main.yml
- cd typescript && bun run typecheck
- make check

## Related internal config
The package is present in config/main.tf, but config/permissions.tf should also explicitly include @atlassian/mcp-compressor under the opensource-upload npm-public target. I do not have write access to buildeng-artifactory-configuration to push that PR.