### PR TITLE
ci: use macos intel release runner

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -46,22 +46,38 @@ jobs:
             python-version: "3.14"
             manylinux-python: /opt/python/cp314-cp314/bin/python
             maturin-target: ""
-          - target: macos-universal2-cp311
+          - target: macos-arm64-cp311
             os: macos-latest
             python-version: "3.11"
-            maturin-target: universal2-apple-darwin
-          - target: macos-universal2-cp312
+            maturin-target: ""
+          - target: macos-arm64-cp312
             os: macos-latest
             python-version: "3.12"
-            maturin-target: universal2-apple-darwin
-          - target: macos-universal2-cp313
+            maturin-target: ""
+          - target: macos-arm64-cp313
             os: macos-latest
             python-version: "3.13"
-            maturin-target: universal2-apple-darwin
-          - target: macos-universal2-cp314
+            maturin-target: ""
+          - target: macos-arm64-cp314
             os: macos-latest
             python-version: "3.14"
-            maturin-target: universal2-apple-darwin
+            maturin-target: ""
+          - target: macos-x86_64-cp311
+            os: macos-15-intel
+            python-version: "3.11"
+            maturin-target: ""
+          - target: macos-x86_64-cp312
+            os: macos-15-intel
+            python-version: "3.12"
+            maturin-target: ""
+          - target: macos-x86_64-cp313
+            os: macos-15-intel
+            python-version: "3.13"
+            maturin-target: ""
+          - target: macos-x86_64-cp314
+            os: macos-15-intel
+            python-version: "3.14"
+            maturin-target: ""
           - target: windows-x86_64-cp311
             os: windows-latest
             python-version: "3.11"

--- a/.github/workflows/publish-typescript-package.yml
+++ b/.github/workflows/publish-typescript-package.yml
@@ -30,9 +30,9 @@ jobs:
           - os: macos-latest
             artifact-suffix: darwin-arm64
             napi-target: ""
-          - os: macos-latest
+          - os: macos-15-intel
             artifact-suffix: darwin-x64
-            napi-target: x86_64-apple-darwin
+            napi-target: ""
           - os: windows-latest
             artifact-suffix: win32-x64-msvc
             napi-target: ""
@@ -57,18 +57,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Install targeted Rust target
-        if: matrix.napi-target != ''
-        working-directory: .
-        run: rustup target add ${{ matrix.napi-target }}
-
       - name: Build native addon
-        if: matrix.napi-target == ''
         run: bun run build:native
-
-      - name: Build targeted native addon
-        if: matrix.napi-target != ''
-        run: bunx napi build --manifest-path ../crates/mcp-compressor-node/Cargo.toml --platform --release --output-dir native --target ${{ matrix.napi-target }}
 
       - name: Upload native addon
         uses: actions/upload-artifact@v4

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -48,7 +48,7 @@ Python publishing uses PyPI trusted publishing from:
 .github/workflows/on-release-main.yml
 ```
 
-The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS universal2, and Windows across supported CPython versions, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform/Python tag, builds one source distribution, and publishes them with:
+The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS arm64, macOS x64, and Windows across supported CPython versions, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform/Python tag, builds one source distribution, and publishes them with:
 
 ```bash
 uv publish --trusted-publishing always dist/*
@@ -97,7 +97,7 @@ The main release workflow does **not** publish TypeScript directly from the tag 
    on the `release` branch,
 5. waits for the dispatched workflow to complete.
 
-The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds native addons on Linux, macOS arm64, macOS x64, and Windows without relying on the scarce Intel macOS runner, bundles those native addons into the package, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
+The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds native addons on Linux, macOS arm64, macOS x64, and Windows using the documented GitHub-hosted macOS Intel runner for x64 artifacts, bundles those native addons into the package, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
 
 For prereleases, npm publish uses:
 


### PR DESCRIPTION
## Summary

- Uses the documented `macos-15-intel` GitHub-hosted runner for macOS x64 release artifacts.
- Restores separate Python macOS arm64 and x86_64 wheel builds instead of universal2 cross-builds.
- Builds the TypeScript darwin-x64 native addon natively on `macos-15-intel` instead of cross-compiling from Apple Silicon.
- Updates release docs to describe the macOS Intel runner usage.

## Why

GitHub now documents `macos-15-intel` for public repositories. This is cleaner than universal2/cross-targeting and avoids the missing `x86_64-apple-darwin` target failures in universal2 and napi cross-builds.

## Validation

- Parsed `.github/workflows/on-release-main.yml` and `.github/workflows/publish-typescript-package.yml` with PyYAML.
- `make docs-test`
- `make check`
