### PR TITLE
Avoid recursive Python CLI delegation

### DIFF
--- a/python/mcp-compressor/mcp_compressor/cli.py
+++ b/python/mcp-compressor/mcp_compressor/cli.py
@@ -4,17 +4,32 @@ from __future__ import annotations
 
 import os
 import signal
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+
+def _resolved_executable(command: str) -> Path | None:
+    resolved = shutil.which(command)
+    if resolved is None:
+        return None
+    return Path(resolved).resolve()
+
+
+def _is_current_entrypoint(command: str) -> bool:
+    resolved_command = _resolved_executable(command)
+    resolved_entrypoint = _resolved_executable(sys.argv[0])
+    return resolved_command is not None and resolved_command == resolved_entrypoint
 
 
 def _candidate_binaries() -> list[str]:
     env_binary = os.environ.get("MCP_COMPRESSOR_BINARY") or os.environ.get("MCP_COMPRESSOR_CORE_BINARY")
     candidates: list[str] = []
     if env_binary:
-        return [env_binary]
-    candidates.append("mcp-compressor")
+        return [] if _is_current_entrypoint(env_binary) else [env_binary]
+    if not _is_current_entrypoint("mcp-compressor"):
+        candidates.append("mcp-compressor")
     repo_binary = Path(__file__).resolve().parents[3] / "target" / "debug" / "mcp-compressor"
     candidates.append(str(repo_binary))
     return candidates

--- a/python/mcp-compressor/tests/test_cli.py
+++ b/python/mcp-compressor/tests/test_cli.py
@@ -57,6 +57,27 @@ def test_python_cli_reports_missing_rust_core_binary(monkeypatch) -> None:
     assert main(["--help"]) == 127
 
 
+def test_python_cli_skips_self_resolving_console_script(tmp_path: Path, monkeypatch) -> None:
+    script = tmp_path / "mcp-compressor"
+    script.write_text("#!/bin/sh\nexec mcp-compressor \"$@\"\n")
+    script.chmod(0o755)
+    commands: list[list[str]] = []
+
+    def popen(command: list[str]) -> None:
+        commands.append(command)
+        raise FileNotFoundError(command[0])
+
+    monkeypatch.delenv("MCP_COMPRESSOR_BINARY", raising=False)
+    monkeypatch.delenv("MCP_COMPRESSOR_CORE_BINARY", raising=False)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setattr("sys.argv", [str(script)])
+    monkeypatch.setattr("subprocess.Popen", popen)
+
+    assert main(["--help"]) == 127
+    assert [str(script), "--help"] not in commands
+    assert ["mcp-compressor", "--help"] not in commands
+
+
 def test_python_cli_ctrl_c_terminates_child_without_traceback(monkeypatch) -> None:
     process = InterruptingProcess(["mcp-compressor"])
 


### PR DESCRIPTION
## Summary

- skip a candidate `mcp-compressor` executable when it resolves to the same console script that is currently running
- apply the same guard to explicit `MCP_COMPRESSOR_BINARY` / `MCP_COMPRESSOR_CORE_BINARY` values that point back at the Python entrypoint
- add a regression test for a self-resolving console script so the wrapper reports a missing core binary instead of recursively spawning itself

Fixes #183.

## Validation

- `python3 -m py_compile python/mcp-compressor/mcp_compressor/cli.py python/mcp-compressor/tests/test_cli.py`
- direct importlib smoke check for the self-recursion guard
