### PR TITLE
fix: restore cli argument parsing parity

### DIFF
--- a/crates/mcp-compressor-core/src/cli/parser.rs
+++ b/crates/mcp-compressor-core/src/cli/parser.rs
@@ -37,7 +37,9 @@ pub fn parse_argv(argv: &[String], tool: &Tool) -> Result<serde_json::Value, Err
             .get(1)
             .ok_or_else(|| Error::Parse("--json requires a value".to_string()))?;
         if argv.len() > 2 {
-            return Err(Error::Parse("--json cannot be combined with other arguments".to_string()));
+            return Err(Error::Parse(
+                "--json cannot be combined with other arguments".to_string(),
+            ));
         }
         return Ok(serde_json::from_str(json)?);
     }
@@ -50,7 +52,9 @@ pub fn parse_argv(argv: &[String], tool: &Tool) -> Result<serde_json::Value, Err
     while index < argv.len() {
         let arg = &argv[index];
         if !arg.starts_with("--") || arg == "--" {
-            return Err(Error::Parse(format!("unexpected positional argument: {arg}")));
+            return Err(Error::Parse(format!(
+                "unexpected positional argument: {arg}"
+            )));
         }
 
         let (property_name, forced_bool) = parse_flag_name(arg);
@@ -61,7 +65,9 @@ pub fn parse_argv(argv: &[String], tool: &Tool) -> Result<serde_json::Value, Err
 
         let (raw_value, consumed) = if forced_bool == Some(false) {
             if schema_type != Some("boolean") {
-                return Err(Error::Parse(format!("{arg} can only be used with boolean properties")));
+                return Err(Error::Parse(format!(
+                    "{arg} can only be used with boolean properties"
+                )));
             }
             (None, 1)
         } else if schema_type == Some("boolean") {
@@ -84,7 +90,9 @@ pub fn parse_argv(argv: &[String], tool: &Tool) -> Result<serde_json::Value, Err
 
     for property in required {
         if !output.contains_key(&property) {
-            return Err(Error::Validation(format!("missing required argument: {property}")));
+            return Err(Error::Validation(format!(
+                "missing required argument: {property}"
+            )));
         }
     }
 
@@ -149,11 +157,21 @@ fn coerce_value(
         Some("integer") => coerce_integer(property_name, raw_value),
         Some("number") => coerce_number(property_name, raw_value),
         Some("array") => {
+            let raw = raw_value.unwrap_or_default();
+            if let Ok(Value::Array(values)) = serde_json::from_str::<Value>(raw) {
+                return Ok(Value::Array(values));
+            }
             let item_schema = array_item_schema(schema).unwrap_or(&Value::Null);
             coerce_value(property_name, item_schema, raw_value, None)
         }
-        _ => Ok(Value::String(raw_value.unwrap_or_default().to_string())),
+        Some("object") => coerce_json_or_string(raw_value),
+        _ => coerce_json_or_string(raw_value),
     }
+}
+
+fn coerce_json_or_string(raw_value: Option<&str>) -> Result<Value, Error> {
+    let raw = raw_value.unwrap_or_default();
+    Ok(serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_string())))
 }
 
 fn coerce_bool(property_name: &str, raw_value: Option<&str>) -> Result<Value, Error> {
@@ -168,31 +186,44 @@ fn coerce_bool(property_name: &str, raw_value: Option<&str>) -> Result<Value, Er
 }
 
 fn coerce_integer(property_name: &str, raw_value: Option<&str>) -> Result<Value, Error> {
-    let value = raw_value.ok_or_else(|| Error::Parse(format!("{property_name} requires a value")))?;
-    let parsed = value
-        .parse::<i64>()
-        .map_err(|_| Error::Parse(format!("invalid integer value for {property_name}: {value}")))?;
+    let value =
+        raw_value.ok_or_else(|| Error::Parse(format!("{property_name} requires a value")))?;
+    let parsed = value.parse::<i64>().map_err(|_| {
+        Error::Parse(format!(
+            "invalid integer value for {property_name}: {value}"
+        ))
+    })?;
     Ok(Value::Number(Number::from(parsed)))
 }
 
 fn coerce_number(property_name: &str, raw_value: Option<&str>) -> Result<Value, Error> {
-    let value = raw_value.ok_or_else(|| Error::Parse(format!("{property_name} requires a value")))?;
+    let value =
+        raw_value.ok_or_else(|| Error::Parse(format!("{property_name} requires a value")))?;
     let parsed = value
         .parse::<f64>()
         .map_err(|_| Error::Parse(format!("invalid number value for {property_name}: {value}")))?;
-    let number = Number::from_f64(parsed)
-        .ok_or_else(|| Error::Parse(format!("invalid number value for {property_name}: {value}")))?;
+    let number = Number::from_f64(parsed).ok_or_else(|| {
+        Error::Parse(format!("invalid number value for {property_name}: {value}"))
+    })?;
     Ok(Value::Number(number))
 }
 
