### PR TITLE
fix: align just-bash command dispatch

### DIFF
--- a/typescript/src/just_bash_commands.ts
+++ b/typescript/src/just_bash_commands.ts
@@ -24,21 +24,44 @@ export interface JustBashCommandSource {
 export function createJustBashCommandRegistrations(
   sources: JustBashCommandSource[],
 ): JustBashCommandRegistration[] {
-  return sources.map((source) => ({
-    providerName: source.providerName,
-    commandName: source.commandName,
-    backendToolName: source.backendToolName,
-    helpToolName: source.helpToolName,
-    command: defineCommand(source.commandName, async (args) => {
-      try {
-        const parsedInput = parseToolArgv(source.tool, args);
-        const toolInput = normalizeStructuredArgValues(source.tool.inputSchema, parsedInput);
-        return output(await source.invoke(toolInput));
-      } catch (error) {
-        return failure(error);
-      }
-    }),
-  }));
+  const grouped = new Map<string, JustBashCommandSource[]>();
+  for (const source of sources) {
+    grouped.set(source.providerName, [...(grouped.get(source.providerName) ?? []), source]);
+  }
+
+  return [...grouped.entries()].map(([providerName, providerSources]) => {
+    const bySubcommand = new Map(
+      providerSources.flatMap((source) => [
+        [source.commandName, source] as const,
+        [source.backendToolName.replaceAll("_", "-"), source] as const,
+        [source.backendToolName, source] as const,
+      ]),
+    );
+    const first = providerSources[0];
+    return {
+      providerName,
+      commandName: providerName,
+      backendToolName: providerName,
+      helpToolName: first?.helpToolName ?? `${providerName}_help`,
+      command: defineCommand(providerName, async (args) => {
+        try {
+          const [subcommand, ...toolArgs] = args;
+          if (subcommand === undefined || subcommand === "--help" || subcommand === "-h") {
+            return output(dispatcherHelp(providerName, providerSources));
+          }
+          const source = bySubcommand.get(subcommand);
+          if (source === undefined) {
+            throw new Error(`Unknown ${providerName} subcommand: ${subcommand}`);
+          }
+          const parsedInput = parseToolArgv(source.tool, toolArgs);
+          const toolInput = normalizeStructuredArgValues(source.tool.inputSchema, parsedInput);
+          return output(await source.invoke(toolInput));
+        } catch (error) {
+          return failure(error);
+        }
+      }),
+    };
+  });
 }
 
 export function installJustBashRegistrations(
@@ -57,6 +80,26 @@ export function installJustBashRegistrations(
       ...registrations.map((registration) => registration.command),
     ];
   }
+}
+
+function dispatcherHelp(providerName: string, sources: JustBashCommandSource[]): string {
+  const maxNameLength = Math.max(
+    ...sources.map((source) => source.backendToolName.replaceAll("_", "-").length),
+    0,
+  );
+  return [
+    `${providerName} - the ${providerName} toolset`,
+    "",
+    "USAGE:",
+    `  ${providerName} <subcommand> [options]`,
+    "",
+    "SUBCOMMANDS:",
+    ...sources.map((source) => {
+      const description = (source.tool.description ?? "").replace(/\s+/g, " ").trim();
+      const subcommand = source.backendToolName.replaceAll("_", "-");
+      return `  ${subcommand.padEnd(maxNameLength + 2)}${description}`.trimEnd();
+    }),
+  ].join("\n");
 }
 
 function output(stdout: string): ExecResult {

--- a/typescript/src/transforms.ts
+++ b/typescript/src/transforms.ts
@@ -60,7 +60,7 @@ export function transformToolsForJustBash(
     command: serverName,
     cliName: serverName,
     tools: executableToolsToSpecs(tools),
-    commandNameForTool: (toolName) => `${serverName}_${toolName}`,
+    commandNameForTool: cliSubcommandName,
   });
   return {
     registrations,

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -491,17 +491,17 @@ describe("local TypeScript tool compression", () => {
     );
 
     expect(Object.keys(result.tools)).toEqual(["alpha_help"]);
-    expect(result.registrations.map((registration) => registration.commandName)).toEqual([
-      "alpha_echo",
-    ]);
-    const commandResult = await bash.exec("alpha_echo --message bash");
-    expect(commandResult.exitCode).toBe(0);
+    expect(result.registrations.map((registration) => registration.commandName)).toEqual(["alpha"]);
+    const commandResult = await bash.exec("alpha echo --message bash");
+    if (commandResult.exitCode !== 0) {
+      throw new Error(`Just Bash failed: ${commandResult.stderr}`);
+    }
     expect(commandResult.stdout).toContain("rows[1]{message,ok}:");
     expect(commandResult.stdout).toContain("bash,true");
     expect(result.tools.alpha_help?.description).toContain(
       "Functionality associated with the alpha toolset is provided via the `alpha` CLI.",
     );
-    expect(result.tools.alpha_help?.description).toContain("alpha_echo");
+    expect(result.tools.alpha_help?.description).toContain("echo  Echo a message.");
     await expect(result.tools.alpha_help?.execute()).resolves.toBe(
       result.tools.alpha_help?.description,
     );
@@ -1022,9 +1022,9 @@ describe("Rust native core wrapper", () => {
       const bash = new Bash({ customCommands: [] });
       const registrations = installJustBashCommands(bash, bashProxy);
       expect(registrations.map((registration) => registration.commandName)).toEqual(
-        expect.arrayContaining(["alpha_echo", "beta_echo"]),
+        expect.arrayContaining(["alpha", "beta"]),
       );
-      const result = await bash.exec("alpha_echo --message via-bash");
+      const result = await bash.exec("alpha echo --message via-bash");
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe("alpha:via-bash");
     } finally {


### PR DESCRIPTION
## Summary
- register one Just Bash dispatcher command per toolset instead of one command per backend tool
- allow Just Bash usage like `alpha echo --message hi`, matching CLI mode's `alpha <subcommand>` shape
- keep command parsing schema-aware through the existing Rust parser binding
- update help descriptions/tests so CLI and Just Bash expose the same agent-facing command model

## Validation
- cd typescript && PYTHON="/Users/tesler/Repos/mcp-compressor/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "direct Just Bash|CLI and bash"
- cd typescript && bun run build:native && bun run typecheck && bun run lint && bun run format:check
- make check