### PR TITLE
fix: run python cli from packaged extension

### DIFF
--- a/crates/mcp-compressor-core/src/app/entrypoint.rs
+++ b/crates/mcp-compressor-core/src/app/entrypoint.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{error::ErrorKind, Parser};
 
 use crate::app::options::{CliCommand, CliOptions, LlmCommand, MultiServerArg};
 use crate::app::runtime::{run_cli_mode, run_compressed_server, run_just_bash_mode};
@@ -13,6 +13,10 @@ use crate::server::{
 pub fn main_exit_code() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
+        Err(CliError::Display(message)) => {
+            print!("{message}");
+            ExitCode::SUCCESS
+        }
         Err(CliError::Usage(message)) => {
             eprintln!("error: {message}");
             ExitCode::from(2)
@@ -25,7 +29,21 @@ pub fn main_exit_code() -> ExitCode {
 }
 
 pub fn run() -> Result<(), CliError> {
-    let cli = CliOptions::parse();
+    run_from(std::env::args())
+}
+
+pub fn run_from<I, T>(args: I) -> Result<(), CliError>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    let cli = CliOptions::try_parse_from(args).map_err(|error| {
+        if matches!(error.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+            CliError::Display(error.to_string())
+        } else {
+            CliError::Usage(error.to_string())
+        }
+    })?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -181,6 +199,7 @@ async fn run_llm_command(command: &LlmCommand) -> Result<(), CliError> {
 
 #[derive(Debug)]
 pub enum CliError {
+    Display(String),
     Usage(String),
     Runtime(String),
 }

--- a/crates/mcp-compressor-python/src/lib.rs
+++ b/crates/mcp-compressor-python/src/lib.rs
@@ -214,6 +214,26 @@ fn clear_oauth_credentials_json(target: Option<&str>) -> PyResult<String> {
     serde_json::to_string(&values).map_err(py_value_error)
 }
 
+#[pyfunction]
+fn run_cli_json(argv_json: &str) -> PyResult<i32> {
+    let argv: Vec<String> = parse_json(argv_json)?;
+    match mcp_compressor_core::app::entrypoint::run_from(argv) {
+        Ok(()) => Ok(0),
+        Err(mcp_compressor_core::app::entrypoint::CliError::Display(message)) => {
+            print!("{message}");
+            Ok(0)
+        }
+        Err(mcp_compressor_core::app::entrypoint::CliError::Usage(message)) => {
+            eprintln!("error: {message}");
+            Ok(2)
+        }
+        Err(mcp_compressor_core::app::entrypoint::CliError::Runtime(message)) => {
+            eprintln!("error: {message}");
+            Ok(1)
+        }
+    }
+}
+
 #[pymodule]
 fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyCompressedSession>()?;
@@ -229,5 +249,6 @@ fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(start_compressed_session_from_mcp_config_json, module)?)?;
     module.add_function(wrap_pyfunction!(list_oauth_credentials_json, module)?)?;
     module.add_function(wrap_pyfunction!(clear_oauth_credentials_json, module)?)?;
+    module.add_function(wrap_pyfunction!(run_cli_json, module)?)?;
     Ok(())
 }

--- a/python/mcp-compressor/mcp_compressor/cli.py
+++ b/python/mcp-compressor/mcp_compressor/cli.py
@@ -1,72 +1,21 @@
-"""Rust-backed mcp-compressor CLI entrypoint for the Python package."""
+"""Console entrypoint for the Python package."""
 
 from __future__ import annotations
 
-import os
-import shutil
-import signal
-import subprocess
+import json
 import sys
-from pathlib import Path
 
-
-def _resolved_executable(command: str) -> Path | None:
-    resolved = shutil.which(command)
-    if resolved is None:
-        return None
-    return Path(resolved).resolve()
-
-
-def _is_current_entrypoint(command: str) -> bool:
-    resolved_command = _resolved_executable(command)
-    resolved_entrypoint = _resolved_executable(sys.argv[0])
-    return resolved_command is not None and resolved_command == resolved_entrypoint
-
-
-def _candidate_binaries() -> list[str]:
-    env_binary = os.environ.get("MCP_COMPRESSOR_BINARY") or os.environ.get("MCP_COMPRESSOR_CORE_BINARY")
-    candidates: list[str] = []
-    if env_binary:
-        return [] if _is_current_entrypoint(env_binary) else [env_binary]
-    if not _is_current_entrypoint("mcp-compressor"):
-        candidates.append("mcp-compressor")
-    repo_binary = Path(__file__).resolve().parents[3] / "target" / "debug" / "mcp-compressor"
-    candidates.append(str(repo_binary))
-    return candidates
-
-
-def _run_child(command: list[str]) -> int:
-    child = subprocess.Popen(command)  # noqa: S603 - controlled CLI delegation
-    try:
-        return int(child.wait())
-    except KeyboardInterrupt:
-        child.terminate()
-        try:
-            child.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            child.kill()
-            child.wait()
-        return 128 + signal.SIGINT
+from mcp_compressor import _native
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the Rust core CLI, preserving stdio and process semantics."""
+    """Run the packaged mcp-compressor CLI.
+
+    The Python package ships the native extension, so the console script should
+    not require a separately installed or locally built Rust binary.
+    """
     args = sys.argv[1:] if argv is None else argv
-    last_error: OSError | None = None
-    for binary in _candidate_binaries():
-        try:
-            return _run_child([binary, *args])
-        except FileNotFoundError as exc:
-            last_error = exc
-            continue
-    print(
-        "mcp-compressor binary was not found. Build it with `cargo build -p mcp-compressor-core` "
-        "or set MCP_COMPRESSOR_BINARY.",
-        file=sys.stderr,
-    )
-    if last_error is not None:
-        print(str(last_error), file=sys.stderr)
-    return 127
+    return int(_native.run_cli_json(json.dumps(["mcp-compressor", *args])))
 
 
 def entrypoint() -> None:

--- a/python/mcp-compressor/pyproject.toml
+++ b/python/mcp-compressor/pyproject.toml
@@ -40,3 +40,4 @@ ignore = ["E501"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]
+"tests/test_cli.py" = ["S603"]

--- a/python/mcp-compressor/tests/test_cli.py
+++ b/python/mcp-compressor/tests/test_cli.py
@@ -1,108 +1,27 @@
 from __future__ import annotations
 
-import os
-import signal
-from pathlib import Path
-
-from mcp_compressor.cli import main
+import subprocess
+import sys
 
 
-class InterruptingProcess:
-    def __init__(self, command: list[str]) -> None:
-        self.command = command
-        self.terminated = False
-        self.killed = False
-        self.wait_calls = 0
-
-    def wait(self, timeout: float | None = None) -> int:
-        self.wait_calls += 1
-        if timeout is None and self.wait_calls == 1:
-            raise KeyboardInterrupt
-        return -signal.SIGTERM
-
-    def terminate(self) -> None:
-        self.terminated = True
-
-    def kill(self) -> None:
-        self.killed = True
+def test_python_cli_runs_packaged_native_help() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "mcp_compressor.cli", "--help"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "mcp-compressor" in result.stdout
 
 
-class StubbornInterruptingProcess(InterruptingProcess):
-    def wait(self, timeout: float | None = None) -> int:
-        self.wait_calls += 1
-        if timeout is None and self.wait_calls == 1:
-            raise KeyboardInterrupt
-        if timeout is not None:
-            import subprocess
-
-            raise subprocess.TimeoutExpired(self.command, timeout)
-        return -signal.SIGKILL
-
-
-def test_python_cli_delegates_to_rust_core_binary(tmp_path: Path, monkeypatch) -> None:
-    log = tmp_path / "argv.txt"
-    binary = tmp_path / "mcp-compressor"
-    binary.write_text('#!/bin/sh\nprintf \'%s\\n\' "$@" > "$MCP_COMPRESSOR_TEST_LOG"\nexit 7\n')
-    binary.chmod(0o755)
-    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", str(binary))
-    monkeypatch.setenv("MCP_COMPRESSOR_TEST_LOG", str(log))
-
-    assert main(["--version"]) == 7
-    assert log.read_text().strip() == "--version"
-
-
-def test_python_cli_reports_missing_rust_core_binary(monkeypatch) -> None:
-    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", os.devnull + "-missing")
-    monkeypatch.setenv("PATH", "")
-    assert main(["--help"]) == 127
-
-
-def test_python_cli_skips_self_resolving_console_script(tmp_path: Path, monkeypatch) -> None:
-    script = tmp_path / "mcp-compressor"
-    script.write_text('#!/bin/sh\nexec mcp-compressor "$@"\n')
-    script.chmod(0o755)
-    commands: list[list[str]] = []
-
-    def popen(command: list[str]) -> None:
-        commands.append(command)
-        raise FileNotFoundError(command[0])
-
-    monkeypatch.delenv("MCP_COMPRESSOR_BINARY", raising=False)
-    monkeypatch.delenv("MCP_COMPRESSOR_CORE_BINARY", raising=False)
-    monkeypatch.setenv("PATH", str(tmp_path))
-    monkeypatch.setattr("sys.argv", [str(script)])
-    monkeypatch.setattr("subprocess.Popen", popen)
-
-    assert main(["--help"]) == 127
-    assert [str(script), "--help"] not in commands
-    assert ["mcp-compressor", "--help"] not in commands
-
-
-def test_python_cli_ctrl_c_terminates_child_without_traceback(monkeypatch) -> None:
-    process = InterruptingProcess(["mcp-compressor"])
-
-    def popen(command: list[str]) -> InterruptingProcess:
-        process.command = command
-        return process
-
-    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", "mcp-compressor")
-    monkeypatch.setattr("subprocess.Popen", popen)
-
-    assert main(["--cli-mode"]) == 128 + signal.SIGINT
-    assert process.terminated
-    assert not process.killed
-
-
-def test_python_cli_ctrl_c_kills_stubborn_child(monkeypatch) -> None:
-    process = StubbornInterruptingProcess(["mcp-compressor"])
-
-    def popen(command: list[str]) -> StubbornInterruptingProcess:
-        process.command = command
-        return process
-
-    monkeypatch.setenv("MCP_COMPRESSOR_BINARY", "mcp-compressor")
-    monkeypatch.setattr("subprocess.Popen", popen)
-
-    assert main(["--cli-mode"]) == 128 + signal.SIGINT
-    assert process.terminated
-    assert process.killed
+def test_python_cli_reports_usage_errors() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "mcp_compressor.cli", "--definitely-not-a-real-option"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "error:" in result.stderr


### PR DESCRIPTION
## Summary

- Fixes the Python package console script so it runs the packaged native extension directly instead of trying to find an external `target/debug/mcp-compressor` binary.
- Adds a Rust entrypoint helper that accepts explicit argv so PyO3 can invoke the same CLI code path as the standalone binary.
- Handles Clap help/version display as successful output rather than usage errors.
- Replaces subprocess-delegation tests with packaged native CLI tests.

## Validation

- Built a release wheel with `uvx maturin build --release --out dist`.
- Installed that wheel into a clean venv and verified:
  - `mcp-compressor --help`
  - `mcp-compressor --version`
- `cd python/mcp-compressor && uv run maturin develop && uv run pytest -q tests/test_cli.py && uv run ruff check mcp_compressor tests && uv run ruff format --check mcp_compressor tests && uv run ty check --project . --python .venv mcp_compressor tests`
- `cargo check -p mcp-compressor-core -p mcp-compressor-python`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary -- --nocapture`
- `make check`
