### PR TITLE
fix: unwrap MCP text content results

### DIFF
--- a/typescript/src/tool_specs.ts
+++ b/typescript/src/tool_specs.ts
@@ -23,7 +23,22 @@ export function normalizeServerName(name: string | undefined): string {
 }
 
 export function stringifyToolResult(value: unknown): string {
-  return typeof value === "string" ? value : JSON.stringify(value);
+  if (typeof value === "string") return value;
+  const mcpText = stringifyMcpTextContent(value);
+  if (mcpText !== undefined) return mcpText;
+  return JSON.stringify(value);
+}
+
+function stringifyMcpTextContent(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const content = (value as { readonly content?: unknown }).content;
+  if (!Array.isArray(content)) return undefined;
+  const textParts = content.flatMap((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+    const candidate = item as { readonly type?: unknown; readonly text?: unknown };
+    return candidate.type === "text" && typeof candidate.text === "string" ? [candidate.text] : [];
+  });
+  return textParts.length > 0 ? textParts.join("\n") : undefined;
 }
 
 export function normalizeStructuredArgValues(

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -594,6 +594,46 @@ describe("local TypeScript tool compression", () => {
     }
   });
 
+  it("stringifies MCP text content results for generated CLI bridges", async () => {
+    const outputDir = join(tmpdir(), "mcp-cli-mcp-text-result");
+    const transform = await transformToolsForCliMode(
+      {
+        user_info: {
+          name: "user_info",
+          description: "Get user info.",
+          inputSchema: { type: "object", properties: {} },
+          execute: async (): Promise<unknown> => ({
+            content: [
+              {
+                type: "text",
+                text: '{"accountId":"abc-123","displayName":"Ada Lovelace"}',
+              },
+            ],
+          }),
+        },
+      },
+      { serverName: "alpha", outputDir },
+    );
+    try {
+      const execResponse = await fetch(`${transform.bridgeUrl}/exec`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${transform.token}`,
+        },
+        body: JSON.stringify({ tool: "user_info", input: {} }),
+      });
+      expect(execResponse.status).toBe(200);
+      const execBody = (await execResponse.json()) as { result: string };
+      expect(execBody.result).not.toContain("[object Object]");
+      expect(execBody.result).not.toContain('"content"');
+      expect(execBody.result).toContain("abc-123");
+      expect(execBody.result).toContain("Ada Lovelace");
+    } finally {
+      transform.close();
+    }
+  });
+
   it("defaults CLI transform output to a user PATH directory", async () => {
     const previousHome = process.env.HOME;
     const home = mkdtempSync(join(tmpdir(), "mcp-cli-home-"));


### PR DESCRIPTION
## Summary
- unwrap MCP-style text content results before CLI bridge serialization
- avoid exposing raw `{ content: [...] }` wrappers in generated CLI output
- add regression coverage for generated CLI bridge results

## Validation
- `PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "MCP text content|generated CLI clients"`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
