### PR TITLE
Document release process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,9 +196,10 @@ Important workflows:
 - `.github/workflows/main.yml` — primary checks.
 - `.github/workflows/atlassian-mcp-integration.yml` — real-world Atlassian MCP tests.
 - `.github/workflows/release-artifacts.yml` — cross-platform artifact smoke tests.
-- `.github/workflows/on-release-main.yml` — unified release workflow for Python, TypeScript, Rust crates, and docs.
+- `.github/workflows/on-release-main.yml` — unified release entrypoint for Python, Rust crates, TypeScript dispatch, and docs.
+- `.github/workflows/publish-typescript-package.yml` — TypeScript npm-public publish workflow dispatched on the `release` branch so Artifactory receives branch-based OIDC claims.
 
-Release versions are derived from tags where possible. Avoid hardcoding release versions in source unless a package manager requires a placeholder.
+Release versions are derived from tags where possible. Avoid hardcoding release versions in source unless a package manager requires a placeholder. See `docs/development-release.md` before changing release workflows.
 
 ## Documentation guidance
 

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -123,25 +123,6 @@ atlassian-labs/artifact-publish-token@v1.0.1
 
 with `output-modes: npm` to create `.npmrc-public`.
 
-## Manual TypeScript fallback
-
-If GitHub Actions publishing is blocked by Artifactory permissions, maintainers can publish locally after obtaining permission:
-
-```bash
-atlas packages permission grant
-cd typescript
-bun run build
-bun run build:native
-npm version 0.15.0-alpha.1 --no-git-tag-version
-npm publish --tag next
-git checkout -- package.json bun.lock
-```
-
-Use `--tag latest` for stable releases.
-
-!!! warning
-    Local publishing only builds the native addon for the current platform. Prefer the GitHub workflow for official releases.
-
 ## Docs publish
 
 Docs are deployed by the release workflow with:

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -113,18 +113,7 @@ For stable releases, it uses:
 
 ### Required npm-public configuration
 
