### PR TITLE
ci: add linux arm64 release artifacts

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -31,6 +31,11 @@ jobs:
             python-version: "3.11"
             manylinux-python: /opt/python/cp311-cp311/bin/python
             maturin-target: ""
+          - target: linux-aarch64-abi3
+            os: ubuntu-24.04-arm
+            python-version: "3.11"
+            manylinux-python: /opt/python/cp311-cp311/bin/python
+            maturin-target: ""
           - target: macos-arm64-abi3
             os: macos-latest
             python-version: "3.11"

--- a/.github/workflows/publish-typescript-package.yml
+++ b/.github/workflows/publish-typescript-package.yml
@@ -27,6 +27,9 @@ jobs:
           - os: ubuntu-latest
             artifact-suffix: linux-x64-gnu
             napi-target: ""
+          - os: ubuntu-24.04-arm
+            artifact-suffix: linux-arm64-gnu
+            napi-target: ""
           - os: macos-latest
             artifact-suffix: darwin-arm64
             napi-target: ""

--- a/docs/development-release.md
+++ b/docs/development-release.md
@@ -48,7 +48,7 @@ Python publishing uses PyPI trusted publishing from:
 .github/workflows/on-release-main.yml
 ```
 
-The workflow patches the package version from the release tag, builds one abi3 wheel per platform for Linux, macOS arm64, macOS x64, and Windows that supports CPython 3.11 and newer, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform, builds one source distribution, and publishes them with:
+The workflow patches the package version from the release tag, builds one abi3 wheel per platform for Linux x64, Linux ARM64, macOS arm64, macOS x64, and Windows that supports CPython 3.11 and newer, builds Linux wheels in a manylinux image for broad distro compatibility, labels wheel jobs by target platform, builds one source distribution, and publishes them with:
 
 ```bash
 uv publish --trusted-publishing always dist/*
@@ -97,7 +97,7 @@ The main release workflow does **not** publish TypeScript directly from the tag 
    on the `release` branch,
 5. waits for the dispatched workflow to complete.
 
-The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds native addons on Linux, macOS arm64, macOS x64, and Windows using the documented GitHub-hosted macOS Intel runner for x64 artifacts, bundles those native addons into the package, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
+The TypeScript workflow reads the tag from the workflow input, with `.release-tag` as a fallback, converts it to an npm-compatible version, builds native addons on Linux x64, Linux ARM64, macOS arm64, macOS x64, and Windows using the documented GitHub-hosted macOS Intel runner for x64 artifacts, bundles those native addons into the package, packs the package, smoke-tests the tarball, then publishes with the npm dist tag derived from the release tag.
 
 For prereleases, npm publish uses:
 


### PR DESCRIPTION
## Summary

- Adds a Linux ARM64 Python abi3 wheel build job.
- Adds a Linux ARM64 TypeScript native addon build job.
- Updates release docs to list Linux ARM64 in the release artifact coverage.

## Validation

- Parsed `.github/workflows/on-release-main.yml` and `.github/workflows/publish-typescript-package.yml` with PyYAML.
- `make docs-test`
- `make check`
