### PR TITLE
fix: install targeted rust target for ts addon

### DIFF
--- a/.github/workflows/publish-typescript-package.yml
+++ b/.github/workflows/publish-typescript-package.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install targeted Rust target
+        if: matrix.napi-target != ''
+        working-directory: .
+        run: rustup target add ${{ matrix.napi-target }}
+
       - name: Build native addon
         if: matrix.napi-target == ''
         run: bun run build:native


### PR DESCRIPTION
## Summary

- Installs the explicit Rust target before building targeted TypeScript native addons.
- Fixes `x86_64-apple-darwin` builds on `macos-latest`, which otherwise fail because the target is not installed by default.

## Validation

- Parsed `.github/workflows/publish-typescript-package.yml` with PyYAML.
- `make check`
