### PR TITLE
fix: stabilize cross-platform release wheels

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -20,13 +20,64 @@ permissions:
 
 jobs:
   build-python-wheels:
-    name: Build Python wheel (${{ matrix.os }}, py${{ matrix.python-version }})
+    name: Build Python wheel (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          - target: linux-x86_64-cp311
+            os: ubuntu-latest
+            python-version: "3.11"
+            manylinux-python: /opt/python/cp311-cp311/bin/python
+          - target: linux-x86_64-cp312
+            os: ubuntu-latest
+            python-version: "3.12"
+            manylinux-python: /opt/python/cp312-cp312/bin/python
+          - target: linux-x86_64-cp313
+            os: ubuntu-latest
+            python-version: "3.13"
+            manylinux-python: /opt/python/cp313-cp313/bin/python
+          - target: linux-x86_64-cp314
+            os: ubuntu-latest
+            python-version: "3.14"
+            manylinux-python: /opt/python/cp314-cp314/bin/python
+          - target: macos-arm64-cp311
+            os: macos-latest
+            python-version: "3.11"
+          - target: macos-arm64-cp312
+            os: macos-latest
+            python-version: "3.12"
+          - target: macos-arm64-cp313
+            os: macos-latest
+            python-version: "3.13"
+          - target: macos-arm64-cp314
+            os: macos-latest
+            python-version: "3.14"
+          - target: macos-x86_64-cp311
+            os: macos-13
+            python-version: "3.11"
+          - target: macos-x86_64-cp312
+            os: macos-13
+            python-version: "3.12"
+          - target: macos-x86_64-cp313
+            os: macos-13
+            python-version: "3.13"
+          - target: macos-x86_64-cp314
+            os: macos-13
+            python-version: "3.14"
+          - target: windows-x86_64-cp311
+            os: windows-latest
+            python-version: "3.11"
+          - target: windows-x86_64-cp312
+            os: windows-latest
+            python-version: "3.12"
+          - target: windows-x86_64-cp313
+            os: windows-latest
+            python-version: "3.13"
+          - target: windows-x86_64-cp314
+            os: windows-latest
+            python-version: "3.14"
     steps:
       - name: Check out release ref
         uses: actions/checkout@v6
@@ -57,7 +108,7 @@ jobs:
         with:
           command: build
           working-directory: python/mcp-compressor
-          args: --release --out dist
+          args: --release --out dist --interpreter ${{ matrix.manylinux-python }}
           manylinux: auto
 
       - name: Build non-Linux wheel
@@ -91,7 +142,7 @@ jobs:
       - name: Upload Python wheel
         uses: actions/upload-artifact@v4
         with:
-          name: python-wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: python-wheel-${{ matrix.target }}
           path: python/mcp-compressor/dist/*.whl
           if-no-files-found: error
 

--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -18,16 +18,21 @@ pub struct CliGenerator;
 
 impl ClientGenerator for CliGenerator {
     fn render(&self, config: &GeneratorConfig) -> Result<Vec<GeneratedArtifact>, Error> {
-        let artifacts = vec![GeneratedArtifact::new(&config.cli_name, render_unix_script(config)).executable()];
-
-        #[cfg(windows)]
-        artifacts.push(GeneratedArtifact::new(
-            format!("{}.cmd", config.cli_name),
-            render_windows_cmd(config),
-        ));
-
-        Ok(artifacts)
+        Ok(render_cli_artifacts(config))
     }
+}
+
+#[cfg(not(windows))]
+fn render_cli_artifacts(config: &GeneratorConfig) -> Vec<GeneratedArtifact> {
+    vec![GeneratedArtifact::new(&config.cli_name, render_unix_script(config)).executable()]
+}
+
+#[cfg(windows)]
+fn render_cli_artifacts(config: &GeneratorConfig) -> Vec<GeneratedArtifact> {
+    vec![
+        GeneratedArtifact::new(&config.cli_name, render_unix_script(config)).executable(),
+        GeneratedArtifact::new(format!("{}.cmd", config.cli_name), render_windows_cmd(config)),
+    ]
 }
 
 fn render_unix_script(config: &GeneratorConfig) -> String {

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -48,7 +48,7 @@ Python publishing uses PyPI trusted publishing from:
 .github/workflows/on-release-main.yml
 ```
 
-The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS, and Windows across supported CPython versions, builds Linux wheels in a manylinux image for broad distro compatibility, builds one source distribution, and publishes them with:
+The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS, and Windows across supported CPython versions, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform/Python tag, builds one source distribution, and publishes them with:
 
 ```bash
 uv publish --trusted-publishing always dist/*


### PR DESCRIPTION
## Summary

- Fixes the Windows-only CLI generator compile error by moving platform artifact construction behind cfg-specific helper functions.
- Changes Python wheel job names from runner names to target names such as `linux-x86_64-cp312` and `windows-x86_64-cp314`.
- Passes explicit manylinux Python interpreter paths to maturin for Linux wheel builds instead of relying on `python3` inside the manylinux container.
- Updates release docs to mention target-labeled wheel jobs.

## Why

The latest release showed two issues:

- Windows wheel builds failed because a vector was only mutated behind `#[cfg(windows)]` but not declared mutable.
- Linux manylinux builds failed with `Couldn't find any python interpreters from 'python3'`; the workflow now uses the explicit `/opt/python/cpXXX.../bin/python` interpreters provided by manylinux images.

## Validation

- `cargo test -p mcp-compressor-core client_gen::cli -- --nocapture`
- `cargo check -p mcp-compressor-core`
- Parsed `.github/workflows/on-release-main.yml` with PyYAML.
- `make docs-test`
- `make check`
