### PR TITLE
ci: avoid scarce macos release runners

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -30,54 +30,54 @@ jobs:
             os: ubuntu-latest
             python-version: "3.11"
             manylinux-python: /opt/python/cp311-cp311/bin/python
+            maturin-target: ""
           - target: linux-x86_64-cp312
             os: ubuntu-latest
             python-version: "3.12"
             manylinux-python: /opt/python/cp312-cp312/bin/python
+            maturin-target: ""
           - target: linux-x86_64-cp313
             os: ubuntu-latest
             python-version: "3.13"
             manylinux-python: /opt/python/cp313-cp313/bin/python
+            maturin-target: ""
           - target: linux-x86_64-cp314
             os: ubuntu-latest
             python-version: "3.14"
             manylinux-python: /opt/python/cp314-cp314/bin/python
-          - target: macos-arm64-cp311
+            maturin-target: ""
+          - target: macos-universal2-cp311
             os: macos-latest
             python-version: "3.11"
-          - target: macos-arm64-cp312
+            maturin-target: universal2-apple-darwin
+          - target: macos-universal2-cp312
             os: macos-latest
             python-version: "3.12"
-          - target: macos-arm64-cp313
+            maturin-target: universal2-apple-darwin
+          - target: macos-universal2-cp313
             os: macos-latest
             python-version: "3.13"
-          - target: macos-arm64-cp314
+            maturin-target: universal2-apple-darwin
+          - target: macos-universal2-cp314
             os: macos-latest
             python-version: "3.14"
-          - target: macos-x86_64-cp311
-            os: macos-13
-            python-version: "3.11"
-          - target: macos-x86_64-cp312
-            os: macos-13
-            python-version: "3.12"
-          - target: macos-x86_64-cp313
-            os: macos-13
-            python-version: "3.13"
-          - target: macos-x86_64-cp314
-            os: macos-13
-            python-version: "3.14"
+            maturin-target: universal2-apple-darwin
           - target: windows-x86_64-cp311
             os: windows-latest
             python-version: "3.11"
+            maturin-target: ""
           - target: windows-x86_64-cp312
             os: windows-latest
             python-version: "3.12"
+            maturin-target: ""
           - target: windows-x86_64-cp313
             os: windows-latest
             python-version: "3.13"
+            maturin-target: ""
           - target: windows-x86_64-cp314
             os: windows-latest
             python-version: "3.14"
+            maturin-target: ""
     steps:
       - name: Check out release ref
         uses: actions/checkout@v6
@@ -112,9 +112,14 @@ jobs:
           manylinux: auto
 
       - name: Build non-Linux wheel
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && matrix.maturin-target == ''
         working-directory: python/mcp-compressor
         run: uvx maturin build --release --out dist
+
+      - name: Build targeted non-Linux wheel
+        if: runner.os != 'Linux' && matrix.maturin-target != ''
+        working-directory: python/mcp-compressor
+        run: uvx maturin build --release --out dist --target ${{ matrix.maturin-target }}
 
       - name: Smoke-test wheel
         shell: bash

--- a/.github/workflows/publish-typescript-package.yml
+++ b/.github/workflows/publish-typescript-package.yml
@@ -26,12 +26,16 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact-suffix: linux-x64-gnu
+            napi-target: ""
           - os: macos-latest
             artifact-suffix: darwin-arm64
-          - os: macos-13
+            napi-target: ""
+          - os: macos-latest
             artifact-suffix: darwin-x64
+            napi-target: x86_64-apple-darwin
           - os: windows-latest
             artifact-suffix: win32-x64-msvc
+            napi-target: ""
     defaults:
       run:
         working-directory: typescript
@@ -54,7 +58,12 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build native addon
+        if: matrix.napi-target == ''
         run: bun run build:native
+
+      - name: Build targeted native addon
+        if: matrix.napi-target != ''
+        run: bunx napi build --manifest-path ../crates/mcp-compressor-node/Cargo.toml --platform --release --output-dir native --target ${{ matrix.napi-target }}
 
       - name: Upload native addon
         uses: actions/upload-artifact@v4

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -48,7 +48,7 @@ Python publishing uses PyPI trusted publishing from:
 .github/workflows/on-release-main.yml
 ```
 
-The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS, and Windows across supported CPython versions, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform/Python tag, builds one source distribution, and publishes them with:
+The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS universal2, and Windows across supported CPython versions, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform/Python tag, builds one source distribution, and publishes them with:
 
 ```bash
 uv publish --trusted-publishing always dist/*
@@ -97,7 +97,7 @@ The main release workflow does **not** publish TypeScript directly from the tag 
    on the `release` branch,
 5. waits for the dispatched workflow to complete.
 
-The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds native addons on Linux, macOS, and Windows, bundles those native addons into the package, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
+The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds native addons on Linux, macOS arm64, macOS x64, and Windows without relying on the scarce Intel macOS runner, bundles those native addons into the package, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
 
 For prereleases, npm publish uses:
 


### PR DESCRIPTION
## Summary

- Removes `macos-13` from release publishing workflows because those Intel macOS runners can sit queued indefinitely.
- Builds Python macOS wheels as `universal2-apple-darwin` on `macos-latest`, covering both arm64 and x86_64.
- Builds the TypeScript `darwin-x64` native addon from `macos-latest` with an explicit `x86_64-apple-darwin` napi target.
- Updates release docs to describe universal2 wheels and macOS x64 addon builds without the Intel macOS runner.

## Validation

- Parsed `.github/workflows/on-release-main.yml` and `.github/workflows/publish-typescript-package.yml` with PyYAML.
- `make docs-test`
- `make check`
