### PR TITLE
fix: centralize host transforms in rust

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/host_transform.rs
+++ b/crates/mcp-compressor-core/src/ffi/host_transform.rs
@@ -1,0 +1,417 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::client_gen::cli::CliGenerator;
+use crate::client_gen::generator::{artifact_map, write_artifacts, ClientGenerator, GeneratorConfig};
+use crate::client_gen::python::PythonGenerator;
+use crate::client_gen::typescript::TypeScriptGenerator;
+use crate::ffi::client_gen::FfiClientArtifactKind;
+use crate::ffi::dto::{FfiGeneratorConfig, FfiTool};
+use crate::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum FfiHostTransformKind {
+    Cli,
+    JustBash,
+    Python,
+    #[serde(rename = "typescript")]
+    TypeScript,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FfiHostTransformConfig {
+    pub kind: FfiHostTransformKind,
+    pub server_name: String,
+    pub tools: Vec<FfiTool>,
+    pub output_dir: Option<PathBuf>,
+    pub command_name: Option<String>,
+    pub bridge_url: Option<String>,
+    pub token: Option<String>,
+    pub session_pid: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FfiHostTransformPlan {
+    pub help_tool_name: String,
+    pub help_description: String,
+    pub output_dir: Option<PathBuf>,
+    pub files: BTreeMap<String, String>,
+    pub paths: Vec<PathBuf>,
+    pub environment: BTreeMap<String, String>,
+    pub just_bash: Option<FfiHostJustBashPlan>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FfiHostJustBashPlan {
+    pub provider_name: String,
+    pub command_name: String,
+    pub help_tool_name: String,
+    pub commands: Vec<FfiHostJustBashCommandPlan>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FfiHostJustBashCommandPlan {
+    pub command_name: String,
+    pub backend_tool_name: String,
+    pub description: Option<String>,
+    pub input_schema: Value,
+}
+
+pub fn build_host_transform_plan(
+    config: FfiHostTransformConfig,
+) -> Result<FfiHostTransformPlan, Error> {
+    let server_name = normalize_server_name(Some(config.server_name));
+    let help_tool_name = format!("{server_name}_help");
+    match config.kind {
+        FfiHostTransformKind::JustBash => {
+            let help_description = shell_tool_help_description(&server_name, &server_name, &config.tools);
+            let commands = config
+                .tools
+                .iter()
+                .map(|tool| FfiHostJustBashCommandPlan {
+                    command_name: cli_subcommand_name(&tool.name),
+                    backend_tool_name: tool.name.clone(),
+                    description: tool.description.clone(),
+                    input_schema: tool.input_schema.clone(),
+                })
+                .collect();
+            Ok(FfiHostTransformPlan {
+                help_tool_name: help_tool_name.clone(),
+                help_description,
+                output_dir: None,
+                files: BTreeMap::new(),
+                paths: Vec::new(),
+                environment: BTreeMap::new(),
+                just_bash: Some(FfiHostJustBashPlan {
+                    provider_name: server_name.clone(),
+                    command_name: server_name,
+                    help_tool_name,
+                    commands,
+                }),
+            })
+        }
+        FfiHostTransformKind::Cli => {
+            let output_dir = config.output_dir.unwrap_or_else(default_cli_output_dir);
+            let command_name = config.command_name.unwrap_or_else(|| server_name.clone());
+            let generator_config = generator_config(
+                &server_name,
+                &output_dir,
+                config.tools.clone(),
+                config.bridge_url,
+                config.token,
+                config.session_pid,
+            );
+            let artifacts = CliGenerator.render(&generator_config)?;
+            let files = artifact_map(&artifacts);
+            let paths = write_artifacts(&artifacts, &output_dir)?;
+            let help_description = shell_tool_help_description(&command_name, &server_name, &config.tools);
+            Ok(FfiHostTransformPlan {
+                help_tool_name,
+                help_description,
+                output_dir: Some(output_dir.clone()),
+                files,
+                paths,
+                environment: path_environment(&output_dir),
+                just_bash: None,
+            })
+        }
+        FfiHostTransformKind::Python | FfiHostTransformKind::TypeScript => {
+            let output_dir = config.output_dir.unwrap_or_else(|| PathBuf::from("./dist"));
+            let artifact_kind = match config.kind {
+                FfiHostTransformKind::Python => FfiClientArtifactKind::Python,
+                FfiHostTransformKind::TypeScript => FfiClientArtifactKind::TypeScript,
+                _ => unreachable!(),
+            };
+            let generator_config = generator_config(
+                &server_name,
+                &output_dir,
+                config.tools.clone(),
+                config.bridge_url,
+                config.token,
+                config.session_pid,
+            );
+            let artifacts = match artifact_kind {
+                FfiClientArtifactKind::Python => PythonGenerator.render(&generator_config)?,
+                FfiClientArtifactKind::TypeScript => TypeScriptGenerator.render(&generator_config)?,
+                FfiClientArtifactKind::Cli => unreachable!(),
+            };
+            let files = artifact_map(&artifacts);
+            let paths = write_artifacts(&artifacts, &output_dir)?;
+            let help_description = code_help_description(artifact_kind, &server_name, &output_dir, &config.tools);
+            let environment = match config.kind {
+                FfiHostTransformKind::Python => {
+                    let mut env = BTreeMap::new();
+                    env.insert(
+                        "PYTHONPATH".to_string(),
+                        output_dir.to_string_lossy().into_owned(),
+                    );
+                    env
+                }
+                _ => BTreeMap::new(),
+            };
+            Ok(FfiHostTransformPlan {
+                help_tool_name,
+                help_description,
+                output_dir: Some(output_dir),
+                files,
+                paths,
+                environment,
+                just_bash: None,
+            })
+        }
+    }
+}
+
+pub fn normalize_host_tool_result(value: Value, toonify: bool) -> String {
+    let output = value_to_string(&value);
+    if toonify {
+        crate::ffi::client_gen::maybe_toonify_output(&output)
+    } else {
+        output
+    }
+}
+
+fn generator_config(
+    server_name: &str,
+    output_dir: &std::path::Path,
+    tools: Vec<FfiTool>,
+    bridge_url: Option<String>,
+    token: Option<String>,
+    session_pid: Option<u32>,
+) -> GeneratorConfig {
+    FfiGeneratorConfig {
+        cli_name: server_name.to_string(),
+        bridge_url: bridge_url.unwrap_or_else(|| "http://127.0.0.1:0".to_string()),
+        token: token.unwrap_or_default(),
+        tools,
+        session_pid: session_pid.unwrap_or_else(std::process::id),
+        output_dir: output_dir.to_path_buf(),
+    }
+    .into()
+}
+
+fn shell_tool_help_description(command: &str, cli_name: &str, tools: &[FfiTool]) -> String {
+    let mut lines = vec![
+        format!(
+            "Functionality associated with the {cli_name} toolset is provided via the `{command}` CLI. Do not call this tool - use the CLI instead."
+        ),
+        format!("{cli_name} - the {cli_name} toolset"),
+        String::new(),
+        "When relevant, outputs from this CLI will prefer using the TOON format for more efficient representation of data.".to_string(),
+        String::new(),
+        "USAGE:".to_string(),
+        format!("  {command} <subcommand> [options]"),
+        String::new(),
+        "SUBCOMMANDS:".to_string(),
+    ];
+    lines.extend(format_subcommands(tools, cli_subcommand_name));
+    lines.extend([
+        String::new(),
+        format!("Run '{command} --help' in the shell for usage."),
+        format!("Run '{command} <subcommand> --help' for per-command help."),
+        format!("Run '{command} <subcommand> [options]' to invoke a tool."),
+    ]);
+    lines.join("\n")
+}
+
+fn code_help_description(
+    kind: FfiClientArtifactKind,
+    server_name: &str,
+    output_dir: &std::path::Path,
+    tools: &[FfiTool],
+) -> String {
+    let (language, language_lower, module_name) = match kind {
+        FfiClientArtifactKind::Python => ("Python", "python", format!("{server_name}.py")),
+        FfiClientArtifactKind::TypeScript => ("TypeScript", "typescript", format!("{server_name}.ts")),
+        FfiClientArtifactKind::Cli => unreachable!(),
+    };
+    let source_path = output_dir.join(&module_name).to_string_lossy().into_owned();
+    let mut lines = vec![
+        format!(
+            "Functionality associated with the {server_name} toolset is provided via a {language} module. Do not call this tool - import and use the {language_lower} functionality instead."
+        ),
+        format!("{server_name} - the {server_name} toolset"),
+        String::new(),
+        format!("{language} source code is available in {source_path}"),
+        String::new(),
+        "Available functions:".to_string(),
+    ];
+    let function_names = tools
+        .iter()
+        .map(|tool| match kind {
+            FfiClientArtifactKind::Python => tool.name.clone(),
+            FfiClientArtifactKind::TypeScript => snake_to_camel(&tool.name),
+            FfiClientArtifactKind::Cli => unreachable!(),
+        })
+        .collect::<Vec<_>>();
+    let max_name_len = function_names.iter().map(String::len).max().unwrap_or(0);
+    for (tool, function_name) in tools.iter().zip(function_names) {
+        let description = compact_description(tool.description.as_deref());
+        lines.push(format!(
+            "  {name:<width$}{description}",
+            name = function_name,
+            width = max_name_len + 2
+        ).trim_end().to_string());
+    }
+    lines.push(String::new());
+    match kind {
+        FfiClientArtifactKind::Python => lines.extend([
+            "For details on a specific function, run:".to_string(),
+            "```python".to_string(),
+            format!("from {server_name} import <function>"),
+            "print(help(<function>))".to_string(),
+            "```".to_string(),
+        ]),
+        FfiClientArtifactKind::TypeScript => lines.extend([
+            "For details on a specific function, inspect the TypeScript declarations or editor hover documentation.".to_string(),
+            format!(
+                "Primary declarations: {}",
+                output_dir.join(format!("{server_name}.d.ts")).to_string_lossy()
+            ),
+        ]),
+        FfiClientArtifactKind::Cli => unreachable!(),
+    }
+    lines.join("\n")
+}
+
+fn format_subcommands(tools: &[FfiTool], name_for_tool: fn(&str) -> String) -> Vec<String> {
+    let names = tools.iter().map(|tool| name_for_tool(&tool.name)).collect::<Vec<_>>();
+    let max_name_len = names.iter().map(String::len).max().unwrap_or(0);
+    tools
+        .iter()
+        .zip(names)
+        .map(|(tool, name)| {
+            let description = compact_description(tool.description.as_deref());
+            format!("  {name:<width$}{description}", width = max_name_len + 2)
+                .trim_end()
+                .to_string()
+        })
+        .collect()
+}
+
+fn cli_subcommand_name(tool_name: &str) -> String {
+    tool_name.replace('_', "-")
+}
+
+fn compact_description(description: Option<&str>) -> String {
+    description.unwrap_or("").split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn snake_to_camel(name: &str) -> String {
+    let mut out = String::new();
+    let mut uppercase_next = false;
+    for ch in name.chars() {
+        if ch == '_' || ch == '-' {
+            uppercase_next = true;
+        } else if uppercase_next {
+            out.extend(ch.to_uppercase());
+            uppercase_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn normalize_server_name(name: Option<String>) -> String {
+    name.unwrap_or_else(|| "mcp".to_string())
+}
+
+fn default_cli_output_dir() -> PathBuf {
+    if let Ok(value) = std::env::var("MCP_COMPRESSOR_CLI_OUTPUT_DIR") {
+        if !value.is_empty() {
+            return PathBuf::from(value);
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            return PathBuf::from(home).join(".local/bin");
+        }
+    }
+    PathBuf::from("./dist")
+}
+
+fn path_environment(output_dir: &std::path::Path) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    env.insert(
+        "PATH".to_string(),
+        format!("{}:$PATH", output_dir.to_string_lossy()),
+    );
+    env
+}
+
+fn value_to_string(value: &Value) -> String {
+    if let Some(value) = value.as_str() {
+        return value.to_string();
+    }
+    if let Some(map) = value.as_object() {
+        if map.len() == 1 && map.contains_key("result") {
+            return value_to_string(&map["result"]);
+        }
+        if let Some(text) = mcp_text_content_to_string(map.get("content")) {
+            return text;
+        }
+    }
+    value.to_string()
+}
+
+fn mcp_text_content_to_string(content: Option<&Value>) -> Option<String> {
+    let content = content?.as_array()?;
+    let parts = content
+        .iter()
+        .filter_map(|item| {
+            let object = item.as_object()?;
+            if object.get("type")?.as_str()? == "text" {
+                object.get("text")?.as_str().map(ToOwned::to_owned)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tool(name: &str, description: &str) -> FfiTool {
+        FfiTool {
+            name: name.to_string(),
+            description: Some(description.to_string()),
+            input_schema: json!({"type":"object","properties":{}}),
+        }
+    }
+
+    #[test]
+    fn cli_plan_contains_subcommand_help() {
+        let plan = build_host_transform_plan(FfiHostTransformConfig {
+            kind: FfiHostTransformKind::Cli,
+            server_name: "alpha".to_string(),
+            tools: vec![tool("echo_message", "Echo a message.")],
+            output_dir: Some(PathBuf::from("./target/tmp-host-plan-cli")),
+            command_name: Some("alpha".to_string()),
+            bridge_url: Some("http://127.0.0.1:1".to_string()),
+            token: Some("token".to_string()),
+            session_pid: Some(1),
+        }).unwrap();
+        assert_eq!(plan.help_tool_name, "alpha_help");
+        assert!(plan.help_description.contains("Functionality associated with the alpha toolset is provided via the `alpha` CLI."));
+        assert!(plan.help_description.contains("  echo-message  Echo a message."));
+    }
+
+    #[test]
+    fn normalizes_mcp_text_content_results() {
+        let value = json!({"content":[{"type":"text","text":"{\"ok\":true}"}]});
+        assert_eq!(normalize_host_tool_result(value, false), "{\"ok\":true}");
+    }
+}

--- a/crates/mcp-compressor-core/src/ffi/mod.rs
+++ b/crates/mcp-compressor-core/src/ffi/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod client_gen;
 pub mod dto;
+pub mod host_transform;
 pub mod oauth;
 pub mod pure;
 pub mod session;
@@ -15,6 +16,10 @@ mod types;
 pub use client_gen::{
     generate_client_artifact_files, generate_client_artifacts, maybe_toonify_output,
     render_client_artifacts, FfiClientArtifactKind,
+};
+pub use host_transform::{
+    build_host_transform_plan, normalize_host_tool_result, FfiHostJustBashCommandPlan,
+    FfiHostJustBashPlan, FfiHostTransformConfig, FfiHostTransformKind, FfiHostTransformPlan,
 };
 pub use dto::{
     FfiBackendConfig, FfiCompressedSessionConfig, FfiCompressedSessionInfo, FfiGeneratorConfig,

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -10,11 +10,12 @@ use serde_json::Value;
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
     clear_oauth_credentials, compress_tool_listing, format_tool_schema_response,
-    generate_client_artifact_files, generate_client_artifacts, list_oauth_credentials,
-    maybe_toonify_output, normalize_sdk_servers, parse_mcp_config, parse_tool_argv,
+    build_host_transform_plan, generate_client_artifact_files, generate_client_artifacts,
+    list_oauth_credentials, maybe_toonify_output, normalize_host_tool_result,
+    normalize_sdk_servers, parse_mcp_config, parse_tool_argv,
     remember_oauth_backend, start_compressed_session, start_compressed_session_from_mcp_config,
     FfiBackendConfig, FfiClientArtifactKind, FfiCompressedSession, FfiCompressedSessionConfig,
-    FfiGeneratorConfig, FfiSdkServersConfig, FfiTool,
+    FfiGeneratorConfig, FfiHostTransformConfig, FfiSdkServersConfig, FfiTool,
 };
 
 fn napi_error(error: impl std::fmt::Display) -> NapiError {
@@ -103,6 +104,20 @@ pub fn generate_client_artifact_files_json(
     let config = parse_json::<FfiGeneratorConfig>(&config_json)?;
     let files = generate_client_artifact_files(kind, config).map_err(napi_error)?;
     serde_json::to_string(&files).map_err(napi_error)
+}
+
+
+#[napi]
+pub fn build_host_transform_plan_json(config_json: String) -> napi::Result<String> {
+    let config = parse_json::<FfiHostTransformConfig>(&config_json)?;
+    let plan = build_host_transform_plan(config).map_err(napi_error)?;
+    serde_json::to_string(&plan).map_err(napi_error)
+}
+
+#[napi]
+pub fn normalize_host_tool_result_json(value_json: String, toonify: bool) -> napi::Result<String> {
+    let value = parse_json::<Value>(&value_json)?;
+    Ok(normalize_host_tool_result(value, toonify))
 }
 
 #[napi]

--- a/typescript/src/local_tool_bridge.ts
+++ b/typescript/src/local_tool_bridge.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from "node:http";
 
 import type { ExecutableTool } from "./adapters.js";
-import { stringifyToolResult } from "./tool_specs.js";
+import { normalizeHostToolResult } from "./rust_core.js";
 
 export interface LocalToolBridge {
   bridgeUrl: string;
@@ -45,7 +45,7 @@ export async function startLocalToolBridge(
       const result = await tool.execute(body.input ?? body.tool_input ?? {});
       response
         .writeHead(200, { "content-type": "application/json" })
-        .end(JSON.stringify({ result: stringifyToolResult(result) }));
+        .end(JSON.stringify({ result: normalizeHostToolResult(result, false) }));
     } catch (error) {
       response
         .writeHead(500, { "content-type": "application/json" })

--- a/typescript/src/native.ts
+++ b/typescript/src/native.ts
@@ -13,6 +13,8 @@ export interface NativeCore {
   parseToolArgvJson(toolJson: string, argvJson: string): string;
   generateClientArtifactsJson(kind: string, configJson: string): string;
   generateClientArtifactFilesJson(kind: string, configJson: string): string;
+  buildHostTransformPlanJson(configJson: string): string;
+  normalizeHostToolResultJson(valueJson: string, toonify: boolean): string;
   normalizeServersJson(serversJson: string): string;
   parseMcpConfigJson(configJson: string): string;
   rememberOauthBackendJson(backendUri: string, backendName: string, storeDir: string): void;

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -262,3 +262,55 @@ export function listOAuthCredentials(): OAuthStoreEntry[] {
 export function clearOAuthCredentials(target?: string | null): string[] {
   return JSON.parse(loadNativeCore().clearOauthCredentialsJson(target ?? null)) as string[];
 }
+
+export interface HostTransformPlanConfig {
+  kind: ClientArtifactKind | "just-bash";
+  serverName: string;
+  tools: ToolSpec[];
+  outputDir?: string;
+  commandName?: string;
+  bridgeUrl?: string;
+  token?: string;
+  sessionPid?: number;
+}
+
+export interface HostTransformPlan {
+  helpToolName: string;
+  helpDescription: string;
+  outputDir?: string;
+  files: Record<string, string>;
+  paths: string[];
+  environment: Record<string, string>;
+  justBash?: {
+    providerName: string;
+    commandName: string;
+    helpToolName: string;
+    commands: Array<{
+      commandName: string;
+      backendToolName: string;
+      description?: string;
+      inputSchema: unknown;
+    }>;
+  };
+}
+
+export function buildHostTransformPlan(config: HostTransformPlanConfig): HostTransformPlan {
+  return JSON.parse(
+    loadNativeCore().buildHostTransformPlanJson(
+      stringify({
+        kind: config.kind,
+        serverName: config.serverName,
+        tools: config.tools.map(toNativeTool),
+        outputDir: config.outputDir,
+        commandName: config.commandName,
+        bridgeUrl: config.bridgeUrl,
+        token: config.token,
+        sessionPid: config.sessionPid,
+      }),
+    ),
+  ) as HostTransformPlan;
+}
+
+export function normalizeHostToolResult(value: unknown, toonify: boolean): string {
+  return loadNativeCore().normalizeHostToolResultJson(stringify(value), toonify);
+}

--- a/typescript/src/transforms.ts
+++ b/typescript/src/transforms.ts
@@ -1,22 +1,17 @@
 import type { ExecutableTool } from "./adapters.js";
 import {
-  generateClientFromBridge,
-  type GeneratedBridgeClientArtifactsResult,
-} from "./generated_clients.js";
-import {
   createJustBashCommandRegistrations,
   installJustBashRegistrations,
   type JustBashCommandRegistration,
   type JustBashCommandSource,
 } from "./just_bash_commands.js";
 import { startLocalToolBridge } from "./local_tool_bridge.js";
-import { maybeToonifyOutput, type ClientArtifactKind } from "./rust_core.js";
 import {
-  executableToolToSpec,
-  executableToolsToSpecs,
-  normalizeServerName,
-  stringifyToolResult,
-} from "./tool_specs.js";
+  buildHostTransformPlan,
+  normalizeHostToolResult,
+  type ClientArtifactKind,
+} from "./rust_core.js";
+import { executableToolToSpec, executableToolsToSpecs, normalizeServerName } from "./tool_specs.js";
 
 export interface TransformToolOptions {
   serverName?: string;
@@ -42,7 +37,12 @@ export interface TransformToolsForCliModeOptions extends TransformToolOptions {
   outputDir?: string;
 }
 
-export interface GeneratedToolTransformResult extends GeneratedBridgeClientArtifactsResult {
+export interface GeneratedToolTransformResult {
+  paths: string[];
+  files: Record<string, string>;
+  environment: Record<string, string>;
+  bridgeUrl: string;
+  token: string;
   tools: Record<string, ExecutableTool>;
   close(): void;
 }
@@ -52,22 +52,20 @@ export function transformToolsForJustBash(
   options: TransformToolsForJustBashOptions,
 ): JustBashTransformResult {
   const serverName = normalizeServerName(options.serverName);
+  const toolSpecs = executableToolsToSpecs(tools);
+  const plan = buildHostTransformPlan({ kind: "just-bash", serverName, tools: toolSpecs });
   const registrations = createJustBashCommandRegistrations(
-    Object.entries(tools).map(([name, tool]) => justBashSource(serverName, name, tool)),
+    (plan.justBash?.commands ?? []).map((command) =>
+      justBashSource(serverName, command.commandName, command.backendToolName, tools),
+    ),
   );
   installJustBashRegistrations(options.bash, registrations);
-  const helpDescription = shellToolHelpDescription({
-    command: serverName,
-    cliName: serverName,
-    tools: executableToolsToSpecs(tools),
-    commandNameForTool: cliSubcommandName,
-  });
   return {
     registrations,
     tools: helpTools({
-      serverName,
-      description: helpDescription,
-      output: helpDescription,
+      name: plan.helpToolName,
+      description: plan.helpDescription,
+      output: plan.helpDescription,
     }),
   };
 }
@@ -89,28 +87,31 @@ export async function transformToolsForCliMode(
   options: TransformToolsForCliModeOptions = {},
 ): Promise<GeneratedToolTransformResult> {
   const serverName = normalizeServerName(options.serverName);
-  const output =
-    options.outputDir === undefined ? defaultCliOutputDir() : { outputDir: options.outputDir };
   return generatedTransform(tools, {
     kind: "cli",
     serverName,
-    outputDir: output.outputDir,
+    outputDir: options.outputDir,
     commandName: serverName,
   });
 }
 
 function justBashSource(
   serverName: string,
-  name: string,
-  tool: ExecutableTool<unknown>,
+  commandName: string,
+  backendToolName: string,
+  tools: Record<string, ExecutableTool<unknown>>,
 ): JustBashCommandSource {
+  const tool = tools[backendToolName];
+  if (tool === undefined) {
+    throw new Error(`missing Just Bash backend tool: ${backendToolName}`);
+  }
   return {
     providerName: serverName,
-    commandName: `${serverName}_${name}`,
-    backendToolName: name,
+    commandName,
+    backendToolName,
     helpToolName: `${serverName}_help`,
-    tool: executableToolToSpec(name, tool),
-    invoke: async (input) => maybeToonifyOutput(stringifyToolResult(await tool.execute(input))),
+    tool: executableToolToSpec(backendToolName, tool),
+    invoke: async (input) => normalizeHostToolResult(await tool.execute(input), true),
   };
 }
 
@@ -119,191 +120,46 @@ async function generatedTransform(
   options: {
     kind: ClientArtifactKind;
     serverName: string;
-    outputDir: string;
+    outputDir?: string;
     commandName?: string;
   },
 ): Promise<GeneratedToolTransformResult> {
   const bridge = await startLocalToolBridge(tools);
-  const generated = generateClientFromBridge({
-    kind: options.kind,
-    name: options.serverName,
-    bridgeUrl: bridge.bridgeUrl,
-    token: bridge.token,
-    tools: executableToolsToSpecs(tools),
-    outputDir: options.outputDir,
-  });
-  const helpDescription = generatedHelpDescription({
+  const plan = buildHostTransformPlan({
     kind: options.kind,
     serverName: options.serverName,
-    outputDir: options.outputDir,
-    files: Object.keys(generated.files),
-    commandName: options.commandName,
     tools: executableToolsToSpecs(tools),
+    outputDir: options.outputDir,
+    commandName: options.commandName,
+    bridgeUrl: bridge.bridgeUrl,
+    token: bridge.token,
   });
   return {
-    ...generated,
+    paths: plan.paths,
+    files: plan.files,
+    environment: plan.environment,
+    bridgeUrl: bridge.bridgeUrl,
+    token: bridge.token,
     tools: helpTools({
-      serverName: options.serverName,
-      description: helpDescription,
-      output: helpDescription,
+      name: plan.helpToolName,
+      description: plan.helpDescription,
+      output: plan.helpDescription,
     }),
     close: () => bridge.close(),
   };
 }
 
 function helpTools(options: {
-  serverName: string;
+  name: string;
   description: string;
   output: string;
 }): Record<string, ExecutableTool> {
-  const name = `${options.serverName}_help`;
   return {
-    [name]: {
-      name,
+    [options.name]: {
+      name: options.name,
       description: options.description,
       inputSchema: { type: "object", properties: {} },
       execute: async () => options.output,
     },
   };
-}
-
-function generatedHelpDescription(options: {
-  kind: ClientArtifactKind;
-  serverName: string;
-  outputDir: string;
-  files: string[];
-  commandName?: string;
-  tools: ReturnType<typeof executableToolsToSpecs>;
-}): string {
-  if (options.kind === "cli") {
-    const command = options.commandName ?? `${options.outputDir}/${options.serverName}`;
-    return cliHelpDescription(command, options.serverName, options.tools);
-  }
-
-  return codeHelpDescription(options);
-}
-
-function cliHelpDescription(
-  command: string,
-  cliName: string,
-  tools: ReturnType<typeof executableToolsToSpecs>,
-): string {
-  return shellToolHelpDescription({
-    command,
-    cliName,
-    tools,
-    commandNameForTool: cliSubcommandName,
-  });
-}
-
-function shellToolHelpDescription(options: {
-  command: string;
-  cliName: string;
-  tools: ReturnType<typeof executableToolsToSpecs>;
-  commandNameForTool(toolName: string): string;
-}): string {
-  return [
-    `Functionality associated with the ${options.cliName} toolset is provided via the \`${options.command}\` CLI. Do not call this tool - use the CLI instead.`,
-    `${options.cliName} - the ${options.cliName} toolset`,
-    "",
-    "When relevant, outputs from this CLI will prefer using the TOON format for more efficient representation of data.",
-    "",
-    "USAGE:",
-    `  ${options.command} <subcommand> [options]`,
-    "",
-    "SUBCOMMANDS:",
-    ...formatSubcommands(options.tools, options.commandNameForTool),
-    "",
-    `Run '${options.command} --help' in the shell for usage.`,
-    `Run '${options.command} <subcommand> --help' for per-command help.`,
-    `Run '${options.command} <subcommand> [options]' to invoke a tool.`,
-  ].join("\n");
-}
-
-function formatSubcommands(
-  tools: ReturnType<typeof executableToolsToSpecs>,
-  commandNameForTool: (toolName: string) => string,
-): string[] {
-  const maxNameLength = Math.max(...tools.map((tool) => commandNameForTool(tool.name).length), 0);
-  return tools.map((tool) => {
-    const subcommand = commandNameForTool(tool.name);
-    const description = compactDescription(tool.description ?? undefined);
-    return `  ${subcommand.padEnd(maxNameLength + 2)}${description}`.trimEnd();
-  });
-}
-
-function cliSubcommandName(toolName: string): string {
-  return toolName.replaceAll("_", "-");
-}
-
-function compactDescription(description?: string): string {
-  return (description ?? "").replace(/\s+/g, " ").trim();
-}
-
-function codeHelpDescription(options: {
-  kind: ClientArtifactKind;
-  serverName: string;
-  outputDir: string;
-  files: string[];
-  tools: ReturnType<typeof executableToolsToSpecs>;
-}): string {
-  const language = options.kind === "python" ? "Python" : "TypeScript";
-  const languageLower = options.kind === "python" ? "python" : "typescript";
-  const moduleName =
-    options.kind === "python" ? `${options.serverName}.py` : `${options.serverName}.ts`;
-  const functions = formatCodeFunctions(options.kind, options.tools);
-  const details =
-    options.kind === "python"
-      ? [
-          "For details on a specific function, run:",
-          "```python",
-          `from ${options.serverName} import <function>`,
-          "print(help(<function>))",
-          "```",
-        ]
-      : [
-          "For details on a specific function, inspect the generated TypeScript declarations or editor hover documentation.",
-          `Primary declarations: ${options.outputDir}/${options.serverName}.d.ts`,
-        ];
-  return [
-    `Functionality associated with the ${options.serverName} toolset is provided via a ${language} module. Do not call this tool - import and use the ${languageLower} functionality instead.`,
-    `${options.serverName} - the ${options.serverName} toolset`,
-    "",
-    `${language} source code is available in ${options.outputDir}/${moduleName}`,
-    "",
-    "Available functions:",
-    ...functions,
-    "",
-    ...details,
-  ].join("\n");
-}
-
-function formatCodeFunctions(
-  kind: ClientArtifactKind,
-  tools: ReturnType<typeof executableToolsToSpecs>,
-): string[] {
-  const names = tools.map((tool) => (kind === "python" ? tool.name : snakeToCamel(tool.name)));
-  const maxNameLength = Math.max(...names.map((name) => name.length), 0);
-  return tools.map((tool, index) => {
-    const name = names[index] ?? tool.name;
-    return `  ${name.padEnd(maxNameLength + 2)}${compactDescription(tool.description ?? undefined)}`.trimEnd();
-  });
-}
-
-function snakeToCamel(name: string): string {
-  return name.replace(/[_-]([a-zA-Z0-9])/g, (_match, char: string) => char.toUpperCase());
-}
-
-function defaultCliOutputDir(): { outputDir: string } {
-  const envDir = process.env.MCP_COMPRESSOR_CLI_OUTPUT_DIR;
-  if (envDir !== undefined && envDir.length > 0) {
-    return { outputDir: envDir };
-  }
-
-  const home = process.env.HOME;
-  if (home !== undefined && home.length > 0) {
-    return { outputDir: `${home}/.local/bin` };
-  }
-
-  return { outputDir: "./dist" };
 }


### PR DESCRIPTION
## Summary
- add a Rust host transform plan API for CLI, Just Bash, Python, and TypeScript transforms
- move host-owned help descriptions, default output paths, artifact rendering, Just Bash metadata, and output normalization into Rust
- keep TypeScript responsible only for JS callback execution, local bridge hosting, and Just Bash command registration
- preserve generated CLI bridge compatibility (`bridgeUrl`, `token`, `files`, `paths`, `environment`)
- keep recent regressions covered: self-contained help descriptions, CLI/Just Bash parity, structured arg parsing, MCP text content output normalization

## Validation
- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `cargo test -p mcp-compressor-core ffi::host_transform -- --nocapture`
- `cd typescript && bun run build:native`
- `PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/transforms_e2e.test.ts tests/rust_core.test.ts -t "generated CLI clients|MCP text content|direct Just Bash|CLI transform|Just Bash transform|Python code transform|TypeScript code transform"`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
