### PR TITLE
docs: remove implementation details from user docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Use this when your application wants to embed compression directly and call tool
 flowchart LR
     App[Python / TypeScript / Rust app]
     SDK[CompressorClient]
-    Proxy[Local Rust proxy\n/token auth]
+    Proxy[Local session proxy\n/token auth]
     Generated[Generated CLI / Python / TS clients]
     Backend[MCP backend servers]
 
@@ -71,7 +71,7 @@ flowchart LR
     Proxy --> Backend
 ```
 
-The SDK starts the Rust proxy in-process. Generated clients call that proxy using a session token. Your app does **not** need to spawn a `mcp-compressor` stdio subprocess.
+The SDK starts a local session proxy for generated clients. Generated clients call that proxy using a session token. Your app does **not** need to spawn a `mcp-compressor` stdio subprocess.
 
 ## Features
 

--- a/docs/usage/auth-and-remote.md
+++ b/docs/usage/auth-and-remote.md
@@ -11,7 +11,7 @@ Most hosted MCP servers require authentication. `mcp-compressor` supports two pa
 
 When a remote backend requires OAuth and you do not provide an explicit `Authorization` header, `mcp-compressor` starts the native OAuth flow:
 
-1. discovers provider metadata,
+1. discovers the provider's OAuth endpoints,
 2. opens a browser to authorize,
 3. listens on a local loopback callback URL,
 4. exchanges the code for tokens,

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -33,7 +33,7 @@ mcp-compressor -c medium --transport streamable-http --port 9000 -- python serve
 
 ## CLI mode
 
-CLI mode writes a shell script that calls a local Rust proxy.
+CLI mode writes a shell script that calls the live local session created by `mcp-compressor`.
 
 ```bash
 mcp-compressor --cli-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
@@ -54,7 +54,7 @@ mcp-compressor --cli-mode --server-name alpha --output-dir ./bin -- python serve
 
 ## Code Mode
 
-Code Mode generates Python or TypeScript functions for backend MCP tools while keeping the local Rust proxy alive. By default, generated Code Mode files are written under `./dist` in the current working directory.
+Code Mode generates Python or TypeScript functions for backend MCP tools while keeping the local `mcp-compressor` session alive. By default, generated Code Mode files are written under `./dist` in the current working directory.
 
 ```bash
 mcp-compressor --code-mode python --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
@@ -70,4 +70,4 @@ See [Code Mode and generated clients](generated-clients.md) for examples of gene
 mcp-compressor --just-bash-mode --server-name atlassian -- https://mcp.atlassian.com/v1/mcp
 ```
 
-Just Bash mode exposes provider metadata for language hosts to register commands. See [Just Bash](just-bash.md).
+Just Bash mode lets language hosts register MCP tools as shell-style commands. See [Just Bash](just-bash.md).

--- a/docs/usage/just-bash.md
+++ b/docs/usage/just-bash.md
@@ -1,20 +1,13 @@
 # Just Bash
 
-Just Bash mode exposes MCP tools as command metadata that a language host can register with `just-bash`.
+Just Bash mode lets command-oriented agents call MCP tools as shell-style commands.
 
-Rust owns:
+Use it when your agent already has a Just Bash environment and you want MCP tools to appear as commands such as:
 
-- MCP backend connections,
-- compression,
-- schema-driven argument parsing,
-- proxy routing,
-- provider metadata.
-
-The language host owns:
-
-- Just Bash environment setup,
-- command registration,
-- command execution UX.
+```text
+alpha_echo --message hello
+beta_search --query "release notes"
+```
 
 ## TypeScript host helper
 