-The package must be configured in Atlassian Artifactory npm-public allowlists. At the time this was set up, the relevant internal configuration was in:
-
-```text
-bitbucket.org/atlassian/buildeng-artifactory-configuration
-```
-
-The package paths should include:
-
-```text
-@atlassian/mcp-compressor/**
-.npm/@atlassian/mcp-compressor/**
-```
+The package must be configured in Atlassian Artifactory npm-public allowlists to enable Artifactory forwarding to npmjs.
 
 The workflow uses:
 

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -1,0 +1,179 @@
+# Release process
+
+This page documents how maintainers publish mcp-compressor release artifacts.
+
+A GitHub Release is the normal release entrypoint. The release tag determines all package versions; versions should not be committed into source files manually.
+
+## Version tags
+
+Use a tag beginning with `v`.
+
+Stable releases use SemVer:
+
+```text
+v1.2.3
+```
+
+Python prerelease-style tags are also supported and are converted for Rust/npm:
+
+| Release tag | Python version | Rust/npm version | npm dist tag |
+| --- | --- | --- | --- |
+| `v0.15.0a1` | `0.15.0a1` | `0.15.0-alpha.1` | `next` |
+| `v0.15.0b2` | `0.15.0b2` | `0.15.0-beta.2` | `next` |
+| `v0.15.0rc3` | `0.15.0rc3` | `0.15.0-rc.3` | `next` |
+| `v1.2.3` | `1.2.3` | `1.2.3` | `latest` |
+
+## Release workflow
+
+The release workflow is:
+
+```text
+.github/workflows/on-release-main.yml
+```
+
+It runs when a GitHub Release is published and can also be run manually with `workflow_dispatch`.
+
+It publishes:
+
+- Python package to PyPI,
+- Rust crates to crates.io,
+- TypeScript package to Atlassian npm-public,
+- documentation to GitHub Pages.
+
+## Python publish
+
+Python publishing uses PyPI trusted publishing from:
+
+```text
+.github/workflows/on-release-main.yml
+```
+
+The workflow patches the package version from the release tag and publishes the `mcp-compressor` wheel/sdist with:
+
+```bash
+uv publish --trusted-publishing always dist/*
+```
+
+No PyPI token should be needed when the trusted publisher is configured on PyPI for this repository/workflow.
+
+## Rust publish
+
+Rust publishing uses crates.io token auth with the repository secret:
+
+```text
+CARGO_REGISTRY_TOKEN
+```
+
+The workflow patches Cargo versions from the release tag, publishes the implementation crate first, waits for the crates.io index, then publishes the public crate.
+
+The public crate is:
+
+```text
+mcp-compressor
+```
+
+It includes the installable binary:
+
+```bash
+cargo install mcp-compressor
+mcp-compressor --help
+```
+
+## TypeScript publish
+
+TypeScript publishing uses Atlassian's npm-public Artifactory flow.
+
+The main release workflow does **not** publish TypeScript directly from the tag ref. Artifactory npm-public publishing requires branch-based GitHub OIDC claims, so the release workflow:
+
+1. checks out the release tag,
+2. writes `.release-tag`,
+3. force-updates the dedicated `release` branch,
+4. dispatches:
+
+   ```text
+   .github/workflows/publish-typescript-package.yml
+   ```
+
+   on the `release` branch,
+5. waits for the dispatched workflow to complete.
+
+The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds the native addon, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
+
+For prereleases, npm publish uses:
+
+```text
+--tag next
+```
+
+For stable releases, it uses:
+
+```text
+--tag latest
+```
+
+### Required npm-public configuration
+
+The package must be configured in Atlassian Artifactory npm-public allowlists. At the time this was set up, the relevant internal configuration was in:
+
+```text
+bitbucket.org/atlassian/buildeng-artifactory-configuration
+```
+
+The package paths should include:
+
+```text
+@atlassian/mcp-compressor/**
+.npm/@atlassian/mcp-compressor/**
+```
+
+The workflow uses:
+
+```yaml
+atlassian-labs/artifact-publish-token@v1.0.1
+```
+
+with `output-modes: npm` to create `.npmrc-public`.
+
+## Manual TypeScript fallback
+
+If GitHub Actions publishing is blocked by Artifactory permissions, maintainers can publish locally after obtaining permission:
+
+```bash
+atlas packages permission grant
+cd typescript
+bun run build
+bun run build:native
+npm version 0.15.0-alpha.1 --no-git-tag-version
+npm publish --tag next
+git checkout -- package.json bun.lock
+```
+
+Use `--tag latest` for stable releases.
+
+!!! warning
+    Local publishing only builds the native addon for the current platform. Prefer the GitHub workflow for official releases.
+
+## Docs publish
+
+Docs are deployed by the release workflow with:
+
+```bash
+uv run mkdocs gh-deploy --force
+```
+
+The docs job has `contents: write` permission so it can push to `gh-pages`.
+
+## Validation before releasing
+
+Before creating a release, run:
+
+```bash
+make check
+make docs-test
+cargo check -p mcp-compressor
+cargo check -p mcp-compressor-core
+cargo check -p mcp-compressor-python
+cargo check -p mcp-compressor-node
+```
+
+For a high-confidence release, also verify the release artifact smoke workflows are green on `main`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - API status: reference/api-status.md
       - API modules: modules.md
   - Development:
+      - Release process: development-release.md
       - LLM assist design: llm-assist-design.md
       - Internal implementation notes: rust-core-design.md
 plugins:


### PR DESCRIPTION
## Summary
- add a release process page covering Python, Rust, TypeScript, and docs publication
- document the TypeScript release-branch dispatch used for Artifactory npm-public OIDC
- document required credentials/config and local TypeScript fallback
- link the page from MkDocs navigation and AGENTS.md

## Validation
- make docs-test
- make check