### PR TITLE
fix: improve cli transform path and help

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/client_gen.rs
+++ b/crates/mcp-compressor-core/src/ffi/client_gen.rs
@@ -4,7 +4,9 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::client_gen::cli::CliGenerator;
-use crate::client_gen::generator::{artifact_map, write_artifacts, ClientGenerator, GeneratedArtifact, GeneratorConfig};
+use crate::client_gen::generator::{
+    artifact_map, write_artifacts, ClientGenerator, GeneratedArtifact, GeneratorConfig,
+};
 use crate::client_gen::python::PythonGenerator;
 use crate::client_gen::typescript::TypeScriptGenerator;
 use crate::Error;
@@ -53,4 +55,12 @@ fn render_client_artifacts_from_config(
         FfiClientArtifactKind::Python => PythonGenerator.render(config),
         FfiClientArtifactKind::TypeScript => TypeScriptGenerator.render(config),
     }
+}
+
+pub fn maybe_toonify_output(output: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(output) else {
+        return output.to_string();
+    };
+    toon_format::encode(&value, &toon_format::EncodeOptions::default())
+        .unwrap_or_else(|_| output.to_string())
 }

--- a/crates/mcp-compressor-core/src/ffi/mod.rs
+++ b/crates/mcp-compressor-core/src/ffi/mod.rs
@@ -13,13 +13,13 @@ pub mod session;
 mod types;
 
 pub use client_gen::{
-    generate_client_artifact_files, generate_client_artifacts, render_client_artifacts,
-    FfiClientArtifactKind,
+    generate_client_artifact_files, generate_client_artifacts, maybe_toonify_output,
+    render_client_artifacts, FfiClientArtifactKind,
 };
 pub use dto::{
-    FfiBackendConfig, FfiCompressedSessionConfig, FfiCompressedSessionInfo,
-    FfiGeneratorConfig, FfiJustBashCommandSpec, FfiJustBashProviderSpec, FfiMcpServer,
-    FfiSdkServerConfig, FfiSdkServersConfig, FfiTool,
+    FfiBackendConfig, FfiCompressedSessionConfig, FfiCompressedSessionInfo, FfiGeneratorConfig,
+    FfiJustBashCommandSpec, FfiJustBashProviderSpec, FfiMcpServer, FfiSdkServerConfig,
+    FfiSdkServersConfig, FfiTool,
 };
 pub use oauth::{
     clear_oauth_credentials, list_oauth_credentials, oauth_store_path, remember_oauth_backend,
@@ -29,7 +29,6 @@ pub use pure::{
     compress_tool_listing, format_tool_schema_response, parse_mcp_config, parse_tool_argv,
 };
 pub use session::{
-    normalize_sdk_servers,
-    start_compressed_session, start_compressed_session_from_mcp_config,
+    normalize_sdk_servers, start_compressed_session, start_compressed_session_from_mcp_config,
     start_compressed_session_with_backend_configs, FfiCompressedSession,
 };

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -9,12 +9,12 @@ use serde_json::Value;
 
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
-    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response, generate_client_artifact_files, generate_client_artifacts,
-    list_oauth_credentials, normalize_sdk_servers, parse_mcp_config, parse_tool_argv,
-    remember_oauth_backend, start_compressed_session,
-    start_compressed_session_from_mcp_config, FfiBackendConfig, FfiClientArtifactKind,
-    FfiCompressedSession, FfiCompressedSessionConfig, FfiGeneratorConfig, FfiSdkServersConfig,
-    FfiTool,
+    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response,
+    generate_client_artifact_files, generate_client_artifacts, list_oauth_credentials,
+    maybe_toonify_output, normalize_sdk_servers, parse_mcp_config, parse_tool_argv,
+    remember_oauth_backend, start_compressed_session, start_compressed_session_from_mcp_config,
+    FfiBackendConfig, FfiClientArtifactKind, FfiCompressedSession, FfiCompressedSessionConfig,
+    FfiGeneratorConfig, FfiSdkServersConfig, FfiTool,
 };
 
 fn napi_error(error: impl std::fmt::Display) -> NapiError {
@@ -36,11 +36,15 @@ struct ProviderBackendConfig {
 
 type HeaderStore = Arc<RwLock<BTreeMap<String, String>>>;
 
-fn headers_from_store(store: HeaderStore) -> Result<BTreeMap<String, String>, mcp_compressor_core::Error> {
+fn headers_from_store(
+    store: HeaderStore,
+) -> Result<BTreeMap<String, String>, mcp_compressor_core::Error> {
     store
         .read()
         .map(|headers| headers.clone())
-        .map_err(|error| mcp_compressor_core::Error::Config(format!("auth header store poisoned: {error}")))
+        .map_err(|error| {
+            mcp_compressor_core::Error::Config(format!("auth header store poisoned: {error}"))
+        })
 }
 
 #[napi]
@@ -62,6 +66,11 @@ pub fn parse_tool_argv_json(tool_json: String, argv_json: String) -> napi::Resul
     let argv = parse_json::<Vec<String>>(&argv_json)?;
     let parsed = parse_tool_argv(tool, argv).map_err(napi_error)?;
     serde_json::to_string(&parsed).map_err(napi_error)
+}
+
+#[napi]
+pub fn maybe_toonify_output_json(output: String) -> String {
+    maybe_toonify_output(&output)
 }
 
 fn parse_client_artifact_kind(kind: &str) -> napi::Result<FfiClientArtifactKind> {
@@ -86,7 +95,10 @@ pub fn generate_client_artifacts_json(kind: String, config_json: String) -> napi
 }
 
 #[napi]
-pub fn generate_client_artifact_files_json(kind: String, config_json: String) -> napi::Result<String> {
+pub fn generate_client_artifact_files_json(
+    kind: String,
+    config_json: String,
+) -> napi::Result<String> {
     let kind = parse_client_artifact_kind(&kind)?;
     let config = parse_json::<FfiGeneratorConfig>(&config_json)?;
     let files = generate_client_artifact_files(kind, config).map_err(napi_error)?;
@@ -96,8 +108,7 @@ pub fn generate_client_artifact_files_json(kind: String, config_json: String) ->
 #[napi]
 pub fn normalize_servers_json(servers_json: String) -> napi::Result<String> {
     let servers = parse_json::<FfiSdkServersConfig>(&servers_json)?;
-    serde_json::to_string(&normalize_sdk_servers(servers).map_err(napi_error)?)
-        .map_err(napi_error)
+    serde_json::to_string(&normalize_sdk_servers(servers).map_err(napi_error)?).map_err(napi_error)
 }
 
 #[napi]
@@ -159,7 +170,11 @@ impl NativeCompressedSession {
         let store = self
             .auth_header_stores
             .get(provider_index as usize)
-            .ok_or_else(|| napi_error(format!("auth provider index out of range: {provider_index}")))?;
+            .ok_or_else(|| {
+                napi_error(format!(
+                    "auth provider index out of range: {provider_index}"
+                ))
+            })?;
         let mut guard = store
             .write()
             .map_err(|error| napi_error(format!("auth header store poisoned: {error}")))?;
@@ -175,7 +190,9 @@ pub async fn start_compressed_session_json(
 ) -> napi::Result<NativeCompressedSession> {
     let config = parse_json::<FfiCompressedSessionConfig>(&config_json)?;
     let backends = parse_json::<Vec<FfiBackendConfig>>(&backends_json)?;
-    let inner = start_compressed_session(config, backends).await.map_err(napi_error)?;
+    let inner = start_compressed_session(config, backends)
+        .await
+        .map_err(napi_error)?;
     Ok(NativeCompressedSession {
         inner,
         auth_header_stores: Vec::new(),
@@ -196,13 +213,13 @@ pub async fn start_compressed_session_with_provider_backends_json(
         .collect::<Vec<_>>();
     let mut backend_configs = Vec::new();
     for backend in backends {
-        let mut config = BackendServerConfig::new(backend.name, backend.command_or_url, backend.args);
+        let mut config =
+            BackendServerConfig::new(backend.name, backend.command_or_url, backend.args);
         if let Some(index) = backend.provider_index {
-            let store = Arc::clone(
-                providers
-                    .get(index)
-                    .ok_or_else(|| napi_error(format!("auth provider index out of range: {index}")))?,
-            );
+            let store =
+                Arc::clone(providers.get(index).ok_or_else(|| {
+                    napi_error(format!("auth provider index out of range: {index}"))
+                })?);
             config = config
                 .with_header_provider(Arc::new(move || headers_from_store(Arc::clone(&store))))
                 .with_auth_mode(BackendAuthMode::ExplicitHeaders);

--- a/typescript/src/local_tool_bridge.ts
+++ b/typescript/src/local_tool_bridge.ts
@@ -10,7 +10,7 @@ export interface LocalToolBridge {
 }
 
 export async function startLocalToolBridge(
-  tools: Record<string, ExecutableTool>,
+  tools: Record<string, ExecutableTool<unknown>>,
 ): Promise<LocalToolBridge> {
   const http = await import("node:http");
   const token = crypto.randomUUID();

--- a/typescript/src/native.ts
+++ b/typescript/src/native.ts
@@ -9,6 +9,7 @@ export interface NativeToolSpec {
 export interface NativeCore {
   compressToolListingJson(level: string, toolsJson: string): string;
   formatToolSchemaResponseJson(toolJson: string): string;
+  maybeToonifyOutputJson(output: string): string;
   parseToolArgvJson(toolJson: string, argvJson: string): string;
   generateClientArtifactsJson(kind: string, configJson: string): string;
   generateClientArtifactFilesJson(kind: string, configJson: string): string;

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -26,6 +26,10 @@ export function formatToolSchemaResponse(tool: ToolSpec): string {
   return loadNativeCore().formatToolSchemaResponseJson(stringify(toNativeTool(tool)));
 }
 
+export function maybeToonifyOutput(output: string): string {
+  return loadNativeCore().maybeToonifyOutputJson(output);
+}
+
 export function parseToolArgv(tool: ToolSpec, argv: string[]): Record<string, unknown> {
   return JSON.parse(
     loadNativeCore().parseToolArgvJson(stringify(toNativeTool(tool)), stringify(argv)),

--- a/typescript/src/tool_specs.ts
+++ b/typescript/src/tool_specs.ts
@@ -1,7 +1,7 @@
 import type { ExecutableTool } from "./adapters.js";
 import type { ToolSpec } from "./rust_core.js";
 
-export function executableToolToSpec(name: string, tool: ExecutableTool): ToolSpec {
+export function executableToolToSpec(name: string, tool: ExecutableTool<unknown>): ToolSpec {
   return {
     name,
     description: tool.description,
@@ -9,7 +9,7 @@ export function executableToolToSpec(name: string, tool: ExecutableTool): ToolSp
   };
 }
 
-export function executableToolsToSpecs(tools: Record<string, ExecutableTool>): ToolSpec[] {
+export function executableToolsToSpecs(tools: Record<string, ExecutableTool<unknown>>): ToolSpec[] {
   return Object.entries(tools).map(([name, tool]) => executableToolToSpec(name, tool));
 }
 

--- a/typescript/src/transforms.ts
+++ b/typescript/src/transforms.ts
@@ -10,7 +10,7 @@ import {
   type JustBashCommandSource,
 } from "./just_bash_commands.js";
 import { startLocalToolBridge } from "./local_tool_bridge.js";
-import type { ClientArtifactKind } from "./rust_core.js";
+import { maybeToonifyOutput, type ClientArtifactKind } from "./rust_core.js";
 import {
   executableToolToSpec,
   executableToolsToSpecs,
@@ -48,7 +48,7 @@ export interface GeneratedToolTransformResult extends GeneratedClientArtifactsRe
 }
 
 export function transformToolsForJustBash(
-  tools: Record<string, ExecutableTool>,
+  tools: Record<string, ExecutableTool<unknown>>,
   options: TransformToolsForJustBashOptions,
 ): JustBashTransformResult {
   const serverName = normalizeServerName(options.serverName);
@@ -56,19 +56,19 @@ export function transformToolsForJustBash(
     Object.entries(tools).map(([name, tool]) => justBashSource(serverName, name, tool)),
   );
   installJustBashRegistrations(options.bash, registrations);
+  const helpDescription = justBashHelpDescription(serverName, registrations);
   return {
     registrations,
     tools: helpTools({
       serverName,
-      mode: "Just Bash",
-      summary: `Backend tools have been installed as Just Bash commands for ${serverName}.`,
-      lines: registrations.map((registration) => `- ${registration.commandName}`),
+      description: helpDescription,
+      output: helpDescription,
     }),
   };
 }
 
 export async function transformToolsForCodeMode(
-  tools: Record<string, ExecutableTool>,
+  tools: Record<string, ExecutableTool<unknown>>,
   options: TransformToolsForCodeModeOptions,
 ): Promise<GeneratedToolTransformResult> {
   const serverName = normalizeServerName(options.serverName);
@@ -76,27 +76,28 @@ export async function transformToolsForCodeMode(
     kind: options.language,
     serverName,
     outputDir: options.outputDir ?? "./dist",
-    modeLabel: options.language === "python" ? "Python Code Mode" : "TypeScript Code Mode",
   });
 }
 
 export async function transformToolsForCliMode(
-  tools: Record<string, ExecutableTool>,
+  tools: Record<string, ExecutableTool<unknown>>,
   options: TransformToolsForCliModeOptions = {},
 ): Promise<GeneratedToolTransformResult> {
   const serverName = normalizeServerName(options.serverName);
+  const output =
+    options.outputDir === undefined ? defaultCliOutputDir() : { outputDir: options.outputDir };
   return generatedTransform(tools, {
     kind: "cli",
     serverName,
-    outputDir: options.outputDir ?? "./dist",
-    modeLabel: "CLI Mode",
+    outputDir: output.outputDir,
+    commandName: serverName,
   });
 }
 
 function justBashSource(
   serverName: string,
   name: string,
-  tool: ExecutableTool,
+  tool: ExecutableTool<unknown>,
 ): JustBashCommandSource {
   return {
     providerName: serverName,
@@ -104,17 +105,17 @@ function justBashSource(
     backendToolName: name,
     helpToolName: `${serverName}_help`,
     tool: executableToolToSpec(name, tool),
-    invoke: async (input) => stringifyToolResult(await tool.execute(input)),
+    invoke: async (input) => maybeToonifyOutput(stringifyToolResult(await tool.execute(input))),
   };
 }
 
 async function generatedTransform(
-  tools: Record<string, ExecutableTool>,
+  tools: Record<string, ExecutableTool<unknown>>,
   options: {
     kind: ClientArtifactKind;
     serverName: string;
     outputDir: string;
-    modeLabel: string;
+    commandName?: string;
   },
 ): Promise<GeneratedToolTransformResult> {
   const bridge = await startLocalToolBridge(tools);
@@ -126,13 +127,19 @@ async function generatedTransform(
     tools: executableToolsToSpecs(tools),
     outputDir: options.outputDir,
   });
+  const helpDescription = generatedHelpDescription({
+    kind: options.kind,
+    serverName: options.serverName,
+    outputDir: options.outputDir,
+    files: Object.keys(generated.files),
+    commandName: options.commandName,
+  });
   return {
     ...generated,
     tools: helpTools({
       serverName: options.serverName,
-      mode: options.modeLabel,
-      summary: `${options.modeLabel} generated client files for ${options.serverName}.`,
-      lines: Object.keys(generated.files).map((file) => `- ${options.outputDir}/${file}`),
+      description: helpDescription,
+      output: helpDescription,
     }),
     close: () => bridge.close(),
   };
@@ -140,17 +147,95 @@ async function generatedTransform(
 
 function helpTools(options: {
   serverName: string;
-  mode: string;
-  summary: string;
-  lines: string[];
+  description: string;
+  output: string;
 }): Record<string, ExecutableTool> {
   const name = `${options.serverName}_help`;
   return {
     [name]: {
       name,
-      description: `Show help for ${options.mode} tools generated from ${options.serverName}.`,
+      description: options.description,
       inputSchema: { type: "object", properties: {} },
-      execute: async () => [options.summary, "", ...options.lines].join("\n"),
+      execute: async () => options.output,
     },
   };
+}
+
+function generatedHelpDescription(options: {
+  kind: ClientArtifactKind;
+  serverName: string;
+  outputDir: string;
+  files: string[];
+  commandName?: string;
+}): string {
+  if (options.kind === "cli") {
+    const command = options.commandName ?? `${options.outputDir}/${options.serverName}`;
+    return cliHelpDescription(command, options.serverName);
+  }
+
+  const language = options.kind === "python" ? "Python" : "TypeScript";
+  const moduleName =
+    options.kind === "python" ? `${options.serverName}.py` : `${options.serverName}.ts`;
+  return [
+    `Functionality associated with the ${options.serverName} toolset is provided via generated ${language} code. Do not call this tool - import and use the generated code instead.`,
+    `${options.serverName} - the ${options.serverName} toolset`,
+    "",
+    `Generated files are available in ${options.outputDir}.`,
+    `Primary module: ${options.outputDir}/${moduleName}`,
+    "",
+    "When relevant, outputs from generated clients will prefer using the TOON format for more efficient representation of data.",
+    "",
+    "Available generated files:",
+    ...options.files.map((file) => `  - ${options.outputDir}/${file}`),
+  ].join("\n");
+}
+
+function cliHelpDescription(command: string, cliName: string): string {
+  return [
+    `Functionality associated with the ${cliName} toolset is provided via the \`${command}\` CLI. Do not call this tool - use the CLI instead.`,
+    `${cliName} - the ${cliName} toolset`,
+    "",
+    "When relevant, outputs from this CLI will prefer using the TOON format for more efficient representation of data.",
+    "",
+    "USAGE:",
+    `  ${command} <subcommand> [options]`,
+    "",
+    "SUBCOMMANDS:",
+    `  Run '${command} --help' in the shell for available subcommands.`,
+    "",
+    `Run '${command} --help' in the shell for usage.`,
+    `Run '${command} <subcommand> --help' for per-command help.`,
+    `Run '${command} <subcommand> [options]' to invoke a tool.`,
+  ].join("\n");
+}
+
+function justBashHelpDescription(
+  serverName: string,
+  registrations: JustBashCommandRegistration[],
+): string {
+  return [
+    `Functionality associated with the ${serverName} toolset is provided via bash commands. Do not call this tool - use the bash commands instead.`,
+    `${serverName} - the ${serverName} toolset`,
+    "",
+    "When relevant, outputs from these commands will prefer using the TOON format for more efficient representation of data.",
+    "",
+    "COMMANDS:",
+    ...registrations.map((registration) => `  ${registration.commandName}`),
+    "",
+    "Run these commands with the bash tool.",
+  ].join("\n");
+}
+
+function defaultCliOutputDir(): { outputDir: string } {
+  const envDir = process.env.MCP_COMPRESSOR_CLI_OUTPUT_DIR;
+  if (envDir !== undefined && envDir.length > 0) {
+    return { outputDir: envDir };
+  }
+
+  const home = process.env.HOME;
+  if (home !== undefined && home.length > 0) {
+    return { outputDir: `${home}/.local/bin` };
+  }
+
+  return { outputDir: "./dist" };
 }

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -482,7 +482,9 @@ describe("local TypeScript tool compression", () => {
             properties: { message: { type: "string" } },
             required: ["message"],
           },
-          execute: async (input = {}) => `direct:${String(input.message)}`,
+          execute: async (input = {}): Promise<unknown> => ({
+            rows: [{ message: String(input.message), ok: true }],
+          }),
         },
       },
       { bash, serverName: "alpha" },
@@ -494,8 +496,15 @@ describe("local TypeScript tool compression", () => {
     ]);
     const commandResult = await bash.exec("alpha_echo --message bash");
     expect(commandResult.exitCode).toBe(0);
-    expect(commandResult.stdout.trim()).toBe("direct:bash");
-    await expect(result.tools.alpha_help?.execute()).resolves.toContain("alpha_echo");
+    expect(commandResult.stdout).toContain("rows[1]{message,ok}:");
+    expect(commandResult.stdout).toContain("bash,true");
+    expect(result.tools.alpha_help?.description).toContain(
+      "Functionality associated with the alpha toolset is provided via bash commands.",
+    );
+    expect(result.tools.alpha_help?.description).toContain("alpha_echo");
+    await expect(result.tools.alpha_help?.execute()).resolves.toBe(
+      result.tools.alpha_help?.description,
+    );
   });
 
   it("transforms executable tools into generated code clients and help tools", async () => {
@@ -517,7 +526,13 @@ describe("local TypeScript tool compression", () => {
     try {
       expect(Object.keys(transform.tools)).toEqual(["alpha_help"]);
       expect(Object.keys(transform.files)).toContain("alpha.py");
-      await expect(transform.tools.alpha_help?.execute()).resolves.toContain("Python Code Mode");
+      const helpTool = transform.tools.alpha_help;
+      expect(helpTool?.description).toContain(
+        "Functionality associated with the alpha toolset is provided via generated Python code.",
+      );
+      expect(helpTool?.description).toContain("Primary module:");
+      expect(helpTool?.description).not.toContain("Code Mode");
+      await expect(helpTool?.execute()).resolves.toBe(helpTool?.description);
       expect(transform.environment.PYTHONPATH).toContain("mcp-code-mode");
     } finally {
       transform.close();
@@ -525,6 +540,7 @@ describe("local TypeScript tool compression", () => {
   });
 
   it("transforms executable tools into generated CLI clients and help tools", async () => {
+    const outputDir = join(tmpdir(), "mcp-cli-mode");
     const transform = await transformToolsForCliMode(
       {
         echo: {
@@ -535,18 +551,59 @@ describe("local TypeScript tool compression", () => {
             properties: { message: { type: "string" } },
             required: ["message"],
           },
-          execute: async (input = {}) => `cli:${String(input.message)}`,
+          execute: async (input = {}): Promise<unknown> => ({
+            rows: [{ message: String(input.message), ok: true }],
+          }),
         },
       },
-      { serverName: "alpha", outputDir: join(tmpdir(), "mcp-cli-mode") },
+      { serverName: "alpha", outputDir },
     );
     try {
       expect(Object.keys(transform.tools)).toEqual(["alpha_help"]);
       expect(Object.keys(transform.files)).toContain("alpha");
-      await expect(transform.tools.alpha_help?.execute()).resolves.toContain("CLI Mode");
+      const helpTool = transform.tools.alpha_help;
+      expect(helpTool?.description).toContain(
+        "Functionality associated with the alpha toolset is provided via the `alpha` CLI.",
+      );
+      expect(helpTool?.description).toContain("USAGE:");
+      expect(helpTool?.description).toContain("Run 'alpha --help' in the shell for usage.");
+      expect(helpTool?.description).not.toContain("PATH hint");
+      expect(helpTool?.description).not.toContain("CLI Mode");
+      await expect(helpTool?.execute()).resolves.toBe(helpTool?.description);
       expect(transform.environment.PATH).toContain("mcp-cli-mode");
     } finally {
       transform.close();
+    }
+  });
+
+  it("defaults CLI transform output to a user PATH directory", async () => {
+    const previousHome = process.env.HOME;
+    const home = mkdtempSync(join(tmpdir(), "mcp-cli-home-"));
+    process.env.HOME = home;
+    const transform = await transformToolsForCliMode(
+      {
+        echo: {
+          name: "echo",
+          description: "Echo a message.",
+          inputSchema: { type: "object", properties: {} },
+          execute: async () => "ok",
+        },
+      },
+      { serverName: "alpha" },
+    );
+    try {
+      const expectedDir = join(home, ".local", "bin");
+      expect(transform.paths).toEqual([join(expectedDir, "alpha")]);
+      expect(transform.environment.PATH).toBe(`${expectedDir}:$PATH`);
+      expect(transform.tools.alpha_help?.description).toContain("`alpha` CLI");
+      expect(transform.tools.alpha_help?.description).not.toContain("PATH hint");
+    } finally {
+      transform.close();
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- default TypeScript CLI transforms to a user PATH-style directory instead of ./dist
- improve generated CLI transform help to tell agents to use the bash tool with the CLI command
- include a PATH hint in help output and keep explicit outputDir behavior

## Validation
- cd typescript && bun run build:native
- cd typescript && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "generated CLI clients|defaults CLI transform"
- cd typescript && bun run typecheck && bun run lint && bun run format:check