@@ -25,7 +18,7 @@ import { CompressorClient, installJustBashCommands } from "@atlassian/mcp-compre
 const proxy = await new CompressorClient({ servers, mode: "bash" }).connect();
 try {
   const bash = new Bash({ customCommands: [] });
-  const registrations = installJustBashCommands(bash, proxy);
+  installJustBashCommands(bash, proxy);
 
   const result = await bash.exec("alpha_echo --message hello");
   console.log(result.stdout);
@@ -49,24 +42,44 @@ with CompressorClient(servers=servers, mode="bash") as proxy:
     print(bash.custom_commands["alpha_echo"](["--message", "hello"]))
 ```
 
+## Local tool functions
+
+If your application already has executable tool functions in memory, you can install them directly into a Bash host without connecting to an MCP server.
+
+=== "TypeScript"
+
+    ```ts
+    import { transformToolsForJustBash } from "@atlassian/mcp-compressor";
+
+    const result = transformToolsForJustBash(tools, {
+      bash,
+      serverName: "alpha",
+    });
+
+    await bash.exec("alpha_echo --message hello");
+    ```
+
+=== "Python"
+
+    ```python
+    from mcp_compressor import transform_tools_for_just_bash
+
+    result = transform_tools_for_just_bash(
+        tools,
+        bash=bash,
+        server_name="alpha",
+    )
+    ```
+
 ## Command names and collisions
 
-If two servers expose the same backend command name, helpers prefix the command with the provider/server name:
+Commands are prefixed with the server name so multiple servers can expose tools with the same backend name without shadowing each other:
 
 ```text
 alpha_echo
 beta_echo
 ```
 
-This avoids one server shadowing another.
+## Lifecycle
 
-## Metadata shape
-
-Provider metadata includes:
-
-- provider name,
-- help tool name,
-- command name,
-- backend tool name,
-- input schema,
-- invoke wrapper name.
+Generated commands call the active `mcp-compressor` session or the local tool functions you provided. Keep that session or host application alive for as long as the agent needs to run the commands.

--- a/docs/usage/sdks.md
+++ b/docs/usage/sdks.md
@@ -219,7 +219,7 @@ The SDKs expose the same main compression options as the CLI.
 |---|---|
 | `compressed` | Standard `get_tool_schema` / `invoke_tool` compressed surface. |
 | `cli` | Help-tool-oriented surface for generated shell command usage. |
-| `bash` | Just Bash provider metadata plus proxy routing. |
+| `bash` | Just Bash command integration for command-oriented agents. |
 
 === "Python"
 

--- a/python/mcp-compressor/README.md
+++ b/python/mcp-compressor/README.md
@@ -10,7 +10,7 @@ from mcp_compressor import CompressorClient
 
 ## Quick start
 
-The primary SDK object is `CompressorClient`. It starts a local Rust-backed proxy in-process and returns a `CompressorProxy`; no `mcp-compressor` stdio subprocess is required.
+The primary SDK object is `CompressorClient`. It starts a local session and returns a `CompressorProxy`; no `mcp-compressor` stdio subprocess is required.
 
 ```python
 from mcp_compressor import CompressorClient
@@ -46,14 +46,14 @@ with CompressorClient(
 `CompressorClient` accepts these modes:
 
 - `compressed` — expose compressed wrapper tools such as `<server>_get_tool_schema` and `<server>_invoke_tool`.
-- `cli` — expose CLI/help transform metadata through the shared Rust runtime.
-- `bash` — expose Just Bash provider metadata through the shared Rust runtime.
+- `cli` — expose CLI/help tools for generated shell command usage.
+- `bash` — expose Just Bash command integration for command-oriented agents.
 
 Generated Python and TypeScript clients are produced with `proxy.write_client(...)` rather than by selecting a long-lived session mode.
 
 ## Just Bash metadata
 
-Just Bash mode exposes the compressed proxy bridge plus typed provider metadata. Language hosts can use this metadata to register backend MCP tools as Just Bash commands without the Rust runtime executing shell commands itself:
+Just Bash mode lets language hosts register backend MCP tools as shell-style commands:
 
 ```python
 from mcp_compressor import CompressorClient, create_just_bash_commands

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -277,7 +277,7 @@ try {
 
 The package root now exposes the Rust-backed `CompressorClient` as the primary SDK surface on the migration trunk.
 
-Just Bash mode exposes typed provider metadata so language hosts can register backend MCP tools as Just Bash commands while Rust owns compression/proxy routing:
+Just Bash mode lets language hosts register backend MCP tools as Just Bash commands:
 
 ```ts
 const proxy = await new CompressorClient({ servers, mode: "bash" }).connect();


### PR DESCRIPTION
## Summary

- Removes implementation-specific wording from user-facing docs and package READMEs.
- Rewrites the Just Bash usage page to describe user outcomes instead of internal ownership/provider metadata.
- Rephrases CLI/Code Mode docs around live mcp-compressor sessions rather than a Rust proxy.
- Keeps implementation/architecture details confined to architecture/development guidance.

## Validation

- Searched public docs/package READMEs for stale phrases such as `Rust owns`, `Rust-backed`, `Rust runtime`, `provider metadata`, `proxy routing`, `MCP backend connections`, and `schema-driven argument parsing`.
- make docs-test
- make check