-fn insert_value(output: &mut Map<String, Value>, property_name: &str, schema: &Value, value: Value) {
+fn insert_value(
+    output: &mut Map<String, Value>,
+    property_name: &str,
+    schema: &Value,
+    value: Value,
+) {
     if schema_type(schema) == Some("array") {
-        output
+        let array = output
             .entry(property_name.to_string())
             .or_insert_with(|| Value::Array(Vec::new()))
             .as_array_mut()
-            .expect("array property should be stored as array")
-            .push(value);
+            .expect("array property should be stored as array");
+        match value {
+            Value::Array(values) => array.extend(values),
+            value => array.push(value),
+        }
     } else {
         output.insert(property_name.to_string(), value);
     }
@@ -243,9 +274,15 @@ mod tests {
                 "method": { "type": "string" }
             }
         }));
-        let result =
-            parse_argv(&args(&["--url", "https://example.com", "--method", "GET"]), &tool).unwrap();
-        assert_eq!(result, json!({ "url": "https://example.com", "method": "GET" }));
+        let result = parse_argv(
+            &args(&["--url", "https://example.com", "--method", "GET"]),
+            &tool,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            json!({ "url": "https://example.com", "method": "GET" })
+        );
     }
 
     // ------------------------------------------------------------------
@@ -347,6 +384,41 @@ mod tests {
         }));
         let result = parse_argv(&args(&["--tags", "a", "--tags", "b"]), &tool).unwrap();
         assert_eq!(result, json!({ "tags": ["a", "b"] }));
+    }
+
+    /// A JSON array value is expanded for array properties.
+    #[test]
+    fn array_arg_json_array_value() {
+        let tool = tool_with_schema(json!({
+            "type": "object",
+            "properties": {
+                "tags": { "type": "array", "items": { "type": "string" } }
+            }
+        }));
+        let result = parse_argv(&args(&["--tags", "[\"a\",\"b\"]"]), &tool).unwrap();
+        assert_eq!(result, json!({ "tags": ["a", "b"] }));
+    }
+
+    /// Object properties parse JSON values, matching legacy Python CLI mode.
+    #[test]
+    fn object_arg_json_value() {
+        let tool = tool_with_schema(json!({
+            "type": "object",
+            "properties": { "metadata": { "type": "object" } }
+        }));
+        let result = parse_argv(&args(&["--metadata", "{\"ok\":true}"]), &tool).unwrap();
+        assert_eq!(result, json!({ "metadata": { "ok": true } }));
+    }
+
+    /// Complex values fall back to strings when JSON parsing fails.
+    #[test]
+    fn object_arg_invalid_json_falls_back_to_string() {
+        let tool = tool_with_schema(json!({
+            "type": "object",
+            "properties": { "metadata": { "type": "object" } }
+        }));
+        let result = parse_argv(&args(&["--metadata", "not-json"]), &tool).unwrap();
+        assert_eq!(result, json!({ "metadata": "not-json" }));
     }
 
     /// A single-element array works correctly.
