### PR TITLE
fix: make local tool bridge compatible with generated cli

### DIFF
--- a/typescript/src/generated_clients.ts
+++ b/typescript/src/generated_clients.ts
@@ -12,6 +12,11 @@ export interface GeneratedClientArtifactsResult {
   environment: Record<string, string>;
 }
 
+export interface GeneratedBridgeClientArtifactsResult extends GeneratedClientArtifactsResult {
+  bridgeUrl: string;
+  token: string;
+}
+
 export interface GenerateClientFromBridgeOptions {
   kind: ClientArtifactKind;
   name: string;
@@ -24,7 +29,7 @@ export interface GenerateClientFromBridgeOptions {
 
 export function generateClientFromBridge(
   options: GenerateClientFromBridgeOptions,
-): GeneratedClientArtifactsResult {
+): GeneratedBridgeClientArtifactsResult {
   const config: ClientGeneratorConfig = {
     cliName: options.name,
     bridgeUrl: options.bridgeUrl,
@@ -37,6 +42,8 @@ export function generateClientFromBridge(
     paths: generateClientArtifacts(options.kind, config),
     files: generateClientArtifactFiles(options.kind, config),
     environment: generatedClientEnvironment(options.kind, options.outputDir),
+    bridgeUrl: options.bridgeUrl,
+    token: options.token,
   };
 }
 

--- a/typescript/src/local_tool_bridge.ts
+++ b/typescript/src/local_tool_bridge.ts
@@ -16,6 +16,10 @@ export async function startLocalToolBridge(
   const token = crypto.randomUUID();
   const server = http.createServer(async (request, response) => {
     try {
+      if (request.method === "GET" && request.url === "/health") {
+        response.writeHead(200, { "content-type": "text/plain" }).end("ok");
+        return;
+      }
       if (request.method !== "POST" || request.url !== "/exec") {
         response.writeHead(404).end("not found");
         return;
@@ -25,10 +29,12 @@ export async function startLocalToolBridge(
         return;
       }
       const body = JSON.parse(await readRequestBody(request)) as {
+        tool?: string;
+        input?: Record<string, unknown>;
         tool_name?: string;
         tool_input?: Record<string, unknown>;
       };
-      const toolName = String(body.tool_name ?? "");
+      const toolName = String(body.tool ?? body.tool_name ?? "");
       const tool = tools[toolName];
       if (!tool) {
         response
@@ -36,7 +42,7 @@ export async function startLocalToolBridge(
           .end(JSON.stringify({ error: `Tool not found: ${toolName}` }));
         return;
       }
-      const result = await tool.execute(body.tool_input ?? {});
+      const result = await tool.execute(body.input ?? body.tool_input ?? {});
       response
         .writeHead(200, { "content-type": "application/json" })
         .end(JSON.stringify({ result: stringifyToolResult(result) }));

--- a/typescript/src/transforms.ts
+++ b/typescript/src/transforms.ts
@@ -1,7 +1,7 @@
 import type { ExecutableTool } from "./adapters.js";
 import {
   generateClientFromBridge,
-  type GeneratedClientArtifactsResult,
+  type GeneratedBridgeClientArtifactsResult,
 } from "./generated_clients.js";
 import {
   createJustBashCommandRegistrations,
@@ -42,7 +42,7 @@ export interface TransformToolsForCliModeOptions extends TransformToolOptions {
   outputDir?: string;
 }
 
-export interface GeneratedToolTransformResult extends GeneratedClientArtifactsResult {
+export interface GeneratedToolTransformResult extends GeneratedBridgeClientArtifactsResult {
   tools: Record<string, ExecutableTool>;
   close(): void;
 }

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -573,6 +573,19 @@ describe("local TypeScript tool compression", () => {
       expect(helpTool?.description).not.toContain("CLI Mode");
       await expect(helpTool?.execute()).resolves.toBe(helpTool?.description);
       expect(transform.environment.PATH).toContain("mcp-cli-mode");
+      const response = await fetch(`${transform.bridgeUrl}/health`);
+      expect(response.status).toBe(200);
+      const execResponse = await fetch(`${transform.bridgeUrl}/exec`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${transform.token}`,
+        },
+        body: JSON.stringify({ tool: "echo", input: { message: "bridge" } }),
+      });
+      expect(execResponse.status).toBe(200);
+      const execBody = (await execResponse.json()) as { result: string };
+      expect(execBody.result).toContain('"message":"bridge"');
     } finally {
       transform.close();
     }


### PR DESCRIPTION
## Summary
- make the TypeScript local tool bridge expose GET /health like the Rust proxy
- accept generated CLI /exec payloads using { tool, input } as well as wrapper payloads using { tool_name, tool_input }
- expose bridgeUrl/token on generated transform results for tests/debugging
- add a regression covering generated CLI bridge compatibility

## Validation
- cd typescript && bun run typecheck && bun run lint && bun run format:check
- cd typescript && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "generated CLI clients"
- make check