### PR TITLE
Dispatch TypeScript publish workflow from release-main

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -121,6 +121,16 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
 
+      - name: Dispatch TypeScript publish workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh workflow run publish-typescript-package.yml \
+            --ref release \
+            -f tag="${{ steps.prepare.outputs.tag }}" \
+            -f publish=true
+
       - name: Wait for TypeScript publish workflow
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-typescript-package.yml
+++ b/.github/workflows/publish-typescript-package.yml
@@ -1,9 +1,6 @@
 name: publish-typescript-package
 
 on:
-  push:
-    branches:
-      - release
   workflow_dispatch:
     inputs:
       tag:
@@ -113,15 +110,15 @@ jobs:
 
       - name: Stop before TypeScript publish in validation mode
         if: github.event_name == 'workflow_dispatch' && inputs.publish != true
-        run: echo "TypeScript validation complete. Set publish=true or push the prepared release branch to publish to npm-public."
+        run: echo "TypeScript validation complete. Set publish=true to publish to npm-public."
 
       - name: Get Artifact Publish Token
-        if: github.event_name == 'push' || inputs.publish == true
+        if: inputs.publish == true
         id: publish-token
         uses: atlassian-labs/artifact-publish-token@v1.0.1
         with:
           output-modes: npm
 
       - name: Publish to Artifactory npm-public
-        if: github.event_name == 'push' || inputs.publish == true
+        if: inputs.publish == true
         run: npm publish /tmp/mcp-compressor-typescript-package.tgz --tag "${{ steps.version.outputs.dist_tag }}" --userconfig "${{ github.workspace }}/.npmrc-public"


### PR DESCRIPTION
## Summary
- explicitly dispatch publish-typescript-package.yml on the release branch after updating refs/heads/release
- keep the release branch update so the dispatched workflow gets branch-based OIDC claims
- keep polling for the dispatched run's release SHA

## Why
GitHub suppresses workflow runs from push events created with GITHUB_TOKEN, so updating refs/heads/release from release-main does not automatically trigger the push workflow.

## Validation
- YAML parse for release workflows
- make check