### PR TITLE
ci: publish cross-platform native packages

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -51,7 +51,17 @@ jobs:
           VERSION="$(python scripts/prepare_python_release.py "$TAG")"
           echo "Building Python wheel at version $VERSION"
 
-      - name: Build wheel
+      - name: Build Linux wheel in manylinux image
+        if: runner.os == 'Linux'
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          working-directory: python/mcp-compressor
+          args: --release --out dist
+          manylinux: auto
+
+      - name: Build non-Linux wheel
+        if: runner.os != 'Linux'
         working-directory: python/mcp-compressor
         run: uvx maturin build --release --out dist
 

--- a/.github/workflows/publish-typescript-package.yml
+++ b/.github/workflows/publish-typescript-package.yml
@@ -17,9 +17,60 @@ permissions:
   id-token: write
 
 jobs:
+  build-typescript-native-addons:
+    name: Build TypeScript native addon (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact-suffix: linux-x64-gnu
+          - os: macos-latest
+            artifact-suffix: darwin-arm64
+          - os: macos-13
+            artifact-suffix: darwin-x64
+          - os: windows-latest
+            artifact-suffix: win32-x64-msvc
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Check out release branch
+        uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build native addon
+        run: bun run build:native
+
+      - name: Upload native addon
+        uses: actions/upload-artifact@v4
+        with:
+          name: typescript-native-${{ matrix.artifact-suffix }}
+          path: |
+            typescript/native/index.js
+            typescript/native/index.d.ts
+            typescript/native/package.json
+            typescript/native/*.node
+          if-no-files-found: error
+
   publish-typescript-package:
     name: Publish TypeScript package
     runs-on: ubuntu-latest
+    needs: build-typescript-native-addons
     defaults:
       run:
         working-directory: typescript
@@ -83,10 +134,19 @@ jobs:
           PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: bun run check:ci
 
-      - name: Build TypeScript package and native addon
-        run: |
-          bun run build
-          bun run build:native
+      - name: Build TypeScript package
+        run: bun run build
+
+      - name: Download cross-platform native addons
+        uses: actions/download-artifact@v4
+        with:
+          pattern: typescript-native-*
+          path: typescript/native
+          merge-multiple: true
+
+      - name: List bundled native addons
+        working-directory: .
+        run: ls -lh typescript/native
 
       - name: Pack package
         shell: bash

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -48,7 +48,7 @@ Python publishing uses PyPI trusted publishing from:
 .github/workflows/on-release-main.yml
 ```
 
-The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS, and Windows across supported CPython versions, builds one source distribution, and publishes them with:
+The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS, and Windows across supported CPython versions, builds Linux wheels in a manylinux image for broad distro compatibility, builds one source distribution, and publishes them with:
 
 ```bash
 uv publish --trusted-publishing always dist/*
@@ -97,7 +97,7 @@ The main release workflow does **not** publish TypeScript directly from the tag 
    on the `release` branch,
 5. waits for the dispatched workflow to complete.
 
-The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds the native addon, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
+The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds native addons on Linux, macOS, and Windows, bundles those native addons into the package, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
 
 For prereleases, npm publish uses:
 


### PR DESCRIPTION
## Summary

- Builds Python Linux wheels in a manylinux image for broader distro compatibility.
- Keeps macOS and Windows Python wheels in the release matrix across CPython 3.11-3.14.
- Builds TypeScript native addons on Linux, macOS arm64, macOS x64, and Windows.
- Downloads those platform addons into the TypeScript publish job before packing so the npm package includes all supported `.node` binaries.
- Updates release docs to describe the cross-platform wheel/addon strategy.

## Why

Python previously published only a Linux/cp312 wheel plus sdist, causing macOS/Python 3.14 `uvx` installs to compile locally. TypeScript similarly bundled only the native addon from the publish runner. Both need broad platform coverage for public package consumption.

## Validation

- Parsed `.github/workflows/on-release-main.yml` and `.github/workflows/publish-typescript-package.yml` with PyYAML.
- `make docs-test`
- `make check`
