### PR TITLE
fix: unwrap result wrappers in host transforms

### DIFF
--- a/typescript/src/tool_specs.ts
+++ b/typescript/src/tool_specs.ts
@@ -24,9 +24,17 @@ export function normalizeServerName(name: string | undefined): string {
 
 export function stringifyToolResult(value: unknown): string {
   if (typeof value === "string") return value;
-  const mcpText = stringifyMcpTextContent(value);
+  const unwrapped = unwrapSingleResultWrapper(value);
+  if (typeof unwrapped === "string") return unwrapped;
+  const mcpText = stringifyMcpTextContent(unwrapped);
   if (mcpText !== undefined) return mcpText;
-  return JSON.stringify(value);
+  return JSON.stringify(unwrapped);
+}
+
+function unwrapSingleResultWrapper(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const entries = Object.entries(value as Record<string, unknown>);
+  return entries.length === 1 && entries[0]?.[0] === "result" ? entries[0][1] : value;
 }
 
 function stringifyMcpTextContent(value: unknown): string | undefined {

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -634,6 +634,50 @@ describe("local TypeScript tool compression", () => {
     }
   });
 
+  it("unwraps single result wrappers before MCP text content results", async () => {
+    const outputDir = join(tmpdir(), "mcp-cli-wrapped-mcp-text-result");
+    const transform = await transformToolsForCliMode(
+      {
+        user_info: {
+          name: "user_info",
+          description: "Get user info.",
+          inputSchema: { type: "object", properties: {} },
+          execute: async (): Promise<unknown> => ({
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: '{"accountId":"abc-123","displayName":"Ada Lovelace"}',
+                },
+              ],
+              isError: false,
+            },
+          }),
+        },
+      },
+      { serverName: "alpha", outputDir },
+    );
+    try {
+      const execResponse = await fetch(`${transform.bridgeUrl}/exec`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${transform.token}`,
+        },
+        body: JSON.stringify({ tool: "user_info", input: {} }),
+      });
+      expect(execResponse.status).toBe(200);
+      const execBody = (await execResponse.json()) as { result: string };
+      expect(execBody.result).not.toContain("[object Object]");
+      expect(execBody.result).not.toContain('"content"');
+      expect(execBody.result).not.toContain('"result"');
+      expect(execBody.result).toContain("abc-123");
+      expect(execBody.result).toContain("Ada Lovelace");
+    } finally {
+      transform.close();
+    }
+  });
+
   it("defaults CLI transform output to a user PATH directory", async () => {
     const previousHome = process.env.HOME;
     const home = mkdtempSync(join(tmpdir(), "mcp-cli-home-"));


### PR DESCRIPTION
## Summary
- match the Rust result formatting behavior by unwrapping single-key `{ result: ... }` wrappers in TypeScript host transforms
- apply MCP text-content unwrapping after the result wrapper is removed
- add generated CLI bridge regression coverage for nested result/content responses

## Validation
- `PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "MCP text content|single result wrappers|generated CLI clients"`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
