### PR TITLE
fix: render host CLI subcommands as kebab-case

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/host_transform.rs
+++ b/crates/mcp-compressor-core/src/ffi/host_transform.rs
@@ -298,7 +298,7 @@ fn format_subcommands(tools: &[FfiTool], name_for_tool: fn(&str) -> String) -> V
 }
 
 fn cli_subcommand_name(tool_name: &str) -> String {
-    tool_name.replace('_', "-")
+    crate::cli::mapping::tool_name_to_subcommand(tool_name)
 }
 
 fn compact_description(description: Option<&str>) -> String {
@@ -407,6 +407,27 @@ mod tests {
         assert_eq!(plan.help_tool_name, "alpha_help");
         assert!(plan.help_description.contains("Functionality associated with the alpha toolset is provided via the `alpha` CLI."));
         assert!(plan.help_description.contains("  echo-message  Echo a message."));
+    }
+
+    #[test]
+    fn cli_plan_uses_kebab_case_for_camel_case_tool_names() {
+        let plan = build_host_transform_plan(FfiHostTransformConfig {
+            kind: FfiHostTransformKind::Cli,
+            server_name: "atlassian".to_string(),
+            tools: vec![
+                tool("atlassianUserInfo", "Get current user info."),
+                tool("getAccessibleAtlassianResources", "Get accessible resources."),
+            ],
+            output_dir: Some(PathBuf::from("./target/tmp-host-plan-camel-cli")),
+            command_name: Some("atlassian".to_string()),
+            bridge_url: Some("http://127.0.0.1:1".to_string()),
+            token: Some("token".to_string()),
+            session_pid: Some(1),
+        }).unwrap();
+        assert!(plan.help_description.contains("  atlassian-user-info"));
+        assert!(plan.help_description.contains("  get-accessible-atlassian-resources"));
+        assert!(!plan.help_description.contains("atlassianUserInfo"));
+        assert!(!plan.help_description.contains("getAccessibleAtlassianResources"));
     }
 
     #[test]

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -594,6 +594,36 @@ describe("local TypeScript tool compression", () => {
     }
   });
 
+  it("renders camelCase tool names as kebab-case CLI subcommands", async () => {
+    const outputDir = join(tmpdir(), "mcp-cli-camel-subcommands");
+    const transform = await transformToolsForCliMode(
+      {
+        atlassianUserInfo: {
+          name: "atlassianUserInfo",
+          description: "Get current user info.",
+          inputSchema: { type: "object", properties: {} },
+          execute: async (): Promise<unknown> => "ok",
+        },
+        getAccessibleAtlassianResources: {
+          name: "getAccessibleAtlassianResources",
+          description: "Get accessible resources.",
+          inputSchema: { type: "object", properties: {} },
+          execute: async (): Promise<unknown> => "ok",
+        },
+      },
+      { serverName: "atlassian", outputDir },
+    );
+    try {
+      const description = transform.tools.atlassian_help?.description ?? "";
+      expect(description).toContain("  atlassian-user-info");
+      expect(description).toContain("  get-accessible-atlassian-resources");
+      expect(description).not.toContain("atlassianUserInfo");
+      expect(description).not.toContain("getAccessibleAtlassianResources");
+    } finally {
+      transform.close();
+    }
+  });
+
   it("stringifies MCP text content results for generated CLI bridges", async () => {
     const outputDir = join(tmpdir(), "mcp-cli-mcp-text-result");
     const transform = await transformToolsForCliMode(


### PR DESCRIPTION
## Summary
- make host transform CLI/Just Bash help use the same tool-name-to-subcommand mapper as the Rust CLI implementation
- render camelCase MCP tool names as kebab-case shell subcommands in generated help descriptions
- add Rust and TypeScript regression coverage so agent-facing help does not expose raw camelCase tool names

## Validation
- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `cargo test -p mcp-compressor-core ffi::host_transform::tests -- --nocapture`
- `PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "generated CLI clients|camelCase tool names|direct Just Bash"`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
