### PR TITLE
Add local LLM assist runtime foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +81,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -347,6 +362,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +422,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -473,10 +514,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -515,6 +576,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1051,6 +1122,8 @@ dependencies = [
  "axum",
  "clap",
  "dirs",
+ "flate2",
+ "fs2",
  "futures",
  "http",
  "libc",
@@ -1062,10 +1135,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "toon-format",
+ "zip",
 ]
 
 [[package]]
@@ -1102,6 +1177,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1906,6 +1991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2072,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2442,6 +2544,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,6 +2785,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,7 +2898,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -26,6 +26,10 @@ futures = "0.3"
 sse-stream = "0.2"
 http = "1"
 clap = { version = "4", features = ["derive"] }
+fs2 = "0.4"
+flate2 = "1"
+tar = "0.4"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 open = "5.3"
 toon-format = { version = "0.4.5", default-features = false }
 [dev-dependencies]

--- a/crates/mcp-compressor-core/src/app/entrypoint.rs
+++ b/crates/mcp-compressor-core/src/app/entrypoint.rs
@@ -2,7 +2,7 @@ use std::process::ExitCode;
 
 use clap::Parser;
 
-use crate::app::options::{CliCommand, CliOptions, MultiServerArg};
+use crate::app::options::{CliCommand, CliOptions, LlmCommand, MultiServerArg};
 use crate::app::runtime::{run_cli_mode, run_compressed_server, run_just_bash_mode};
 use crate::oauth::clear_oauth_store;
 use crate::server::{
@@ -36,7 +36,7 @@ pub fn run() -> Result<(), CliError> {
 async fn run_async(cli: CliOptions) -> Result<(), CliError> {
     cli.validate().map_err(CliError::Usage)?;
     if let Some(command) = &cli.command_kind {
-        return run_command(command);
+        return run_command(command).await;
     }
     let server = build_server(&cli).await?;
 
@@ -103,7 +103,10 @@ async fn build_server(cli: &CliOptions) -> Result<CompressedServer, CliError> {
     }
 }
 
-fn run_command(command: &CliCommand) -> Result<(), CliError> {
+async fn run_command(command: &CliCommand) -> Result<(), CliError> {
+    if let Some(llm_command) = command.llm_command() {
+        return run_llm_command(llm_command).await;
+    }
     let removed = clear_oauth_store(command.clear_oauth_target())
         .map_err(|error| CliError::Runtime(error.to_string()))?;
     if removed.is_empty() {
@@ -114,6 +117,64 @@ fn run_command(command: &CliCommand) -> Result<(), CliError> {
             removed.len(),
             if removed.len() == 1 { "y" } else { "ies" }
         );
+    }
+    Ok(())
+}
+
+async fn run_llm_command(command: &LlmCommand) -> Result<(), CliError> {
+    match command {
+        LlmCommand::Status(options) => {
+            let config = options.config(false).map_err(CliError::Usage)?;
+            let status = crate::llm_assist::install_status(&config)
+                .map_err(|error| CliError::Runtime(error.to_string()))?;
+            println!(
+                "llama-server: {}",
+                if status.llama_server_ready {
+                    "ready"
+                } else {
+                    "missing"
+                }
+            );
+            if let Some(path) = status.llama_server_path {
+                println!("llama-server path: {}", path.display());
+            }
+            println!("model: {}", status.model_ref);
+            println!(
+                "model status: {}",
+                if status.model_ready {
+                    "ready"
+                } else {
+                    "missing"
+                }
+            );
+            println!("model path: {}", status.model_path.display());
+        }
+        LlmCommand::Pull(options) => {
+            let config = options.config(true).map_err(CliError::Usage)?;
+            let prepared = crate::llm_assist::pull_llm_assets(config)
+                .await
+                .map_err(|error| CliError::Runtime(error.to_string()))?;
+            println!(
+                "llama-server ready: {}",
+                prepared.llama_server_path.display()
+            );
+            println!("model ready: {}", prepared.model_path.display());
+        }
+        LlmCommand::Remove(options) => {
+            crate::llm_assist::remove_managed_llm_assets(options.cache_dir())
+                .map_err(|error| CliError::Runtime(error.to_string()))?;
+            println!("Removed managed LLM assets from the mcp-compressor cache.");
+        }
+        LlmCommand::Test(options) => {
+            let config = options.config(true).map_err(CliError::Usage)?;
+            let assistant = crate::llm_assist::LlmAssistant::from_config(config);
+            assistant.start_background_preparation();
+            let response = assistant
+                .complete("You are a concise local utility model.", options.prompt())
+                .await
+                .map_err(|error| CliError::Runtime(error.to_string()))?;
+            println!("{response}");
+        }
     }
     Ok(())
 }

--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -1,5 +1,6 @@
-use std::path::PathBuf;
 use crate::ffi::FfiClientArtifactKind;
+use crate::llm_assist::{ModelRef, DEFAULT_MODEL_REF};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
@@ -168,13 +169,98 @@ pub enum CliCommand {
         /// Backend server name or URL to clear. If omitted, all Rust OAuth state is removed.
         target: Option<String>,
     },
+
+    /// Manage optional local LLM assistance assets.
+    Llm {
+        #[command(subcommand)]
+        command: LlmCommand,
+    },
 }
 
 impl CliCommand {
     pub fn clear_oauth_target(&self) -> Option<&str> {
         match self {
             Self::ClearOauth { target } => target.as_deref(),
+            Self::Llm { .. } => None,
         }
+    }
+
+    pub fn llm_command(&self) -> Option<&LlmCommand> {
+        match self {
+            Self::Llm { command } => Some(command),
+            Self::ClearOauth { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum LlmCommand {
+    /// Show local llama-server/model installation status.
+    Status(LlmCommandOptions),
+    /// Download/install llama-server and the configured model.
+    Pull(LlmCommandOptions),
+    /// Remove managed LLM runtime and model assets from the cache.
+    Remove(LlmCommandOptions),
+    /// Download/install assets and run a test prompt.
+    Test(LlmTestOptions),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct LlmCommandOptions {
+    /// Model reference, for example LiquidAI/LFM2.5-350M-GGUF:Q4_K_M.
+    #[arg(long = "model", default_value = DEFAULT_MODEL_REF)]
+    model: String,
+
+    /// Override mcp-compressor LLM cache directory.
+    #[arg(long = "cache-dir")]
+    cache_dir: Option<PathBuf>,
+
+    /// Explicit llama-server binary path.
+    #[arg(long = "llama-server")]
+    llama_server_path: Option<PathBuf>,
+}
+
+impl LlmCommandOptions {
+    pub fn config(
+        &self,
+        allow_download: bool,
+    ) -> Result<crate::llm_assist::LlmRuntimeConfig, String> {
+        let mut config = crate::llm_assist::LlmRuntimeConfig::local_default(allow_download)
+            .with_model(ModelRef::parse(&self.model).map_err(|error| error.to_string())?);
+        if let Some(cache_dir) = &self.cache_dir {
+            config = config.with_cache_dir(cache_dir.clone());
+        }
+        if let Some(path) = &self.llama_server_path {
+            config = config.with_llama_server_path(path.clone());
+        }
+        Ok(config)
+    }
+
+    pub fn cache_dir(&self) -> Option<PathBuf> {
+        self.cache_dir.clone()
+    }
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct LlmTestOptions {
+    #[command(flatten)]
+    options: LlmCommandOptions,
+
+    /// Prompt to send to the local model.
+    #[arg(long = "prompt", default_value = "Say hello in one short sentence.")]
+    prompt: String,
+}
+
+impl LlmTestOptions {
+    pub fn config(
+        &self,
+        allow_download: bool,
+    ) -> Result<crate::llm_assist::LlmRuntimeConfig, String> {
+        self.options.config(allow_download)
+    }
+
+    pub fn prompt(&self) -> &str {
+        &self.prompt
     }
 }
 

--- a/crates/mcp-compressor-core/src/error.rs
+++ b/crates/mcp-compressor-core/src/error.rs
@@ -26,4 +26,10 @@ pub enum Error {
 
     #[error("config error: {0}")]
     Config(String),
+
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("LLM assist error: {0}")]
+    LlmAssist(String),
 }

--- a/crates/mcp-compressor-core/src/lib.rs
+++ b/crates/mcp-compressor-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod compression;
 pub mod config;
 pub mod error;
 pub mod ffi;
+pub mod llm_assist;
 pub mod oauth;
 pub mod proxy;
 pub mod sdk;

--- a/crates/mcp-compressor-core/src/llm_assist/mod.rs
+++ b/crates/mcp-compressor-core/src/llm_assist/mod.rs
@@ -1,0 +1,1351 @@
+//! Optional local LLM assistance primitives.
+//!
+//! This module intentionally exposes a small, reusable core that can be called
+//! from different proxy paths without deciding which proxy feature owns the
+//! prompt. It provides:
+//!
+//! - model reference parsing,
+//! - lazy Hugging Face GGUF download/cache management,
+//! - a prompt-completion trait, and
+//! - an ephemeral official `llama-server` runtime for local GGUF inference.
+
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use flate2::read::GzDecoder;
+use fs2::FileExt;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::process::{Child, Command};
+use tokio::sync::{Mutex, Notify};
+
+use crate::Error;
+
+pub const DEFAULT_MODEL_REF: &str = "LiquidAI/LFM2.5-350M-GGUF:Q4_K_M";
+pub const INPUT_TOKEN_BUDGET: usize = 32_768;
+pub const OUTPUT_TOKEN_BUDGET: usize = 4_096;
+pub const DEFAULT_TEMPERATURE: f32 = 0.0;
+pub const DEFAULT_TOP_P: f32 = 1.0;
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+
+const DEFAULT_HF_REVISION: &str = "main";
+const DEFAULT_CACHE_ENV: &str = "MCP_COMPRESSOR_CACHE_DIR";
+const MODEL_MANIFEST_FILE: &str = "manifest.json";
+const RUNTIME_MANIFEST_FILE: &str = "manifest.json";
+const LLAMA_CPP_RELEASE_TAG: &str = "b9150";
+const LLAMA_CPP_RELEASE_BASE: &str = "https://github.com/ggml-org/llama.cpp/releases/download";
+const SERVER_READY_TIMEOUT: Duration = Duration::from_secs(60);
+const SERVER_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const SERVER_START_RETRIES: usize = 3;
+
+/// Reference to a GGUF model artifact.
+///
+/// The compact form is `<org>/<repo>:<quant>`, for example
+/// `LiquidAI/LFM2.5-350M-GGUF:Q4_K_M`. A specific filename can be provided as
+/// `<org>/<repo>#<filename>`. The filename form is useful for models whose GGUF
+/// filenames cannot be derived from the repository name and quantization suffix.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelRef {
+    raw: String,
+    repo_id: String,
+    quantization: Option<String>,
+    filename: String,
+    revision: String,
+}
+
+impl ModelRef {
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, Error> {
+        let raw = value.as_ref().trim();
+        if raw.is_empty() {
+            return Err(Error::LlmAssist(
+                "model reference cannot be empty".to_string(),
+            ));
+        }
+
+        let (repo_part, explicit_filename) = match raw.split_once('#') {
+            Some((repo, filename)) if !repo.is_empty() && !filename.is_empty() => {
+                (repo, Some(filename.to_string()))
+            }
+            Some(_) => {
+                return Err(Error::LlmAssist(
+                    "model reference filename form must be <repo>#<filename>".to_string(),
+                ));
+            }
+            None => (raw, None),
+        };
+
+        let (repo_id, quantization) = match repo_part.rsplit_once(':') {
+            Some((repo, quant)) if repo.contains('/') && !quant.is_empty() => {
+                (repo.to_string(), Some(quant.to_string()))
+            }
+            _ => (repo_part.to_string(), None),
+        };
+
+        if repo_id.split('/').count() != 2 || repo_id.contains("..") {
+            return Err(Error::LlmAssist(format!(
+                "invalid Hugging Face model repo id: {repo_id}"
+            )));
+        }
+
+        let filename = match explicit_filename {
+            Some(filename) => filename,
+            None => derive_gguf_filename(&repo_id, quantization.as_deref())?,
+        };
+        validate_safe_filename(&filename)?;
+
+        Ok(Self {
+            raw: raw.to_string(),
+            repo_id,
+            quantization,
+            filename,
+            revision: DEFAULT_HF_REVISION.to_string(),
+        })
+    }
+
+    pub fn default_model() -> Self {
+        Self::parse(DEFAULT_MODEL_REF).expect("default model reference is valid")
+    }
+
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn repo_id(&self) -> &str {
+        &self.repo_id
+    }
+
+    pub fn quantization(&self) -> Option<&str> {
+        self.quantization.as_deref()
+    }
+
+    pub fn filename(&self) -> &str {
+        &self.filename
+    }
+
+    pub fn revision(&self) -> &str {
+        &self.revision
+    }
+
+    pub fn download_url(&self) -> String {
+        format!(
+            "https://huggingface.co/{}/resolve/{}/{}",
+            self.repo_id, self.revision, self.filename
+        )
+    }
+
+    fn cache_key(&self) -> PathBuf {
+        let mut path = PathBuf::new();
+        for segment in self.repo_id.split('/') {
+            path.push(sanitize_path_segment(segment));
+        }
+        path.push(sanitize_path_segment(&self.revision));
+        path.push(&self.filename);
+        path
+    }
+}
+
+impl Default for ModelRef {
+    fn default() -> Self {
+        Self::default_model()
+    }
+}
+
+impl fmt::Display for ModelRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.raw)
+    }
+}
+
+/// Local model cache and lazy downloader.
+#[derive(Debug, Clone)]
+pub struct ModelStore {
+    root: PathBuf,
+    client: reqwest::Client,
+}
+
+impl ModelStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn default_cache_dir() -> Result<PathBuf, Error> {
+        if let Some(path) = std::env::var_os(DEFAULT_CACHE_ENV) {
+            return Ok(PathBuf::from(path).join("models"));
+        }
+        let base = dirs::cache_dir().ok_or_else(|| {
+            Error::LlmAssist(
+                "could not determine a cache directory for model downloads".to_string(),
+            )
+        })?;
+        Ok(base.join("mcp-compressor").join("models"))
+    }
+
+    pub fn default_store() -> Result<Self, Error> {
+        Ok(Self::new(Self::default_cache_dir()?))
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn model_path(&self, model: &ModelRef) -> PathBuf {
+        self.root.join(model.cache_key())
+    }
+
+    pub fn is_cached(&self, model: &ModelRef) -> bool {
+        self.model_path(model).is_file()
+    }
+
+    /// Return the local model path, downloading only when `allow_download` is true.
+    pub async fn ensure_model(
+        &self,
+        model: &ModelRef,
+        allow_download: bool,
+    ) -> Result<PathBuf, Error> {
+        let path = self.model_path(model);
+        if path.is_file() {
+            return Ok(path);
+        }
+        if !allow_download {
+            return Err(Error::LlmAssist(format!(
+                "model {model} is not cached at {}; enable model download or run setup first",
+                path.display()
+            )));
+        }
+        self.download_model(model).await
+    }
+
+    pub async fn download_model(&self, model: &ModelRef) -> Result<PathBuf, Error> {
+        let final_path = self.model_path(model);
+        if final_path.is_file() {
+            return Ok(final_path);
+        }
+
+        let parent = final_path.parent().ok_or_else(|| {
+            Error::LlmAssist(format!(
+                "invalid model cache path: {}",
+                final_path.display()
+            ))
+        })?;
+        fs::create_dir_all(parent)?;
+        fs::create_dir_all(&self.root)?;
+        let lock_path = self.root.join("download.lock");
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(lock_path)?;
+        lock_file.lock_exclusive()?;
+        if final_path.is_file() {
+            let _ = lock_file.unlock();
+            return Ok(final_path);
+        }
+
+        let partial_path = final_path.with_extension("gguf.part");
+        let mut file = File::create(&partial_path)?;
+        let response = self
+            .client
+            .get(model.download_url())
+            .send()
+            .await?
+            .error_for_status()?;
+        let expected_size = response.content_length();
+        let mut stream = response.bytes_stream();
+        let mut bytes_written: u64 = 0;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            std::io::Write::write_all(&mut file, &chunk)?;
+            bytes_written += chunk.len() as u64;
+        }
+        std::io::Write::flush(&mut file)?;
+        drop(file);
+
+        if bytes_written == 0 {
+            let _ = std::fs::remove_file(&partial_path);
+            return Err(Error::LlmAssist(format!(
+                "downloaded model {model} from {} but received an empty response",
+                model.download_url()
+            )));
+        }
+        if let Some(expected) = expected_size {
+            if expected != bytes_written {
+                let _ = std::fs::remove_file(&partial_path);
+                return Err(Error::LlmAssist(format!(
+                    "downloaded model size mismatch for {model}: expected {expected} bytes, wrote {bytes_written} bytes"
+                )));
+            }
+        }
+
+        fs::rename(&partial_path, &final_path)?;
+        let result = self
+            .write_manifest(model, &final_path, bytes_written)
+            .map(|_| final_path);
+        let _ = lock_file.unlock();
+        result
+    }
+
+    fn write_manifest(&self, model: &ModelRef, path: &Path, size_bytes: u64) -> Result<(), Error> {
+        let manifest = ModelManifest {
+            model_ref: model.raw().to_string(),
+            repo_id: model.repo_id().to_string(),
+            revision: model.revision().to_string(),
+            filename: model.filename().to_string(),
+            download_url: model.download_url(),
+            local_path: path.display().to_string(),
+            size_bytes,
+            downloaded_at_unix_seconds: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        };
+        let manifest_path = path
+            .parent()
+            .ok_or_else(|| Error::LlmAssist("model path has no parent directory".to_string()))?
+            .join(MODEL_MANIFEST_FILE);
+        let json = serde_json::to_string_pretty(&manifest)?;
+        std::fs::write(manifest_path, json)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelManifest {
+    pub model_ref: String,
+    pub repo_id: String,
+    pub revision: String,
+    pub filename: String,
+    pub download_url: String,
+    pub local_path: String,
+    pub size_bytes: u64,
+    pub downloaded_at_unix_seconds: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeStore {
+    root: PathBuf,
+    client: reqwest::Client,
+}
+
+impl RuntimeStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn default_cache_dir() -> Result<PathBuf, Error> {
+        let base = if let Some(path) = std::env::var_os(DEFAULT_CACHE_ENV) {
+            PathBuf::from(path)
+        } else {
+            dirs::cache_dir()
+                .ok_or_else(|| {
+                    Error::LlmAssist(
+                        "could not determine a cache directory for llama-server downloads"
+                            .to_string(),
+                    )
+                })?
+                .join("mcp-compressor")
+        };
+        Ok(base.join("llama.cpp"))
+    }
+
+    pub fn default_store() -> Result<Self, Error> {
+        Ok(Self::new(Self::default_cache_dir()?))
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn runtime_path(&self) -> Result<PathBuf, Error> {
+        Ok(self.platform_dir()?.join(default_llama_server_binary()))
+    }
+
+    pub fn is_installed(&self) -> bool {
+        self.runtime_path()
+            .map(|path| path.is_file())
+            .unwrap_or(false)
+    }
+
+    pub async fn ensure_llama_server(
+        &self,
+        explicit_path: Option<&Path>,
+        allow_download: bool,
+    ) -> Result<PathBuf, Error> {
+        if let Some(path) = explicit_path {
+            if path.is_file() {
+                return Ok(path.to_path_buf());
+            }
+            return Err(Error::LlmAssist(format!(
+                "configured llama-server path does not exist: {}",
+                path.display()
+            )));
+        }
+        if let Ok(path) = self.runtime_path() {
+            if path.is_file() {
+                return Ok(path);
+            }
+        }
+        if let Some(path) = find_on_path(default_llama_server_binary()) {
+            return Ok(path);
+        }
+        if !allow_download {
+            return Err(Error::LlmAssist(
+                "llama-server is not installed; enable download or install llama.cpp".to_string(),
+            ));
+        }
+        self.download_llama_server().await
+    }
+
+    pub async fn download_llama_server(&self) -> Result<PathBuf, Error> {
+        let final_path = self.runtime_path()?;
+        if final_path.is_file() {
+            return Ok(final_path);
+        }
+        fs::create_dir_all(self.platform_dir()?)?;
+        fs::create_dir_all(&self.root)?;
+        let lock_path = self.root.join("download.lock");
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(lock_path)?;
+        lock_file.lock_exclusive()?;
+        let result = self.download_llama_server_locked(&final_path).await;
+        let _ = lock_file.unlock();
+        result
+    }
+
+    async fn download_llama_server_locked(&self, final_path: &Path) -> Result<PathBuf, Error> {
+        if final_path.is_file() {
+            return Ok(final_path.to_path_buf());
+        }
+        let asset = LlamaCppAsset::for_current_platform()?;
+        let mut last_error: Option<String> = None;
+        for archive_name in asset.archive_names() {
+            let archive_path = self.root.join(&archive_name);
+            let download_url = asset.download_url(&archive_name);
+            if !archive_path.is_file() {
+                match download_file(&self.client, &download_url, &archive_path).await {
+                    Ok(()) => {}
+                    Err(error) => {
+                        last_error = Some(error.to_string());
+                        let _ = fs::remove_file(&archive_path);
+                        continue;
+                    }
+                }
+            }
+            let extract_dir = self.root.join(format!("extract-{}", asset.platform));
+            if extract_dir.exists() {
+                fs::remove_dir_all(&extract_dir)?;
+            }
+            fs::create_dir_all(&extract_dir)?;
+            if let Err(error) = extract_archive(&archive_path, &extract_dir) {
+                last_error = Some(error.to_string());
+                let _ = fs::remove_dir_all(&extract_dir);
+                continue;
+            }
+            let extracted = match find_file_named(&extract_dir, default_llama_server_binary()) {
+                Some(path) => path,
+                None => {
+                    last_error = Some(format!(
+                        "downloaded {archive_name} but could not find {} inside it",
+                        default_llama_server_binary()
+                    ));
+                    let _ = fs::remove_dir_all(&extract_dir);
+                    continue;
+                }
+            };
+            if let Some(parent) = final_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(&extracted, final_path)?;
+            make_executable(final_path)?;
+            let _ = fs::remove_dir_all(&extract_dir);
+            let manifest = RuntimeManifest {
+                runtime: "llama-server".to_string(),
+                source: "llama.cpp".to_string(),
+                version: LLAMA_CPP_RELEASE_TAG.to_string(),
+                platform: asset.platform.to_string(),
+                archive_name,
+                download_url,
+                local_path: final_path.display().to_string(),
+                downloaded_at_unix_seconds: now_unix_seconds(),
+            };
+            let json = serde_json::to_string_pretty(&manifest)?;
+            fs::write(self.platform_dir()?.join(RUNTIME_MANIFEST_FILE), json)?;
+            return Ok(final_path.to_path_buf());
+        }
+        Err(Error::LlmAssist(format!(
+            "failed to download llama-server for {} from llama.cpp release {}: {}",
+            asset.platform,
+            LLAMA_CPP_RELEASE_TAG,
+            last_error.unwrap_or_else(|| "no candidate assets were available".to_string())
+        )))
+    }
+
+    fn platform_dir(&self) -> Result<PathBuf, Error> {
+        Ok(self
+            .root
+            .join(LlamaCppAsset::for_current_platform()?.platform))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeManifest {
+    pub runtime: String,
+    pub source: String,
+    pub version: String,
+    pub platform: String,
+    pub archive_name: String,
+    pub download_url: String,
+    pub local_path: String,
+    pub downloaded_at_unix_seconds: u64,
+}
+
+#[derive(Debug, Clone)]
+struct LlamaCppAsset {
+    platform: &'static str,
+}
+
+impl LlamaCppAsset {
+    fn for_current_platform() -> Result<Self, Error> {
+        let os = std::env::consts::OS;
+        let arch = std::env::consts::ARCH;
+        let platform = match (os, arch) {
+            ("macos", "aarch64") => "macos-arm64",
+            ("macos", "x86_64") => "macos-x64",
+            ("linux", "x86_64") => "linux-x64",
+            ("linux", "aarch64") => "linux-arm64",
+            ("windows", "x86_64") => "win-x64",
+            _ => {
+                return Err(Error::LlmAssist(format!(
+                    "managed llama-server download is not available for {os}-{arch}"
+                )));
+            }
+        };
+        Ok(Self { platform })
+    }
+
+    fn archive_names(&self) -> Vec<String> {
+        vec![
+            format!("llama-{}-{}.zip", LLAMA_CPP_RELEASE_TAG, self.platform),
+            format!("llama-{}-bin-{}.zip", LLAMA_CPP_RELEASE_TAG, self.platform),
+            format!("llama-{}-{}.tar.gz", LLAMA_CPP_RELEASE_TAG, self.platform),
+        ]
+    }
+
+    fn download_url(&self, archive_name: &str) -> String {
+        format!(
+            "{}/{}/{}",
+            LLAMA_CPP_RELEASE_BASE, LLAMA_CPP_RELEASE_TAG, archive_name
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedLlmRuntime {
+    pub llama_server_path: PathBuf,
+    pub model_path: PathBuf,
+    pub model: ModelRef,
+}
+
+#[derive(Debug, Clone)]
+pub struct LlmPreparationManager {
+    config: LlmRuntimeConfig,
+    state: Arc<Mutex<PreparationState>>,
+    notify: Arc<Notify>,
+}
+
+#[derive(Debug, Clone)]
+enum PreparationState {
+    NotStarted,
+    Preparing,
+    Ready(PreparedLlmRuntime),
+    Failed(String),
+}
+
+impl LlmPreparationManager {
+    pub fn new(config: LlmRuntimeConfig) -> Self {
+        Self {
+            config,
+            state: Arc::new(Mutex::new(PreparationState::NotStarted)),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    pub fn start_background(&self) {
+        let manager = self.clone();
+        tokio::spawn(async move {
+            let _ = manager.prepare().await;
+        });
+    }
+
+    pub async fn prepare(&self) -> Result<PreparedLlmRuntime, Error> {
+        {
+            let mut state = self.state.lock().await;
+            match &*state {
+                PreparationState::Ready(prepared) => return Ok(prepared.clone()),
+                PreparationState::Failed(message) => return Err(Error::LlmAssist(message.clone())),
+                PreparationState::Preparing => {}
+                PreparationState::NotStarted => {
+                    *state = PreparationState::Preparing;
+                    drop(state);
+                    let result = self.prepare_inner().await;
+                    let mut state = self.state.lock().await;
+                    match result {
+                        Ok(prepared) => {
+                            *state = PreparationState::Ready(prepared.clone());
+                            self.notify.notify_waiters();
+                            return Ok(prepared);
+                        }
+                        Err(error) => {
+                            let message = error.to_string();
+                            *state = PreparationState::Failed(message.clone());
+                            self.notify.notify_waiters();
+                            return Err(Error::LlmAssist(message));
+                        }
+                    }
+                }
+            }
+        }
+
+        loop {
+            self.notify.notified().await;
+            let state = self.state.lock().await;
+            match &*state {
+                PreparationState::Ready(prepared) => return Ok(prepared.clone()),
+                PreparationState::Failed(message) => return Err(Error::LlmAssist(message.clone())),
+                PreparationState::Preparing | PreparationState::NotStarted => {}
+            }
+        }
+    }
+
+    pub async fn status(&self) -> String {
+        match &*self.state.lock().await {
+            PreparationState::NotStarted => "not-started".to_string(),
+            PreparationState::Preparing => "preparing".to_string(),
+            PreparationState::Ready(prepared) => format!(
+                "ready: llama-server={}, model={}",
+                prepared.llama_server_path.display(),
+                prepared.model_path.display()
+            ),
+            PreparationState::Failed(message) => format!("failed: {message}"),
+        }
+    }
+
+    async fn prepare_inner(&self) -> Result<PreparedLlmRuntime, Error> {
+        let runtime_store = match &self.config.cache_dir {
+            Some(cache_dir) => RuntimeStore::new(cache_dir.join("llama.cpp")),
+            None => RuntimeStore::default_store()?,
+        };
+        let model_store = match &self.config.cache_dir {
+            Some(cache_dir) => ModelStore::new(cache_dir.join("models")),
+            None => ModelStore::default_store()?,
+        };
+        let llama_server_path = runtime_store
+            .ensure_llama_server(
+                self.config.llama_server_path.as_deref(),
+                self.config.allow_download,
+            )
+            .await?;
+        let model_path = model_store
+            .ensure_model(&self.config.model, self.config.allow_download)
+            .await?;
+        Ok(PreparedLlmRuntime {
+            llama_server_path,
+            model_path,
+            model: self.config.model.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmInstallStatus {
+    pub llama_server_path: Option<PathBuf>,
+    pub llama_server_ready: bool,
+    pub model_path: PathBuf,
+    pub model_ready: bool,
+    pub model_ref: String,
+}
+
+pub fn install_status(config: &LlmRuntimeConfig) -> Result<LlmInstallStatus, Error> {
+    let runtime_store = match &config.cache_dir {
+        Some(cache_dir) => RuntimeStore::new(cache_dir.join("llama.cpp")),
+        None => RuntimeStore::default_store()?,
+    };
+    let model_store = match &config.cache_dir {
+        Some(cache_dir) => ModelStore::new(cache_dir.join("models")),
+        None => ModelStore::default_store()?,
+    };
+    let llama_server_path = config
+        .llama_server_path
+        .clone()
+        .or_else(|| {
+            runtime_store
+                .runtime_path()
+                .ok()
+                .filter(|path| path.is_file())
+        })
+        .or_else(|| find_on_path(default_llama_server_binary()));
+    let model_path = model_store.model_path(&config.model);
+    Ok(LlmInstallStatus {
+        llama_server_ready: llama_server_path
+            .as_ref()
+            .map(|path| path.is_file())
+            .unwrap_or(false),
+        llama_server_path,
+        model_ready: model_path.is_file(),
+        model_path,
+        model_ref: config.model.to_string(),
+    })
+}
+
+pub async fn pull_llm_assets(config: LlmRuntimeConfig) -> Result<PreparedLlmRuntime, Error> {
+    let manager = LlmPreparationManager::new(LlmRuntimeConfig {
+        allow_download: true,
+        ..config
+    });
+    manager.prepare().await
+}
+
+pub fn remove_managed_llm_assets(cache_dir: Option<PathBuf>) -> Result<(), Error> {
+    let base = if let Some(cache_dir) = cache_dir {
+        cache_dir
+    } else if let Some(path) = std::env::var_os(DEFAULT_CACHE_ENV) {
+        PathBuf::from(path)
+    } else {
+        dirs::cache_dir()
+            .ok_or_else(|| Error::LlmAssist("could not determine cache directory".to_string()))?
+            .join("mcp-compressor")
+    };
+    let models = base.join("models");
+    let runtime = base.join("llama.cpp");
+    if models.exists() {
+        fs::remove_dir_all(models)?;
+    }
+    if runtime.exists() {
+        fs::remove_dir_all(runtime)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LlmResponseFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmRequest {
+    pub system_prompt: String,
+    pub user_prompt: String,
+    pub response_format: LlmResponseFormat,
+    pub timeout: Duration,
+}
+
+impl LlmRequest {
+    pub fn new(system_prompt: impl Into<String>, user_prompt: impl Into<String>) -> Self {
+        Self {
+            system_prompt: system_prompt.into(),
+            user_prompt: user_prompt.into(),
+            response_format: LlmResponseFormat::Text,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmResponse {
+    pub text: String,
+    pub model: String,
+}
+
+#[async_trait]
+pub trait LocalLlmRuntime: Send + Sync {
+    async fn complete(&self, request: LlmRequest) -> Result<LlmResponse, Error>;
+}
+
+#[async_trait]
+impl<T> LocalLlmRuntime for Arc<T>
+where
+    T: LocalLlmRuntime + ?Sized,
+{
+    async fn complete(&self, request: LlmRequest) -> Result<LlmResponse, Error> {
+        (**self).complete(request).await
+    }
+}
+
+/// Runtime configuration for the reusable assistant handle.
+#[derive(Debug, Clone)]
+pub struct LlmRuntimeConfig {
+    pub model: ModelRef,
+    pub allow_download: bool,
+    pub cache_dir: Option<PathBuf>,
+    pub llama_server_path: Option<PathBuf>,
+}
+
+impl LlmRuntimeConfig {
+    pub fn local_default(allow_download: bool) -> Self {
+        Self {
+            model: ModelRef::default(),
+            allow_download,
+            cache_dir: None,
+            llama_server_path: None,
+        }
+    }
+
+    pub fn with_model(mut self, model: ModelRef) -> Self {
+        self.model = model;
+        self
+    }
+
+    pub fn with_cache_dir(mut self, cache_dir: impl Into<PathBuf>) -> Self {
+        self.cache_dir = Some(cache_dir.into());
+        self
+    }
+
+    pub fn with_llama_server_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.llama_server_path = Some(path.into());
+        self
+    }
+}
+
+/// High-level assistant handle used by proxy features to send prompts.
+#[derive(Clone)]
+pub struct LlmAssistant {
+    preparation: LlmPreparationManager,
+}
+
+impl LlmAssistant {
+    pub fn from_config(config: LlmRuntimeConfig) -> Self {
+        Self {
+            preparation: LlmPreparationManager::new(config),
+        }
+    }
+
+    pub fn start_background_preparation(&self) {
+        self.preparation.start_background();
+    }
+
+    pub async fn preparation_status(&self) -> String {
+        self.preparation.status().await
+    }
+
+    pub async fn complete(
+        &self,
+        system_prompt: impl Into<String>,
+        user_prompt: impl Into<String>,
+    ) -> Result<String, Error> {
+        let response = self
+            .complete_request(LlmRequest::new(system_prompt, user_prompt))
+            .await?;
+        Ok(response.text)
+    }
+
+    pub async fn complete_request(&self, request: LlmRequest) -> Result<LlmResponse, Error> {
+        let prepared = self.preparation.prepare().await?;
+        let runtime =
+            EphemeralLlamaServerRuntime::new(prepared.model_path, prepared.model.to_string())
+                .with_llama_server_path(prepared.llama_server_path);
+        runtime.complete(request).await
+    }
+}
+
+/// Runtime that starts official `llama-server` for one request, calls its
+/// OpenAI-compatible chat endpoint, then tears it down.
+///
+/// The server mode is an internal detail: users configure the model, while the
+/// runtime uses official llama.cpp with a clean JSON API and avoids keeping an
+/// idle ~32k-context server resident for the full proxy session.
+#[derive(Debug, Clone)]
+pub struct EphemeralLlamaServerRuntime {
+    model_path: PathBuf,
+    model_ref: String,
+    llama_server_path: PathBuf,
+    client: reqwest::Client,
+}
+
+impl EphemeralLlamaServerRuntime {
+    pub fn new(model_path: impl Into<PathBuf>, model_ref: impl Into<String>) -> Self {
+        Self {
+            model_path: model_path.into(),
+            model_ref: model_ref.into(),
+            llama_server_path: PathBuf::from(default_llama_server_binary()),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn with_llama_server_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.llama_server_path = path.into();
+        self
+    }
+
+    async fn complete_once(&self, request: LlmRequest) -> Result<LlmResponse, Error> {
+        let mut last_error: Option<Error> = None;
+        for _ in 0..SERVER_START_RETRIES {
+            match self.try_complete_once(request.clone()).await {
+                Ok(response) => return Ok(response),
+                Err(error) => last_error = Some(error),
+            }
+        }
+        Err(last_error.unwrap_or_else(|| {
+            Error::LlmAssist("llama-server failed before start was attempted".to_string())
+        }))
+    }
+
+    async fn try_complete_once(&self, request: LlmRequest) -> Result<LlmResponse, Error> {
+        let addr = reserve_local_addr()?;
+        let base_url = format!("http://{addr}");
+        let mut child = ServerChild::spawn(
+            &self.llama_server_path,
+            &self.model_path,
+            addr,
+            request.timeout,
+        )?;
+        child.wait_until_ready(&self.client, &base_url).await?;
+        let response = self
+            .post_chat_completion(&base_url, &request)
+            .await
+            .map_err(|error| {
+                Error::LlmAssist(format!("llama-server completion failed: {error}"))
+            })?;
+        child.shutdown().await;
+        Ok(response)
+    }
+
+    async fn post_chat_completion(
+        &self,
+        base_url: &str,
+        request: &LlmRequest,
+    ) -> Result<LlmResponse, Error> {
+        #[derive(Serialize)]
+        struct ChatRequest<'a> {
+            model: &'a str,
+            messages: Vec<ChatMessage<'a>>,
+            temperature: f32,
+            top_p: f32,
+            max_tokens: usize,
+            response_format: Option<ResponseFormat>,
+        }
+
+        #[derive(Serialize)]
+        struct ChatMessage<'a> {
+            role: &'a str,
+            content: &'a str,
+        }
+
+        #[derive(Serialize)]
+        struct ResponseFormat {
+            #[serde(rename = "type")]
+            kind: &'static str,
+        }
+
+        #[derive(Deserialize)]
+        struct ChatResponse {
+            choices: Vec<Choice>,
+        }
+
+        #[derive(Deserialize)]
+        struct Choice {
+            message: AssistantMessage,
+        }
+
+        #[derive(Deserialize)]
+        struct AssistantMessage {
+            content: String,
+        }
+
+        let response_format = match request.response_format {
+            LlmResponseFormat::Text => None,
+            LlmResponseFormat::Json => Some(ResponseFormat {
+                kind: "json_object",
+            }),
+        };
+        let body = ChatRequest {
+            model: "local",
+            messages: vec![
+                ChatMessage {
+                    role: "system",
+                    content: &request.system_prompt,
+                },
+                ChatMessage {
+                    role: "user",
+                    content: &request.user_prompt,
+                },
+            ],
+            temperature: DEFAULT_TEMPERATURE,
+            top_p: DEFAULT_TOP_P,
+            max_tokens: OUTPUT_TOKEN_BUDGET,
+            response_format,
+        };
+
+        let response = tokio::time::timeout(
+            request.timeout,
+            self.client
+                .post(format!("{base_url}/v1/chat/completions"))
+                .json(&body)
+                .send(),
+        )
+        .await
+        .map_err(|_| Error::LlmAssist("llama-server completion timed out".to_string()))??
+        .error_for_status()?
+        .json::<ChatResponse>()
+        .await?;
+        let text = response
+            .choices
+            .into_iter()
+            .next()
+            .map(|choice| choice.message.content)
+            .ok_or_else(|| Error::LlmAssist("llama-server returned no choices".to_string()))?;
+        Ok(LlmResponse {
+            text,
+            model: self.model_ref.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl LocalLlmRuntime for EphemeralLlamaServerRuntime {
+    async fn complete(&self, request: LlmRequest) -> Result<LlmResponse, Error> {
+        tokio::time::timeout(request.timeout, self.complete_once(request))
+            .await
+            .map_err(|_| Error::LlmAssist("ephemeral llama-server request timed out".to_string()))?
+    }
+}
+
+struct ServerChild {
+    child: Child,
+}
+
+impl ServerChild {
+    fn spawn(
+        llama_server_path: &Path,
+        model_path: &Path,
+        addr: SocketAddr,
+        timeout: Duration,
+    ) -> Result<Self, Error> {
+        let mut command = Command::new(llama_server_path);
+        command
+            .arg("-m")
+            .arg(model_path)
+            .arg("-c")
+            .arg(INPUT_TOKEN_BUDGET.to_string())
+            .arg("--host")
+            .arg(addr.ip().to_string())
+            .arg("--port")
+            .arg(addr.port().to_string())
+            .arg("--temp")
+            .arg(DEFAULT_TEMPERATURE.to_string())
+            .arg("--top-p")
+            .arg(DEFAULT_TOP_P.to_string())
+            .arg("--no-webui")
+            .arg("--no-perf")
+            .kill_on_drop(true)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        if timeout < SERVER_READY_TIMEOUT {
+            // The request-level timeout still controls the whole operation. This
+            // branch is intentionally only a reminder that the child is tied to
+            // the request lifetime through kill_on_drop and the outer timeout.
+        }
+        let child = command.spawn().map_err(|error| {
+            Error::LlmAssist(format!(
+                "failed to start llama-server at {}: {error}",
+                llama_server_path.display()
+            ))
+        })?;
+        Ok(Self { child })
+    }
+
+    async fn wait_until_ready(
+        &mut self,
+        client: &reqwest::Client,
+        base_url: &str,
+    ) -> Result<(), Error> {
+        let deadline = tokio::time::Instant::now() + SERVER_READY_TIMEOUT;
+        loop {
+            if let Some(status) = self.child.try_wait()? {
+                return Err(Error::LlmAssist(format!(
+                    "llama-server exited before becoming ready with status {status}"
+                )));
+            }
+            match client.get(format!("{base_url}/health")).send().await {
+                Ok(response) if response.status().is_success() => return Ok(()),
+                Ok(_) | Err(_) => {}
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(Error::LlmAssist(
+                    "llama-server did not become ready before timeout".to_string(),
+                ));
+            }
+            tokio::time::sleep(SERVER_POLL_INTERVAL).await;
+        }
+    }
+
+    async fn shutdown(&mut self) {
+        if self.child.try_wait().ok().flatten().is_some() {
+            return;
+        }
+        let _ = self.child.start_kill();
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.child.wait()).await;
+    }
+}
+
+impl Drop for ServerChild {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+async fn download_file(client: &reqwest::Client, url: &str, path: &Path) -> Result<(), Error> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let partial_path = path.with_extension("part");
+    let mut file = File::create(&partial_path)?;
+    let response = client.get(url).send().await?.error_for_status()?;
+    let expected_size = response.content_length();
+    let mut stream = response.bytes_stream();
+    let mut bytes_written = 0_u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        file.write_all(&chunk)?;
+        bytes_written += chunk.len() as u64;
+    }
+    file.flush()?;
+    drop(file);
+    if bytes_written == 0 {
+        let _ = fs::remove_file(&partial_path);
+        return Err(Error::LlmAssist(format!(
+            "download from {url} returned no bytes"
+        )));
+    }
+    if let Some(expected) = expected_size {
+        if expected != bytes_written {
+            let _ = fs::remove_file(&partial_path);
+            return Err(Error::LlmAssist(format!(
+                "download size mismatch for {url}: expected {expected} bytes, wrote {bytes_written} bytes"
+            )));
+        }
+    }
+    fs::rename(&partial_path, path)?;
+    Ok(())
+}
+
+fn extract_archive(archive_path: &Path, destination: &Path) -> Result<(), Error> {
+    let name = archive_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if name.ends_with(".zip") {
+        let file = File::open(archive_path)?;
+        let mut archive = zip::ZipArchive::new(file)
+            .map_err(|error| Error::LlmAssist(format!("failed to open zip archive: {error}")))?;
+        archive
+            .extract(destination)
+            .map_err(|error| Error::LlmAssist(format!("failed to extract zip archive: {error}")))?;
+        Ok(())
+    } else if name.ends_with(".tar.gz") || name.ends_with(".tgz") {
+        let file = File::open(archive_path)?;
+        let decoder = GzDecoder::new(file);
+        let mut archive = tar::Archive::new(decoder);
+        archive.unpack(destination)?;
+        Ok(())
+    } else {
+        Err(Error::LlmAssist(format!(
+            "unsupported llama.cpp archive format: {}",
+            archive_path.display()
+        )))
+    }
+}
+
+fn find_file_named(root: &Path, file_name: &str) -> Option<PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let entries = fs::read_dir(&path).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.file_name().and_then(|name| name.to_str()) == Some(file_name) {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+fn find_on_path(binary_name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(binary_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), Error> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), Error> {
+    Ok(())
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn reserve_local_addr() -> Result<SocketAddr, Error> {
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))?;
+    let addr = listener.local_addr()?;
+    drop(listener);
+    Ok(addr)
+}
+
+fn derive_gguf_filename(repo_id: &str, quantization: Option<&str>) -> Result<String, Error> {
+    let repo_name = repo_id
+        .rsplit('/')
+        .next()
+        .ok_or_else(|| Error::LlmAssist(format!("invalid model repo id: {repo_id}")))?;
+    let base = repo_name.strip_suffix("-GGUF").unwrap_or(repo_name);
+    match quantization {
+        Some(quant) => Ok(format!("{base}-{quant}.gguf")),
+        None => Err(Error::LlmAssist(format!(
+            "model reference {repo_id} must include a quantization suffix like :Q4_K_M or an explicit #filename"
+        ))),
+    }
+}
+
+fn validate_safe_filename(filename: &str) -> Result<(), Error> {
+    if filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains("..")
+        || !filename.ends_with(".gguf")
+    {
+        return Err(Error::LlmAssist(format!(
+            "model filename must be a safe .gguf filename: {filename}"
+        )));
+    }
+    Ok(())
+}
+
+fn sanitize_path_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|ch| match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
+fn default_llama_server_binary() -> &'static str {
+    if cfg!(windows) {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_default_model_reference() {
+        let model = ModelRef::parse(DEFAULT_MODEL_REF).unwrap();
+        assert_eq!(model.repo_id(), "LiquidAI/LFM2.5-350M-GGUF");
+        assert_eq!(model.quantization(), Some("Q4_K_M"));
+        assert_eq!(model.filename(), "LFM2.5-350M-Q4_K_M.gguf");
+        assert_eq!(
+            model.download_url(),
+            "https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF/resolve/main/LFM2.5-350M-Q4_K_M.gguf"
+        );
+    }
+
+    #[test]
+    fn parses_explicit_filename_reference() {
+        let model = ModelRef::parse("Org/Repo-GGUF#custom-name.gguf").unwrap();
+        assert_eq!(model.repo_id(), "Org/Repo-GGUF");
+        assert_eq!(model.quantization(), None);
+        assert_eq!(model.filename(), "custom-name.gguf");
+    }
+
+    #[test]
+    fn rejects_unsafe_filename_reference() {
+        assert!(ModelRef::parse("Org/Repo#../bad.gguf").is_err());
+        assert!(ModelRef::parse("Org/Repo#bad.bin").is_err());
+    }
+
+    #[test]
+    fn model_store_uses_sanitized_cache_key() {
+        let store = ModelStore::new(PathBuf::from("/cache"));
+        let model = ModelRef::parse(DEFAULT_MODEL_REF).unwrap();
+        let path = store.model_path(&model);
+        assert!(path.ends_with(Path::new(
+            "LiquidAI/LFM2.5-350M-GGUF/main/LFM2.5-350M-Q4_K_M.gguf"
+        )));
+    }
+
+    #[test]
+    fn local_default_config_uses_default_model() {
+        let config = LlmRuntimeConfig::local_default(false);
+        assert_eq!(config.model.raw(), DEFAULT_MODEL_REF);
+        assert!(!config.allow_download);
+        assert!(config.cache_dir.is_none());
+        assert!(config.llama_server_path.is_none());
+    }
+
+    #[test]
+    fn config_accepts_llama_server_path() {
+        let config =
+            LlmRuntimeConfig::local_default(false).with_llama_server_path("/bin/llama-server");
+        assert_eq!(
+            config.llama_server_path,
+            Some(PathBuf::from("/bin/llama-server"))
+        );
+    }
+
+    #[test]
+    fn reserve_local_addr_returns_localhost() {
+        let addr = reserve_local_addr().unwrap();
+        assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_ne!(addr.port(), 0);
+    }
+
+    #[tokio::test]
+    async fn ensure_model_without_download_returns_actionable_error() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let store = ModelStore::new(tempdir.path());
+        let model = ModelRef::parse(DEFAULT_MODEL_REF).unwrap();
+        let error = store.ensure_model(&model, false).await.unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("is not cached"));
+        assert!(message.contains("enable model download"));
+    }
+}

--- a/docs/llm-assist-design.md
+++ b/docs/llm-assist-design.md
@@ -1,0 +1,543 @@
+# Design: optional local LLM assistance in the proxy layer
+
+This document proposes an optional local-LLM assistance layer for `mcp-compressor`. The goal is to keep the existing deterministic compression path fast and dependency-light, while allowing users to opt in to higher-level proxy behaviors that benefit from a small utility model.
+
+## Summary
+
+`mcp-compressor` should add an optional `llm-assist` subsystem inside the Rust proxy layer. When enabled, the proxy can ask a small local model to help with tasks such as response filtering, next-call suggestions, generated `SKILL.md` drafts, validation-error repair, and semantic help lookup.
+
+The recommended first runtime is [llama.cpp](https://github.com/ggml-org/llama.cpp), accessed through Rust bindings such as [`llama-cpp-2`](https://docs.rs/llama-cpp-2/latest/llama_cpp_2/). The recommended default model is [LiquidAI/LFM2.5-350M-GGUF](https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF) with `Q4_K_M` quantization. Hugging Face reports this artifact as approximately **229 MB**, with smaller `Q4_0` at 219 MB and larger `Q8_0` at 379 MB. Liquid describes LFM2 as a hybrid model family designed for edge and on-device deployment, and the model card includes llama.cpp usage examples.
+
+The model must be optional. It should be downloaded only when a user enables an LLM-assisted feature or explicitly runs a setup command. Standard proxy mode, SDK sessions, generated clients, and TypeScript local tool compression should not download model artifacts or initialize an inference engine.
+
+## Goals
+
+- Preserve the current deterministic compressed MCP proxy behavior by default.
+- Keep all LLM assistance local-first and optional.
+- Avoid sending backend tool schemas, tool inputs, tool outputs, credentials, or user data to a remote model provider.
+- Support incremental adoption: each LLM-assisted feature can be enabled independently.
+- Use the LLM for bounded utility tasks, not as the source of truth for MCP protocol behavior.
+- Keep public Python and TypeScript packages thin by implementing shared behavior in Rust.
+
+## Non-goals
+
+- Replacing the existing compression levels with an LLM-only compression strategy.
+- Running a large general-purpose coding model in the proxy process.
+- Fine-tuning or training models as part of `mcp-compressor`.
+- Depending on a hosted inference API for core behavior.
+- Allowing the model to call tools autonomously without the client agent's explicit request.
+
+## Proposed user experience
+
+LLM assistance should be off by default:
+
+```bash
+mcp-compressor -c medium -- python server.py
+```
+
+A user opts in at the CLI:
+
+```bash
+mcp-compressor \
+  --llm-assist response-filter,next-suggestion,validation-repair \
+  --llm-model LiquidAI/LFM2.5-350M-GGUF:Q4_K_M \
+  -c medium \
+  -- python server.py
+```
+
+SDKs expose the same setting through configuration:
+
+=== "Python"
+
+    ```python
+    from mcp_compressor import CompressorClient
+
+    client = CompressorClient(
+        compression="medium",
+        llm_assist={
+            "features": ["response_filter", "validation_repair"],
+            "model": "LiquidAI/LFM2.5-350M-GGUF:Q4_K_M",
+        },
+    )
+    ```
+
+=== "TypeScript"
+
+    ```ts
+    import { CompressorClient } from "@atlassian/mcp-compressor";
+
+    const client = new CompressorClient({
+      compression: "medium",
+      llmAssist: {
+        features: ["response_filter", "validation_repair"],
+        model: "LiquidAI/LFM2.5-350M-GGUF:Q4_K_M",
+      },
+    });
+    ```
+
+=== "Rust"
+
+    ```rust
+    use mcp_compressor::sdk::{CompressorClient, LlmAssistConfig};
+
+    let client = CompressorClient::builder()
+        .compression("medium")
+        .llm_assist(LlmAssistConfig::local_default())
+        .build()?;
+    ```
+
+The first enabled use should show a clear one-time message before download in CLI mode:
+
+```text
+LLM assistance needs LiquidAI/LFM2.5-350M-GGUF:Q4_K_M (~229 MB).
+Download to ~/.cache/mcp-compressor/models? [y/N]
+```
+
+SDK mode should not prompt unexpectedly. It should either:
+
+- fail with an actionable `ModelNotAvailable` error, or
+- download only when `allow_model_download=true` is set.
+
+## Runtime and model choice
+
+### Runtime: llama.cpp
+
+Use official `llama-server` from llama.cpp as the first inference backend because it is widely used for local GGUF inference, supports CPU and common acceleration backends, runs on macOS, Linux, and Windows, exposes a clean OpenAI-compatible JSON API, and avoids relying on less-supported Rust bindings or scraping human-oriented CLI output.
+
+Cross-platform support is a requirement for the default path. The embedded runtime must work on the same primary platforms as the CLI and SDK packages:
+
+| Platform | Baseline requirement | Acceleration policy |
+|---|---|---|
+| macOS arm64/x64 | Supported | Metal may be used when available, but CPU fallback is required. |
+| Linux x64/aarch64 | Supported | CPU fallback is required; CUDA/Vulkan/other acceleration must be optional. |
+| Windows x64 | Supported unless proven infeasible | CPU fallback is required; MSVC build and packaged binary behavior must be validated before release. |
+
+The initial implementation should prepare the local runtime in the background when LLM assistance is enabled, then use an **ephemeral `llama-server`** process as an internal runtime detail for each prompt:
+
+1. start background preparation at proxy startup,
+2. install `llama-server` into the `mcp-compressor` cache if needed,
+3. download/cache the configured GGUF model if needed,
+4. on first LLM use, wait for preparation if it is still running,
+5. choose a free loopback port,
+6. start `llama-server` bound to `127.0.0.1`,
+7. wait for `/health`,
+8. send one `/v1/chat/completions` request,
+9. parse the JSON response, and
+10. terminate the server.
+
+This keeps startup latency close to normal proxy startup while avoiding surprise blocking until the first LLM-assisted feature is actually needed. It also keeps the user-facing configuration simple: users choose the model, not the serving mode. Ephemeral serving avoids keeping a 32k-context local server resident for the whole proxy session, which matters when multiple `mcp-compressor` processes are running. A persistent server can be added later as an internal optimization if repeated prompt volume justifies the memory cost.
+
+### Default model: LiquidAI/LFM2.5-350M-GGUF Q4_K_M
+
+Use `LiquidAI/LFM2.5-350M-GGUF:Q4_K_M` as the default because it is small enough to download opportunistically, is designed for edge/on-device use, and is available as a GGUF artifact compatible with llama.cpp. The Hugging Face model page lists:
+
+| Quantization | Approximate artifact size |
+|---|---:|
+| `Q4_0` | 219 MB |
+| `Q4_K_M` | 229 MB |
+| `Q5_K_M` | 260 MB |
+| `Q6_K` | 293 MB |
+| `Q8_0` | 379 MB |
+| `BF16` / `F16` | 711 MB |
+
+Default settings:
+
+```toml
+[llm_assist]
+enabled = false
+runtime = "llama.cpp"
+model = "LiquidAI/LFM2.5-350M-GGUF:Q4_K_M"
+input_token_budget = 32768
+output_token_budget = 4096
+temperature = 0.0
+top_p = 1.0
+allow_model_download = false
+```
+
+The context window needs to be much larger than the original compression wrapper budget because LLM assistance may inspect multiple tool schemas, validation errors, partial tool outputs, generated-client help text, and retrieved documentation snippets at the same time. The proxy should own fixed token budgets of **32,768 input tokens** and **4,096 output tokens**. These should not be user-facing knobs initially; each feature should use deterministic truncation, retrieval, and summarization policies to fit within those limits. If the selected model cannot support the fixed input budget, startup should fail with an actionable model-compatibility error instead of silently lowering quality.
+
+For the initial design, the user should only configure the model. Users can choose a stronger local model for SKILL generation, a smaller/faster quant for response filtering, or a model with a larger context window if the default artifact cannot meet the fixed context budget on a particular platform.
+
+## Download and cache behavior
+
+Model acquisition must be lazy and explicit:
+
+1. Parse config and determine whether any enabled feature needs local inference.
+2. Resolve the configured model reference.
+3. Check the local cache.
+4. If missing:
+   - CLI interactive mode asks for confirmation.
+   - CLI non-interactive mode fails unless `--llm-allow-download` is set.
+   - SDK mode fails unless the SDK config sets `allow_model_download=true`.
+5. Download the selected GGUF artifact.
+6. Verify expected metadata where available: repo, filename/quant, size, and optionally checksum when provided by the model host.
+7. Store a local manifest recording source, resolved file, size, creation time, and license acknowledgement.
+
+Recommended cache location:
+
+```text
+$MCP_COMPRESSOR_CACHE_DIR/models/
+$XDG_CACHE_HOME/mcp-compressor/models/
+~/Library/Caches/mcp-compressor/models/        # macOS fallback
+%LOCALAPPDATA%\mcp-compressor\models\          # Windows fallback
+```
+
+If the embedded runtime uses a Hugging Face-compatible cache API, it may reuse the standard Hugging Face cache to avoid duplicate downloads. `mcp-compressor` should still maintain its own small manifest so `mcp-compressor llm status` can explain what is installed and why.
+
+Management commands:
+
+```bash
+mcp-compressor llm status
+mcp-compressor llm pull --model LiquidAI/LFM2.5-350M-GGUF:Q4_K_M
+mcp-compressor llm test --prompt "Say hello in one short sentence."
+mcp-compressor llm remove
+```
+
+`pull` installs the managed `llama-server` artifact and downloads the configured model. `status` reports whether each asset is ready. `test` performs setup if needed and sends a single prompt through the ephemeral server path. `remove` deletes managed runtime/model assets from the `mcp-compressor` cache.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Client[MCP client / agent]
+  Proxy[mcp-compressor proxy]
+  Assist[LLM assist coordinator]
+  Cache[Model cache]
+  Runtime[llama.cpp runtime]
+  Backend[MCP backend]
+
+  Client --> Proxy
+  Proxy --> Backend
+  Proxy -. optional prompts .-> Assist
+  Assist --> Cache
+  Assist --> Runtime
+  Runtime --> Assist
+  Assist -. bounded result .-> Proxy
+```
+
+Add a new Rust module, for example `crates/mcp-compressor-core/src/llm_assist/`:
+
+```text
+llm_assist/
+  mod.rs              # feature registry and public coordinator
+  config.rs           # runtime/model/download configuration
+  model_store.rs      # cache resolution and manifest management
+  runtime.rs          # trait for local inference
+  llama_cpp.rs        # llama.cpp-backed implementation behind feature flag
+  prompts.rs          # fixed prompts and structured output schemas
+  response_filter.rs  # tool result filtering pipeline
+  suggestions.rs      # next-call suggestion pipeline
+  skill_gen.rs        # SKILL.md generator
+  repair.rs           # validation repair pipeline
+  help.rs             # semantic help lookup pipeline
+```
+
+Core trait:
+
+```rust
+pub trait LocalLlmRuntime: Send + Sync {
+    async fn complete(&self, request: LlmRequest) -> Result<LlmResponse>;
+}
+
+pub struct LlmRequest {
+    pub system_prompt: String,
+    pub user_prompt: String,
+    pub response_format: LlmResponseFormat,
+    pub output_token_budget: usize,
+    pub timeout: Duration,
+}
+```
+
+The proxy should interact with the coordinator through feature-specific methods instead of free-form prompting:
+
+```rust
+impl LlmAssistCoordinator {
+    async fn filter_tool_result(&self, request: ResponseFilterRequest) -> Result<ResponseFilterDecision>;
+    async fn suggest_next_calls(&self, request: SuggestionRequest) -> Result<Vec<ToolSuggestion>>;
+    async fn draft_skill(&self, request: SkillDraftRequest) -> Result<String>;
+    async fn repair_validation_error(&self, request: RepairRequest) -> Result<RepairDecision>;
+    async fn lookup_help(&self, request: HelpLookupRequest) -> Result<HelpLookupResult>;
+}
+```
+
+## Feature designs
+
+### 1. Filter large tool responses
+
+Problem: Some MCP tools return large JSON payloads, logs, search results, or documents where only a small subset is useful for the current call.
+
+Design:
+
+- Trigger only when enabled and the tool result exceeds configurable thresholds such as byte size, token estimate, or item count.
+- Preserve the original tool result by default in the proxy internals for debugging and optional retrieval.
+- Ask the local model to produce a structured filtered result with:
+  - a concise summary,
+  - retained high-signal fields,
+  - omitted-field notes,
+  - confidence and warning flags.
+- Never filter binary outputs or opaque attachments.
+- Mark filtered outputs clearly so client agents know the result was transformed.
+
+Example output envelope:
+
+```json
+{
+  "mcp_compressor_filtered": true,
+  "summary": "Found 3 matching issues; the most relevant is PROJ-123.",
+  "important_items": [
+    {"key": "PROJ-123", "status": "In Progress", "why_relevant": "mentions the failing auth flow"}
+  ],
+  "omitted": {"items": 47, "reason": "low lexical relevance to the original request"},
+  "original_available": true
+}
+```
+
+Safety rules:
+
+- Filtering must be opt-in per server or per tool class.
+- The original result should remain available through an explicit debug or retrieval path.
+- Filtering should be disabled automatically for outputs that appear to contain secrets unless the redaction pass succeeds first.
+- Tool-call side effects must not be hidden; the proxy should preserve success/failure status exactly.
+
+### 2. Suggest the next tool or command to call
+
+Problem: At high compression levels, agents may not know which backend tool to inspect next.
+
+Design:
+
+- Provide suggestions as metadata alongside wrapper-tool responses, not as autonomous actions.
+- Inputs should include the compressed tool catalog, recently inspected schemas, the current tool result summary, and the user's original intent when available.
+- Output a ranked list of possible next calls, each with a reason and required arguments still missing.
+
+Example:
+
+```json
+{
+  "suggestions": [
+    {
+      "tool": "get_tool_schema",
+      "arguments": {"tool_name": "search_jira_using_jql"},
+      "reason": "The user needs issue discovery and no JQL-capable schema has been inspected yet.",
+      "confidence": 0.78
+    }
+  ]
+}
+```
+
+The proxy should expose this either:
+
+- as optional metadata in TOON/JSON wrapper responses, or
+- through a dedicated compressed helper tool such as `suggest_next_tool` when LLM assistance is enabled.
+
+### 3. Generate `SKILL.md` files for proxied MCP servers
+
+Problem: Repeated use of a large MCP server benefits from durable, human-readable operating instructions.
+
+Design:
+
+- Add an explicit command, not an automatic background behavior:
+
+```bash
+mcp-compressor skill draft --server atlassian --output ./.rovodev/skills/atlassian-mcp/SKILL.md
+```
+
+- Input to the model:
+  - tool names,
+  - compact descriptions,
+  - full schemas for selected high-value tools,
+  - examples from observed successful calls when the user opts in,
+  - server name and authentication notes with secrets redacted.
+- Output a draft `SKILL.md` with:
+  - what the server is for,
+  - when to use each major tool family,
+  - required setup/auth assumptions,
+  - common workflows,
+  - pitfalls and validation constraints.
+
+This should require user approval before writing outside an explicitly requested output path. The model should draft, not publish, operational guidance.
+
+### 4. Automatically fix tool call validation errors
+
+Problem: Client agents often make near-miss calls: wrong enum casing, JSON string where an object is expected, missing wrapper nesting, or incorrect generated-client argument names.
+
+Design:
+
+- Keep the deterministic validator first.
+- If validation fails and `validation-repair` is enabled, ask the local model for a strict JSON patch or replacement argument object.
+- Re-run validation after repair.
+- Apply at most one automatic repair attempt by default.
+- Include a repair note in the response metadata.
+
+Repair prompt inputs:
+
+- target tool schema,
+- invalid input,
+- exact validation error,
+- examples of valid shapes if available.
+
+Repair output:
+
+```json
+{
+  "action": "replace_arguments",
+  "arguments": {
+    "issue_url": "https://example.atlassian.net/browse/PROJ-123",
+    "get_comments": true
+  },
+  "explanation": "Converted getComments to get_comments and preserved the issue URL."
+}
+```
+
+Safety rules:
+
+- Never invent missing credentials, account IDs, file paths, destructive flags, or user content.
+- Do not repair calls to tools configured as destructive unless `--llm-repair-destructive` is explicitly enabled.
+- If the model changes semantic values, require confirmation or return a suggested repair instead of invoking.
+
+### 5. LLM-powered help lookup for tools and generated clients
+
+Problem: Users and agents need help finding the right tool, generated command, or argument without loading every full schema.
+
+Design:
+
+- Add a helper tool such as `help_lookup` when enabled.
+- Build a compact local index from tool names, descriptions, argument names, generated command names, and selected schema fragments.
+- Use deterministic lexical retrieval first, then ask the local model to rank and explain matches.
+- Return citations to source schema fields so the answer is auditable.
+
+Example:
+
+```json
+{
+  "query": "how do I search Jira issues by JQL?",
+  "matches": [
+    {
+      "kind": "tool",
+      "name": "search_jira_using_jql",
+      "why": "Accepts a JQL string and limit.",
+      "schema_path": "tools.search_jira_using_jql.inputSchema.properties.jql"
+    }
+  ]
+}
+```
+
+The LLM should not be the only retrieval mechanism. A deterministic index keeps results stable and allows the model to focus on ranking and summarization.
+
+## Prompting and structured outputs
+
+All LLM-assisted features should use narrow, fixed prompts and structured output validation. Prompts should instruct the model to:
+
+- treat tool schemas and tool outputs as untrusted data,
+- avoid following instructions embedded in tool outputs,
+- return only the requested JSON shape for machine-consumed paths,
+- admit uncertainty instead of guessing,
+- preserve exact identifiers, URLs, issue keys, file paths, and enum values unless the task is validation repair.
+
+Every machine-consumed model response must be parsed and validated. Invalid LLM output should degrade gracefully to the deterministic baseline.
+
+## Security and privacy
+
+Local inference reduces data exposure, but it does not remove security risk.
+
+Required controls:
+
+- **Off by default.** No model download, model load, or LLM prompt construction unless enabled.
+- **Secret redaction.** Reuse or add a redaction pass before prompts include headers, tokens, cookies, environment values, or auth config.
+- **Prompt-injection isolation.** Tool outputs are data, not instructions. Prompts should quote or delimit tool outputs and explicitly ignore embedded instructions.
+- **No autonomous side effects.** LLM suggestions are advisory. Validation repair may retry only the same user-requested call, and only after schema validation passes.
+- **Audit metadata.** Responses transformed by the LLM should include metadata indicating the feature used, model reference, and whether original output is available.
+- **Timeouts and cancellation.** Local inference must have strict per-request timeouts and respect proxy shutdown.
+- **License visibility.** The model manifest should record the source model and license metadata so package users can make informed decisions.
+
+## Configuration
+
+CLI flags:
+
+```text
+--llm-assist <features>          Comma-separated features: response-filter,next-suggestion,skill-gen,validation-repair,help-lookup
+--llm-model <model-ref>          Default: LiquidAI/LFM2.5-350M-GGUF:Q4_K_M
+--llm-allow-download             Permit lazy model download in non-interactive contexts
+--llm-cache-dir <path>           Override model cache location
+--llm-timeout <duration>         Bound local inference latency
+```
+
+MCP JSON config extension:
+
+```json
+{
+  "mcpServers": {
+    "example": {
+      "command": "python",
+      "args": ["server.py"],
+      "mcp-compressor": {
+        "llmAssist": {
+          "features": ["response_filter", "help_lookup"],
+          "model": "LiquidAI/LFM2.5-350M-GGUF:Q4_K_M",
+          "allowModelDownload": false,
+          "responseFilter": {
+            "minBytes": 32768,
+            "preserveOriginal": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Failure behavior
+
+LLM assistance should never make the proxy unusable when deterministic behavior would have worked.
+
+| Failure | Behavior |
+|---|---|
+| Model missing and downloads disallowed | Return actionable setup error for the LLM-assisted feature; continue normal proxy operation where possible. |
+| Download fails | Keep cache unchanged; report source and retry guidance. |
+| Runtime fails to load | Disable LLM-assisted features for the session and continue deterministic proxying. |
+| Prompt too large | Truncate with explicit policy or skip the feature. |
+| Invalid model output | Ignore LLM result and return deterministic baseline. |
+| Timeout | Cancel inference and return deterministic baseline. |
+
+## Observability
+
+Add debug logs and optional metrics for:
+
+- model cache hit/miss,
+- model load time,
+- inference latency,
+- input/output token estimates,
+- feature used,
+- fallback reason,
+- bytes removed by response filtering,
+- validation repair attempted/succeeded/failed.
+
+Logs must not include raw prompts by default because prompts may contain tool outputs or user data.
+
+## Rollout plan
+
+1. Add config types, CLI parsing, and no-op coordinator behind an optional Cargo feature.
+2. Add model cache/status commands without runtime inference.
+3. Add local llama.cpp runtime integration and feature-gated smoke tests for macOS, Linux, and Windows release targets.
+4. Add packaging validation for Python wheels, TypeScript native packages, and Rust binaries on each supported platform; if any target is infeasible, document the limitation and enable the local-server fallback for that target.
+5. Implement `validation-repair` first because it has the clearest bounded input/output contract.
+6. Implement `help-lookup` with deterministic retrieval plus LLM ranking.
+7. Implement `response-filter` with an original-result retrieval path.
+8. Add `next-suggestion` metadata.
+9. Add explicit `skill draft` command.
+10. Document security model, download behavior, SDK configuration, platform support, and fallback behavior.
+
+## Open questions
+
+- Should the default binary ship with the `llm-assist` Cargo feature disabled and offer a separate feature/build for users who want embedded llama.cpp?
+- Should model downloads use the Hugging Face cache directly, or should `mcp-compressor` maintain a separate cache and deduplicate opportunistically?
+- What is the best API for retrieving an original unfiltered tool result without exposing stale sensitive data indefinitely?
+- Should generated clients surface LLM help/suggestions, or should this remain only in the live proxy API?
+- Which features should be safe in non-interactive automation by default?
+
+## Research references
+
+- [LiquidAI/LFM2.5-350M-GGUF on Hugging Face](https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF): GGUF model card, llama.cpp examples, quantization sizes, and license metadata.
+- [Liquid AI LFM2.5 350M announcement](https://www.liquid.ai/blog/lfm2-5-350m-no-size-left-behind): describes the 350M model release and edge/on-device positioning.
+- [Liquid AI llama.cpp documentation](https://docs.liquid.ai/docs/inference/llama-cpp): documents llama.cpp local inference modes and Hugging Face download behavior.
+- [llama.cpp README](https://github.com/ggml-org/llama.cpp/blob/master/README.md): documents GGUF usage, `-hf <user>/<model>[:quant]`, and Hugging Face cache behavior.
+- [`llama-cpp-2` docs.rs](https://docs.rs/llama-cpp-2/latest/llama_cpp_2/): Rust bindings considered for embedded local inference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - API status: reference/api-status.md
       - API modules: modules.md
   - Development:
+      - LLM assist design: llm-assist-design.md
       - Internal implementation notes: rust-core-design.md
 plugins:
   - search


### PR DESCRIPTION
## Summary
- add an optional LLM assist core module with model reference parsing, cache/download management, background preparation, and ephemeral llama-server prompt execution
- add managed llama-server/model status, pull, remove, and test CLI commands
- document the LLM assist design, runtime choice, cache/download behavior, fixed token budgets, and rollout plan

## Validation
- cargo check -p mcp-compressor-core
- cargo test -p mcp-compressor-core llm_assist -- --nocapture
- uv run python scripts/check_public_api_names.py
- make docs-test