### PR TITLE
fix: keep rust source crate versions current

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-compressor"
-version = "0.1.0"
+version = "0.19.8"
 dependencies = [
  "mcp-compressor-core",
  "serde_json",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-compressor-core"
-version = "0.1.0"
+version = "0.19.8"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "mcp-compressor-core"
-version       = "0.1.0"
+version       = "0.19.8"
 edition       = "2021"
 description   = "Internal Rust core for mcp-compressor. Prefer the public mcp-compressor crate."
 license       = "Apache-2.0"

--- a/crates/mcp-compressor/Cargo.toml
+++ b/crates/mcp-compressor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "mcp-compressor"
-version       = "0.1.0"
+version       = "0.19.8"
 edition       = "2021"
 description   = "Compress MCP tool surfaces and generate CLI, Python, and TypeScript clients."
 license       = "Apache-2.0"
@@ -16,7 +16,7 @@ name = "mcp-compressor"
 path = "src/main.rs"
 
 [dependencies]
-mcp-compressor-core = { path = "../mcp-compressor-core", version = "0.1.0" }
+mcp-compressor-core = { path = "../mcp-compressor-core", version = "0.19.8" }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
## Summary

Keep the checked-in Rust crate versions aligned with the latest published release.

`cargo search` shows `mcp-compressor` and `mcp-compressor-core` are published at `0.19.8`, but running `cargo info mcp-compressor` from the repository reported the local path crate version `0.1.0` because the workspace manifests were still pinned to the old source version.

This PR updates:

- `crates/mcp-compressor/Cargo.toml`
- `crates/mcp-compressor-core/Cargo.toml`
- `Cargo.lock`

to `0.19.8`.

## Notes

The release workflow still patches versions from tags before publishing, so this does not change release mechanics. It just avoids confusing local `cargo info` / metadata output after the release.

## Validation

- `cargo check -p mcp-compressor --locked`
- `make check`
