### PR TITLE
ci: publish abi3 python wheels

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -26,73 +26,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: linux-x86_64-cp311
+          - target: linux-x86_64-abi3
             os: ubuntu-latest
             python-version: "3.11"
             manylinux-python: /opt/python/cp311-cp311/bin/python
             maturin-target: ""
-          - target: linux-x86_64-cp312
-            os: ubuntu-latest
-            python-version: "3.12"
-            manylinux-python: /opt/python/cp312-cp312/bin/python
-            maturin-target: ""
-          - target: linux-x86_64-cp313
-            os: ubuntu-latest
-            python-version: "3.13"
-            manylinux-python: /opt/python/cp313-cp313/bin/python
-            maturin-target: ""
-          - target: linux-x86_64-cp314
-            os: ubuntu-latest
-            python-version: "3.14"
-            manylinux-python: /opt/python/cp314-cp314/bin/python
-            maturin-target: ""
-          - target: macos-arm64-cp311
+          - target: macos-arm64-abi3
             os: macos-latest
             python-version: "3.11"
             maturin-target: ""
-          - target: macos-arm64-cp312
-            os: macos-latest
-            python-version: "3.12"
-            maturin-target: ""
-          - target: macos-arm64-cp313
-            os: macos-latest
-            python-version: "3.13"
-            maturin-target: ""
-          - target: macos-arm64-cp314
-            os: macos-latest
-            python-version: "3.14"
-            maturin-target: ""
-          - target: macos-x86_64-cp311
+          - target: macos-x86_64-abi3
             os: macos-15-intel
             python-version: "3.11"
             maturin-target: ""
-          - target: macos-x86_64-cp312
-            os: macos-15-intel
-            python-version: "3.12"
-            maturin-target: ""
-          - target: macos-x86_64-cp313
-            os: macos-15-intel
-            python-version: "3.13"
-            maturin-target: ""
-          - target: macos-x86_64-cp314
-            os: macos-15-intel
-            python-version: "3.14"
-            maturin-target: ""
-          - target: windows-x86_64-cp311
+          - target: windows-x86_64-abi3
             os: windows-latest
             python-version: "3.11"
-            maturin-target: ""
-          - target: windows-x86_64-cp312
-            os: windows-latest
-            python-version: "3.12"
-            maturin-target: ""
-          - target: windows-x86_64-cp313
-            os: windows-latest
-            python-version: "3.13"
-            maturin-target: ""
-          - target: windows-x86_64-cp314
-            os: windows-latest
-            python-version: "3.14"
             maturin-target: ""
     steps:
       - name: Check out release ref
@@ -276,7 +225,7 @@ jobs:
           TAG="${{ steps.prepare.outputs.tag }}"
           RELEASE_SHA="${{ steps.prepare.outputs.release_sha }}"
           echo "Waiting for publish-typescript-package workflow on release branch for $TAG at $RELEASE_SHA"
-          for attempt in $(seq 1 60); do
+          for attempt in $(seq 1 120); do
             RUN_JSON="$(gh run list \
               --workflow publish-typescript-package.yml \
               --branch release \
@@ -284,7 +233,7 @@ jobs:
               --json databaseId,status,conclusion,headSha \
               --jq '.[0] // empty')"
             if [ -z "$RUN_JSON" ]; then
-              echo "No TypeScript publish run found yet (attempt $attempt/60)"
+              echo "No TypeScript publish run found yet (attempt $attempt/120)"
               sleep 20
               continue
             fi
@@ -308,7 +257,7 @@ jobs:
             fi
             sleep 20
           done
-          echo "Timed out waiting for TypeScript publish workflow" >&2
+          echo "Timed out waiting for TypeScript publish workflow after 40 minutes" >&2
           exit 1
 
   publish-rust-crate:

--- a/crates/mcp-compressor-python/Cargo.toml
+++ b/crates/mcp-compressor-python/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 mcp-compressor-core = { path = "../mcp-compressor-core" }
-pyo3 = { version = "0.28.3", features = ["extension-module"] }
+pyo3 = { version = "0.28.3", features = ["extension-module", "abi3-py311"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -48,7 +48,7 @@ Python publishing uses PyPI trusted publishing from:
 .github/workflows/on-release-main.yml
 ```
 
-The workflow patches the package version from the release tag, builds platform wheels for Linux, macOS arm64, macOS x64, and Windows across supported CPython versions, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform/Python tag, builds one source distribution, and publishes them with:
+The workflow patches the package version from the release tag, builds one abi3 wheel per platform for Linux, macOS arm64, macOS x64, and Windows that supports CPython 3.11 and newer, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform, builds one source distribution, and publishes them with:
 
 ```bash
 uv publish --trusted-publishing always dist/*


### PR DESCRIPTION
## Summary

- Enables PyO3 `abi3-py311` for the Python extension.
- Collapses Python wheel publishing from 16 CPython-specific wheels to one ABI-stable wheel per platform.
- Keeps platform coverage for Linux x64, macOS arm64, macOS x64, and Windows x64.
- Extends the release workflow's TypeScript publish poller from 20 minutes to 40 minutes.
- Updates release docs to explain the abi3 wheel strategy.

## Why

Python extension modules built with PyO3 abi3 can support Python 3.11+ with a single wheel per platform. We do not need separate wheels for CPython 3.11, 3.12, 3.13, and 3.14.

The TypeScript publish workflow now takes longer because it builds multiple native addons, so the release-main poller needs a longer timeout.

## Validation

- Built a local Python 3.14 wheel and verified maturin emitted `cp311-abi3`:
  `mcp_compressor-0.1.0-cp311-abi3-macosx_11_0_arm64.whl`
- Parsed `.github/workflows/on-release-main.yml` with PyYAML.
- `cargo check -p mcp-compressor-python`
- `make docs-test`
- `make check`
