### PR TITLE
fix: keep packaged cli mode process alive

### DIFF
--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -15,7 +15,7 @@ serde      = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror  = "1"
 rand       = "0.8"
-tokio      = { version = "1", features = ["sync", "rt-multi-thread"] }
+tokio      = { version = "1", features = ["signal", "sync", "rt-multi-thread"] }
 rmcp       = { version = "1.6.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest", "reqwest", "auth"] }
 axum       = "0.8"
 libc       = "0.2"

--- a/crates/mcp-compressor-core/src/app/entrypoint.rs
+++ b/crates/mcp-compressor-core/src/app/entrypoint.rs
@@ -37,13 +37,28 @@ where
     I: IntoIterator<Item = T>,
     T: Into<std::ffi::OsString> + Clone,
 {
-    let cli = CliOptions::try_parse_from(args).map_err(|error| {
-        if matches!(error.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+    let cli = parse_cli(args)?;
+    run_cli(cli)
+}
+
+pub fn parse_cli<I, T>(args: I) -> Result<CliOptions, CliError>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    CliOptions::try_parse_from(args).map_err(|error| {
+        if matches!(
+            error.kind(),
+            ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+        ) {
             CliError::Display(error.to_string())
         } else {
             CliError::Usage(error.to_string())
         }
-    })?;
+    })
+}
+
+pub fn run_cli(cli: CliOptions) -> Result<(), CliError> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -94,6 +94,16 @@ pub struct CliOptions {
 }
 
 impl CliOptions {
+    pub fn is_long_lived_mode(&self) -> bool {
+        if std::env::var_os("MCP_COMPRESSOR_EXIT_AFTER_READY").is_some() {
+            return false;
+        }
+        matches!(
+            self.transform_mode(),
+            ProxyTransformMode::Cli | ProxyTransformMode::JustBash
+        )
+    }
+
     pub fn validate(&self) -> Result<(), String> {
         if self.config_path.is_some() && self.server_name.is_some() {
             return Err("--server-name cannot be used with --config; MCP config server names come from mcpServers keys".to_string());

--- a/crates/mcp-compressor-core/src/app/runtime.rs
+++ b/crates/mcp-compressor-core/src/app/runtime.rs
@@ -210,5 +210,8 @@ async fn wait_until_stopped() {
         return;
     }
 
-    std::future::pending::<()>().await;
+    match tokio::signal::ctrl_c().await {
+        Ok(()) => {}
+        Err(_) => std::future::pending::<()>().await,
+    }
 }

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -497,3 +497,61 @@ fn rust_cli_contract_just_bash_transform_mode_multi_server() {
         .stdout(predicate::str::contains("Bridge URL:"))
         .stdout(predicate::str::contains("Session: bash"));
 }
+
+
+#[test]
+fn rust_cli_mode_exits_on_ctrl_c() {
+    #[cfg(unix)]
+    {
+        use std::io::{BufRead, BufReader};
+        use std::process::Stdio;
+        use std::time::{Duration, Instant};
+
+        let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("mcp-compressor"))
+            .arg("--cli-mode")
+            .arg("--server-name")
+            .arg("alpha")
+            .arg("--output-dir")
+            .arg(tempfile::tempdir().expect("tempdir").path())
+            .arg("--")
+            .arg(common::python_command())
+            .arg(common::fixture_path("alpha_server.py"))
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn mcp-compressor");
+
+        let stdout = child.stdout.take().expect("stdout");
+        let reader = BufReader::new(stdout);
+        let started = Instant::now();
+        let mut saw_ready = false;
+        for line in reader.lines() {
+            let line = line.expect("line");
+            if line.contains("Press Ctrl+C to stop.") {
+                saw_ready = true;
+                break;
+            }
+            if started.elapsed() > Duration::from_secs(20) {
+                break;
+            }
+        }
+        assert!(saw_ready, "CLI mode did not become ready");
+
+        unsafe {
+            libc::kill(child.id() as i32, libc::SIGINT);
+        }
+
+        let started = Instant::now();
+        loop {
+            if let Some(status) = child.try_wait().expect("try_wait") {
+                assert!(status.success(), "unexpected status: {status}");
+                break;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(10),
+                "process did not exit after SIGINT"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}

--- a/crates/mcp-compressor-python/src/lib.rs
+++ b/crates/mcp-compressor-python/src/lib.rs
@@ -11,10 +11,11 @@ use serde_json::Value;
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
     clear_oauth_credentials, compress_tool_listing, format_tool_schema_response,
-    generate_client_artifact_files, generate_client_artifacts, list_oauth_credentials, normalize_sdk_servers, parse_mcp_config,
-    parse_tool_argv, start_compressed_session, start_compressed_session_from_mcp_config,
-    FfiBackendConfig, FfiClientArtifactKind, FfiCompressedSession, FfiCompressedSessionConfig,
-    FfiGeneratorConfig, FfiSdkServersConfig, FfiTool,
+    generate_client_artifact_files, generate_client_artifacts, list_oauth_credentials,
+    normalize_sdk_servers, parse_mcp_config, parse_tool_argv, start_compressed_session,
+    start_compressed_session_from_mcp_config, FfiBackendConfig, FfiClientArtifactKind,
+    FfiCompressedSession, FfiCompressedSessionConfig, FfiGeneratorConfig, FfiSdkServersConfig,
+    FfiTool,
 };
 
 fn py_value_error(error: impl std::fmt::Display) -> PyErr {
@@ -34,14 +35,16 @@ struct ProviderBackendConfig {
     provider_index: Option<usize>,
 }
 
-fn provider_headers_from_python(provider: &Py<PyAny>) -> Result<BTreeMap<String, String>, mcp_compressor_core::Error> {
+fn provider_headers_from_python(
+    provider: &Py<PyAny>,
+) -> Result<BTreeMap<String, String>, mcp_compressor_core::Error> {
     Python::attach(|py| {
         let value = provider
             .call0(py)
             .map_err(|error| mcp_compressor_core::Error::Config(error.to_string()))?;
-        let dict = value
-            .downcast_bound::<PyDict>(py)
-            .map_err(|_| mcp_compressor_core::Error::Config("auth_provider must return a dict".to_string()))?;
+        let dict = value.downcast_bound::<PyDict>(py).map_err(|_| {
+            mcp_compressor_core::Error::Config("auth_provider must return a dict".to_string())
+        })?;
         let mut headers = BTreeMap::new();
         for (key, value) in dict.iter() {
             headers.insert(
@@ -82,7 +85,9 @@ fn parse_client_artifact_kind(kind: &str) -> PyResult<FfiClientArtifactKind> {
         "cli" => Ok(FfiClientArtifactKind::Cli),
         "python" => Ok(FfiClientArtifactKind::Python),
         "typescript" => Ok(FfiClientArtifactKind::TypeScript),
-        other => Err(py_value_error(format!("unsupported client artifact kind: {other}"))),
+        other => Err(py_value_error(format!(
+            "unsupported client artifact kind: {other}"
+        ))),
     }
 }
 
@@ -91,8 +96,13 @@ fn generate_client_artifacts_json(kind: &str, config_json: &str) -> PyResult<Str
     let kind = parse_client_artifact_kind(kind)?;
     let config = parse_json::<FfiGeneratorConfig>(config_json)?;
     let paths = generate_client_artifacts(kind, config).map_err(py_value_error)?;
-    serde_json::to_string(&paths.iter().map(|path| path.to_string_lossy().to_string()).collect::<Vec<_>>())
-        .map_err(py_value_error)
+    serde_json::to_string(
+        &paths
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect::<Vec<_>>(),
+    )
+    .map_err(py_value_error)
 }
 
 #[pyfunction]
@@ -105,7 +115,8 @@ fn generate_client_artifact_files_json(kind: &str, config_json: &str) -> PyResul
 
 #[pyfunction]
 fn normalize_servers_json(servers_json: &str) -> PyResult<String> {
-    let servers: FfiSdkServersConfig = serde_json::from_str(servers_json).map_err(py_value_error)?;
+    let servers: FfiSdkServersConfig =
+        serde_json::from_str(servers_json).map_err(py_value_error)?;
     serde_json::to_string(&normalize_sdk_servers(servers).map_err(py_value_error)?)
         .map_err(py_value_error)
 }
@@ -165,12 +176,15 @@ fn start_compressed_session_with_provider_backends_json(
     let backends = parse_json::<Vec<ProviderBackendConfig>>(backends_json)?;
     let mut backend_configs = Vec::new();
     for backend in backends {
-        let mut config = BackendServerConfig::new(backend.name, backend.command_or_url, backend.args);
+        let mut config =
+            BackendServerConfig::new(backend.name, backend.command_or_url, backend.args);
         if let Some(index) = backend.provider_index {
             let provider = Python::attach(|py| {
                 providers
                     .get(index)
-                    .ok_or_else(|| py_value_error(format!("auth provider index out of range: {index}")))
+                    .ok_or_else(|| {
+                        py_value_error(format!("auth provider index out of range: {index}"))
+                    })
                     .map(|provider| provider.clone_ref(py))
             })?;
             config = config
@@ -182,10 +196,12 @@ fn start_compressed_session_with_provider_backends_json(
     let runtime = tokio::runtime::Runtime::new().map_err(py_value_error)?;
     let inner = py
         .detach(|| {
-            runtime.block_on(mcp_compressor_core::ffi::start_compressed_session_with_backend_configs(
-                config,
-                backend_configs,
-            ))
+            runtime.block_on(
+                mcp_compressor_core::ffi::start_compressed_session_with_backend_configs(
+                    config,
+                    backend_configs,
+                ),
+            )
         })
         .map_err(py_value_error)?;
     Ok(PyCompressedSession { inner, runtime })
@@ -199,7 +215,10 @@ fn start_compressed_session_from_mcp_config_json(
     let config = parse_json::<FfiCompressedSessionConfig>(config_json)?;
     let runtime = tokio::runtime::Runtime::new().map_err(py_value_error)?;
     let inner = runtime
-        .block_on(start_compressed_session_from_mcp_config(config, mcp_config_json))
+        .block_on(start_compressed_session_from_mcp_config(
+            config,
+            mcp_config_json,
+        ))
         .map_err(py_value_error)?;
     Ok(PyCompressedSession { inner, runtime })
 }
@@ -212,6 +231,15 @@ fn clear_oauth_credentials_json(target: Option<&str>) -> PyResult<String> {
         .map(|path| Value::String(path.to_string_lossy().into_owned()))
         .collect::<Vec<_>>();
     serde_json::to_string(&values).map_err(py_value_error)
+}
+
+#[pyfunction]
+fn cli_needs_external_process_json(argv_json: &str) -> PyResult<bool> {
+    let argv: Vec<String> = parse_json(argv_json)?;
+    match mcp_compressor_core::app::entrypoint::parse_cli(argv) {
+        Ok(cli) => Ok(cli.is_long_lived_mode()),
+        Err(_) => Ok(false),
+    }
 }
 
 #[pyfunction]
@@ -241,14 +269,24 @@ fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(format_tool_schema_response_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_tool_argv_json, module)?)?;
     module.add_function(wrap_pyfunction!(generate_client_artifacts_json, module)?)?;
-    module.add_function(wrap_pyfunction!(generate_client_artifact_files_json, module)?)?;
+    module.add_function(wrap_pyfunction!(
+        generate_client_artifact_files_json,
+        module
+    )?)?;
     module.add_function(wrap_pyfunction!(normalize_servers_json, module)?)?;
     module.add_function(wrap_pyfunction!(parse_mcp_config_json, module)?)?;
     module.add_function(wrap_pyfunction!(start_compressed_session_json, module)?)?;
-    module.add_function(wrap_pyfunction!(start_compressed_session_with_provider_backends_json, module)?)?;
-    module.add_function(wrap_pyfunction!(start_compressed_session_from_mcp_config_json, module)?)?;
+    module.add_function(wrap_pyfunction!(
+        start_compressed_session_with_provider_backends_json,
+        module
+    )?)?;
+    module.add_function(wrap_pyfunction!(
+        start_compressed_session_from_mcp_config_json,
+        module
+    )?)?;
     module.add_function(wrap_pyfunction!(list_oauth_credentials_json, module)?)?;
     module.add_function(wrap_pyfunction!(clear_oauth_credentials_json, module)?)?;
+    module.add_function(wrap_pyfunction!(cli_needs_external_process_json, module)?)?;
     module.add_function(wrap_pyfunction!(run_cli_json, module)?)?;
     Ok(())
 }

--- a/python/mcp-compressor/mcp_compressor/_native_cli.py
+++ b/python/mcp-compressor/mcp_compressor/_native_cli.py
@@ -1,0 +1,16 @@
+"""External-process runner for long-lived packaged CLI modes."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from mcp_compressor import _native
+
+
+def main() -> int:
+    return int(_native.run_cli_json(json.dumps(["mcp-compressor", *sys.argv[1:]])))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/mcp-compressor/mcp_compressor/cli.py
+++ b/python/mcp-compressor/mcp_compressor/cli.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
+import signal
+import subprocess
 import sys
+import threading
 from importlib.metadata import PackageNotFoundError, version
 
 from mcp_compressor import _native
@@ -19,7 +23,41 @@ def main(argv: list[str] | None = None) -> int:
     if args in (["--version"], ["-V"]):
         print(f"mcp-compressor {_package_version()}")
         return 0
+    if _needs_long_lived_process(args):
+        return _run_external_process(args)
     return int(_native.run_cli_json(json.dumps(["mcp-compressor", *args])))
+
+
+def _needs_long_lived_process(args: list[str]) -> bool:
+    if os.environ.get("MCP_COMPRESSOR_FORCE_NATIVE_CLI") == "1":
+        return False
+    return bool(_native.cli_needs_external_process_json(json.dumps(["mcp-compressor", *args])))
+
+
+def _run_external_process(args: list[str]) -> int:
+    child = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-m", "mcp_compressor._native_cli", *args]
+    )
+    previous_sigint = signal.getsignal(signal.SIGINT)
+
+    def forward_sigint(_signum: int, _frame: object) -> None:
+        child.send_signal(signal.SIGINT)
+
+    if threading.current_thread() is threading.main_thread():
+        signal.signal(signal.SIGINT, forward_sigint)
+    try:
+        return child.wait()
+    except KeyboardInterrupt:
+        child.send_signal(signal.SIGINT)
+        try:
+            return child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.wait()
+            return 130
+    finally:
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, previous_sigint)
 
 
 def _package_version() -> str:

--- a/python/mcp-compressor/tests/test_cli.py
+++ b/python/mcp-compressor/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import signal
 import subprocess
 import sys
 from importlib.metadata import version
@@ -37,3 +38,78 @@ def test_python_cli_reports_usage_errors() -> None:
     )
     assert result.returncode == 2
     assert "error:" in result.stderr
+
+
+def test_python_cli_uses_external_process_for_cli_mode(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    class FakeProcess:
+        def __init__(self, command: list[str]) -> None:
+            calls.append(command)
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 17
+
+    monkeypatch.setattr("mcp_compressor.cli.subprocess.Popen", FakeProcess)
+    monkeypatch.delenv("MCP_COMPRESSOR_EXIT_AFTER_READY", raising=False)
+
+    from mcp_compressor.cli import main
+
+    result = main(["--cli-mode", "--server-name", "alpha", "--", "python", "server.py"])
+
+    assert result == 17
+    assert calls == [
+        [
+            sys.executable,
+            "-m",
+            "mcp_compressor._native_cli",
+            "--cli-mode",
+            "--server-name",
+            "alpha",
+            "--",
+            "python",
+            "server.py",
+        ]
+    ]
+
+
+def test_python_cli_keeps_exit_after_ready_modes_in_process(monkeypatch) -> None:
+    def fail_popen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("exit-after-ready commands should not spawn an external process")
+
+    monkeypatch.setattr("mcp_compressor.cli.subprocess.Popen", fail_popen)
+    monkeypatch.setenv("MCP_COMPRESSOR_EXIT_AFTER_READY", "1")
+
+    from mcp_compressor.cli import _needs_long_lived_process
+
+    assert not _needs_long_lived_process(["--cli-mode", "--server-name", "alpha", "--", "python", "server.py"])
+
+
+def test_python_cli_forwards_keyboard_interrupt_to_external_process(monkeypatch) -> None:
+    signals: list[int] = []
+    killed = False
+
+    class FakeProcess:
+        def wait(self, timeout: float | None = None) -> int:
+            if timeout is None:
+                raise KeyboardInterrupt
+            return 0
+
+        def send_signal(self, sig: int) -> None:
+            signals.append(sig)
+
+        def poll(self) -> int | None:
+            return None
+
+        def kill(self) -> None:
+            nonlocal killed
+            killed = True
+
+    monkeypatch.setattr("mcp_compressor.cli.subprocess.Popen", lambda *_args, **_kwargs: FakeProcess())
+    monkeypatch.delenv("MCP_COMPRESSOR_EXIT_AFTER_READY", raising=False)
+
+    from mcp_compressor.cli import main
+
+    assert main(["--cli-mode", "--server-name", "alpha", "--", "python", "server.py"]) == 0
+    assert signals == [signal.SIGINT]
+    assert not killed


### PR DESCRIPTION
## Summary

Fixes the packaged Python CLI behavior for long-lived modes such as `--cli-mode`.

The Python package console script had been invoking the native PyO3 function in-process. That works for short-lived commands like `--help`, but for CLI Mode it meant long-lived runtime behavior was trapped inside the wrapper process/native call path and signal handling was poor. Published `uvx mcp-compressor --cli-mode ...` could leave the generated CLI pointing at a stopped proxy, and Ctrl-C did not reliably shut down the session.

This PR:

- detects long-lived modes using the Rust CLI parser,
- runs those modes in a child Python process via `python -m mcp_compressor._native_cli`,
- forwards Ctrl-C/SIGINT from the console wrapper to that child process,
- makes Rust CLI Mode / Just Bash wait on `tokio::signal::ctrl_c()` instead of an uninterruptible pending future,
- keeps short-lived commands in-process for fast `--help`, `--version`, and validation behavior.

## Validation

- `cd python/mcp-compressor && PYTHON="$PWD/../../.venv/bin/python" uv run pytest -q tests/test_cli.py`
- `cd python/mcp-compressor && uv run ruff check mcp_compressor tests`
- `cd python/mcp-compressor && uv run ruff format --check mcp_compressor tests`
- `cd python/mcp-compressor && uv run ty check --project . --python .venv mcp_compressor tests`
- `cargo check -p mcp-compressor-core -p mcp-compressor-python`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test cli_binary rust_cli_mode_exits_on_ctrl_c -- --nocapture`
- `make check`

Also manually smoke-tested the Python package CLI Mode against the alpha fixture: generated CLI invocation succeeded and SIGINT stopped the wrapper process.
