### PR TITLE
Align npm-public publish flags

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Publish to Artifactory npm-public
         if: github.event_name == 'release' || inputs.publish == true
-        run: npm publish /tmp/mcp-compressor-typescript-package.tgz --access public --tag "${{ steps.version.outputs.dist_tag }}" --userconfig "${{ github.workspace }}/.npmrc-public"
+        run: npm publish /tmp/mcp-compressor-typescript-package.tgz --tag "${{ steps.version.outputs.dist_tag }}" --userconfig "${{ github.workspace }}/.npmrc-public"
 
   publish-rust-crate:
     name: Publish Rust crates


### PR DESCRIPTION
## Summary
- remove the npmjs-specific --access public flag from TypeScript npm-public publishing
- keep --tag for prerelease/stable dist-tags
- match atlassian/date-time-api more closely by relying on artifact-publish-token's generated .npmrc-public and package publishConfig for registry/access behavior

## Validation
- YAML parse for .github/workflows/on-release-main.yml
- make check