@@ -462,8 +534,7 @@ mod tests {
     #[test]
     fn json_escape_hatch() {
         let tool = tool_with_schema(json!({ "type": "object", "properties": {} }));
-        let result =
-            parse_argv(&args(&["--json", r#"{"key": "val"}"#]), &tool).unwrap();
+        let result = parse_argv(&args(&["--json", r#"{"key": "val"}"#]), &tool).unwrap();
         assert_eq!(result, json!({ "key": "val" }));
     }
 

--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -126,27 +126,112 @@ HELP
     }}
     python3 - "$BRIDGE_ENTRY" "{tool_name}" "$@" <<'PY'
 import json, sys, urllib.error, urllib.request
+
+TOOL_SCHEMAS = json.loads({tool_schemas:?})
+
 bridge_entry, tool_name, *argv = sys.argv[1:]
 entry = json.loads(bridge_entry)
 bridge = entry["bridge"]
 token = entry["token"]
-tool_input = {{}}
-index = 0
-while index < len(argv):
-    flag = argv[index]
-    if not flag.startswith("--"):
-        raise SystemExit(f"unexpected positional argument: {{flag}}")
-    key = flag[2:].replace("-", "_")
-    if index + 1 >= len(argv) or argv[index + 1].startswith("--"):
-        tool_input[key] = True
-        index += 1
-    else:
-        raw_value = argv[index + 1]
+tool_schema = TOOL_SCHEMAS[tool_name]
+properties = tool_schema.get("inputSchema") or tool_schema.get("input_schema") or {{}}
+properties = properties.get("properties", {{}}) if isinstance(properties, dict) else {{}}
+
+def schema_type(schema):
+    return schema.get("type") if isinstance(schema, dict) else None
+
+def flag_to_property(flag):
+    raw = flag[2:]
+    if raw.startswith("no-"):
+        raw = raw[3:]
+    snake = raw.replace("-", "_")
+    if snake in properties:
+        return snake
+    return raw.replace("_", "-")
+
+def coerce_value(schema, raw_value, forced_bool=None):
+    if forced_bool is not None:
+        return forced_bool
+    typ = schema_type(schema)
+    if typ == "boolean":
+        if raw_value is None:
+            return True
+        if raw_value == "true":
+            return True
+        if raw_value == "false":
+            return False
+        raise SystemExit(f"invalid boolean value: {{raw_value}}")
+    if typ == "integer":
         try:
-            tool_input[key] = json.loads(raw_value)
-        except json.JSONDecodeError:
-            tool_input[key] = raw_value
-        index += 2
+            return int(raw_value)
+        except Exception:
+            raise SystemExit(f"invalid integer value: {{raw_value}}")
+    if typ == "number":
+        try:
+            return float(raw_value)
+        except Exception:
+            raise SystemExit(f"invalid number value: {{raw_value}}")
+    if typ == "array":
+        try:
+            parsed = json.loads(raw_value)
+            if isinstance(parsed, list):
+                return parsed
+        except Exception:
+            pass
+        return coerce_value(schema.get("items", {{}}), raw_value)
+    try:
+        return json.loads(raw_value or "")
+    except Exception:
+        return raw_value or ""
+
+def insert_value(output, key, schema, value):
+    if schema_type(schema) == "array":
+        values = value if isinstance(value, list) else [value]
+        output.setdefault(key, []).extend(values)
+    else:
+        output[key] = value
+
+def parse_args(argv):
+    if argv and argv[0] == "--json":
+        if len(argv) < 2:
+            raise SystemExit("--json requires a value")
+        if len(argv) > 2:
+            raise SystemExit("--json cannot be combined with other arguments")
+        return json.loads(argv[1])
+    output = {{}}
+    index = 0
+    while index < len(argv):
+        flag = argv[index]
+        if not flag.startswith("--") or flag == "--":
+            raise SystemExit(f"unexpected positional argument: {{flag}}")
+        prop = flag_to_property(flag)
+        if prop not in properties:
+            raise SystemExit(f"unknown flag: {{flag}}")
+        schema = properties[prop]
+        typ = schema_type(schema)
+        forced_bool = False if flag.startswith("--no-") else None
+        if forced_bool is False:
+            if typ != "boolean":
+                raise SystemExit(f"{{flag}} can only be used with boolean properties")
+            raw_value = None
+            consumed = 1
+        elif typ == "boolean":
+            if index + 1 < len(argv) and not argv[index + 1].startswith("--"):
+                raw_value = argv[index + 1]
+                consumed = 2
+            else:
+                raw_value = None
+                consumed = 1
+        else:
+            if index + 1 >= len(argv) or argv[index + 1].startswith("--"):
+                raise SystemExit(f"{{flag}} requires a value")
+            raw_value = argv[index + 1]
+            consumed = 2
+        insert_value(output, prop, schema, coerce_value(schema, raw_value, forced_bool))
+        index += consumed
+    return output
+
+tool_input = parse_args(argv)
 payload = json.dumps({{"tool": tool_name, "input": tool_input}}).encode()
 req = urllib.request.Request(
     bridge + "/exec",
@@ -174,6 +259,7 @@ PY
             subcommand = subcommand,
             tool_help = tool_help,
             tool_name = shell_quote(&tool.name),
+            tool_schemas = tool_schema_map_literal(config),
         ));
     }
 
@@ -230,6 +316,17 @@ pub fn read_live_bridge_entries(script: &str) -> Vec<CliBridgeEntry> {
         })
         .filter(|entry| bridge_is_live(&entry.bridge_url))
         .collect()
+}
+
+fn tool_schema_map_literal(config: &GeneratorConfig) -> String {
+    let mut map = serde_json::Map::new();
+    for tool in &config.tools {
+        map.insert(
+            tool.name.clone(),
+            serde_json::to_value(tool).unwrap_or_else(|_| serde_json::json!({})),
+        );
+    }
+    serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
 }
 
 fn bridge_map_literal(config: &GeneratorConfig) -> String {

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -111,6 +111,63 @@ async fn generated_cli_script_handles_structured_json_arguments() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn generated_cli_script_matches_legacy_argument_parser_features() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let (config, _proxy) = running_proxy_config(tempdir.path()).await;
+    let mut config = config;
+    config.tools = real_backend_tools().await;
+
+    CliGenerator.generate(&config).unwrap();
+    let script = tempdir.path().join("alpha");
+
+    let repeated = std::process::Command::new(&script)
+        .args([
+            "summarize-payload",
+            "--items",
+            "one",
+            "--items",
+            "two",
+            "--metadata",
+            "{\"source\":\"repeat\"}",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        repeated.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&repeated.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&repeated.stdout);
+    assert!(stdout.contains("repeat"));
+    assert!(stdout.contains("one"));
+    assert!(stdout.contains("two"));
+
+    let json_escape = std::process::Command::new(&script)
+        .args([
+            "summarize-payload",
+            "--json",
+            "{\"items\":[\"json\"],\"metadata\":{\"source\":\"escape\"}}",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        json_escape.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&json_escape.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&json_escape.stdout);
+    assert!(stdout.contains("escape"));
+    assert!(stdout.contains("json"));
+
+    let unknown = std::process::Command::new(&script)
+        .args(["echo", "--unknown", "value"])
+        .output()
+        .unwrap();
+    assert!(!unknown.status.success());
+    assert!(String::from_utf8_lossy(&unknown.stderr).contains("unknown flag"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_cli_script_invokes_real_proxy_and_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let (config, _proxy) = running_proxy_config(tempdir.path()).await;


### PR DESCRIPTION
## Summary
- restore legacy CLI parser behavior for complex/object JSON arguments
- support JSON array values for array properties in addition to repeated flags
- update generated CLI scripts to use schema-aware parsing instead of ad-hoc json.loads parsing
- add generated CLI parity coverage for repeated flags, --json escape hatch, and unknown flag errors

## Validation
- cargo test -p mcp-compressor-core cli::parser -- --nocapture
- PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test generated_clients generated_cli_script_handles_structured_json_arguments -- --nocapture
- PYTHON="/Users/tesler/Repos/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test generated_clients generated_cli_script_matches_legacy_argument_parser_features -- --nocapture
- cargo check -p mcp-compressor-core
- make check