### PR TITLE
fix: report python package cli version

### DIFF
--- a/python/mcp-compressor/mcp_compressor/cli.py
+++ b/python/mcp-compressor/mcp_compressor/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from importlib.metadata import PackageNotFoundError, version
 
 from mcp_compressor import _native
 
@@ -15,7 +16,17 @@ def main(argv: list[str] | None = None) -> int:
     not require a separately installed or locally built Rust binary.
     """
     args = sys.argv[1:] if argv is None else argv
+    if args in (["--version"], ["-V"]):
+        print(f"mcp-compressor {_package_version()}")
+        return 0
     return int(_native.run_cli_json(json.dumps(["mcp-compressor", *args])))
+
+
+def _package_version() -> str:
+    try:
+        return version("mcp-compressor")
+    except PackageNotFoundError:
+        return "0.0.0+editable"
 
 
 def entrypoint() -> None:

--- a/python/mcp-compressor/tests/test_cli.py
+++ b/python/mcp-compressor/tests/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from importlib.metadata import version
 
 
 def test_python_cli_runs_packaged_native_help() -> None:
@@ -14,6 +15,17 @@ def test_python_cli_runs_packaged_native_help() -> None:
     assert result.returncode == 0
     assert "Usage:" in result.stdout
     assert "mcp-compressor" in result.stdout
+
+
+def test_python_cli_reports_package_version() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "mcp_compressor.cli", "--version"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == f"mcp-compressor {version('mcp-compressor')}"
 
 
 def test_python_cli_reports_usage_errors() -> None:


### PR DESCRIPTION
## Summary

- make the Python package console script answer `--version` / `-V` from Python package metadata
- add regression coverage for the packaged CLI version output

## Notes

Published wheels correctly install quickly now, but `uvx mcp-compressor==0.19.7 --version` reported the native crate fallback version. The Python console script now reports the installed Python distribution version instead.

I also investigated the noisy TypeScript install output seen during smoke tests. The actionable noise was from local npm/user registry config rather than package code; published TS package install/import smoke tests passed.

## Validation

- `cd python/mcp-compressor && uv run pytest -q tests/test_cli.py && uv run ruff check mcp_compressor tests && uv run ruff format --check mcp_compressor tests && uv run ty check --project . --python .venv mcp_compressor tests`
- built a temporary wheel with version `9.8.7` and confirmed `mcp-compressor --version` printed `mcp-compressor 9.8.7`
- `make check`
