### PR TITLE
fix: map camelCase properties to kebab flags

### DIFF
--- a/crates/mcp-compressor-core/src/cli/parser.rs
+++ b/crates/mcp-compressor-core/src/cli/parser.rs
@@ -57,7 +57,9 @@ pub fn parse_argv(argv: &[String], tool: &Tool) -> Result<serde_json::Value, Err
             )));
         }
 
-        let (property_name, forced_bool) = parse_flag_name(arg);
+        let (flag_property_name, forced_bool) = parse_flag_name(arg);
+        let property_name = resolve_property_name(&properties, &flag_property_name)
+            .ok_or_else(|| Error::Parse(format!("unknown flag: {arg}")))?;
         let schema = properties
             .get(&property_name)
             .ok_or_else(|| Error::Parse(format!("unknown flag: {arg}")))?;
@@ -132,6 +134,28 @@ fn parse_flag_name(flag: &str) -> (String, Option<bool>) {
 
 fn flag_to_property_name(flag: &str) -> String {
     flag.replace('-', "_")
+}
+
+fn resolve_property_name(
+    properties: &serde_json::Map<String, Value>,
+    flag_property_name: &str,
+) -> Option<String> {
+    if properties.contains_key(flag_property_name) {
+        return Some(flag_property_name.to_string());
+    }
+    let canonical = canonical_property_name(flag_property_name);
+    properties
+        .keys()
+        .find(|property| canonical_property_name(property) == canonical)
+        .cloned()
+}
+
+fn canonical_property_name(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| *ch != '-' && *ch != '_')
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 fn schema_type(schema: &Value) -> Option<&str> {

--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -140,14 +140,23 @@ properties = properties.get("properties", {{}}) if isinstance(properties, dict) 
 def schema_type(schema):
     return schema.get("type") if isinstance(schema, dict) else None
 
+def canonical_name(value):
+    return value.replace("-", "_").replace("_", "").lower()
+
 def flag_to_property(flag):
     raw = flag[2:]
     if raw.startswith("no-"):
         raw = raw[3:]
+    if raw in properties:
+        return raw
     snake = raw.replace("-", "_")
     if snake in properties:
         return snake
-    return raw.replace("_", "-")
+    canonical = canonical_name(raw)
+    for prop in properties:
+        if canonical_name(prop) == canonical:
+            return prop
+    return raw
 
 def coerce_value(schema, raw_value, forced_bool=None):
     if forced_bool is not None:

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -48,6 +48,52 @@ async fn running_proxy_config(output_dir: &std::path::Path) -> (GeneratorConfig,
     (config, proxy)
 }
 
+
+#[test]
+fn generated_cli_help_renders_camel_case_properties_as_kebab_case_flags() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = GeneratorConfig {
+        cli_name: "atlassian".to_string(),
+        bridge_url: "http://127.0.0.1:1".to_string(),
+        token: "token".to_string(),
+        tools: vec![mcp_compressor_core::compression::engine::Tool::new(
+            "searchJiraIssuesUsingJql",
+            Some("Search issues with JQL".to_string()),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "cloudId": { "type": "string", "description": "Cloud ID" },
+                    "jql": { "type": "string", "description": "JQL query" },
+                    "maxResults": { "type": "number", "description": "Max results" },
+                    "nextPageToken": { "type": "string", "description": "Page token" }
+                },
+                "required": ["cloudId", "jql"]
+            }),
+        )],
+        session_pid: std::process::id(),
+        output_dir: tempdir.path().to_path_buf(),
+        extra_cli_bridges: Vec::new(),
+    };
+    CliGenerator.generate(&config).unwrap();
+    let script = tempdir.path().join("atlassian");
+    let output = Command::new(&script)
+        .args(["search-jira-issues-using-jql", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--cloud-id <value>"), "stdout: {stdout}");
+    assert!(stdout.contains("--jql <value>"), "stdout: {stdout}");
+    assert!(stdout.contains("--max-results <value>"), "stdout: {stdout}");
+    assert!(stdout.contains("--next-page-token <value>"), "stdout: {stdout}");
+    assert!(!stdout.contains("--cloudId"), "stdout: {stdout}");
+    assert!(!stdout.contains("--maxResults"), "stdout: {stdout}");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_typescript_module_reports_stopped_proxy_without_fetch_noise() {
     let tempdir = tempfile::tempdir().unwrap();

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -594,6 +594,40 @@ describe("local TypeScript tool compression", () => {
     }
   });
 
+  it("renders camelCase schema properties as kebab-case CLI flags", async () => {
+    const outputDir = join(tmpdir(), "mcp-cli-camel-flags");
+    const transform = await transformToolsForCliMode(
+      {
+        searchJiraIssuesUsingJql: {
+          name: "searchJiraIssuesUsingJql",
+          description: "Search issues with JQL",
+          inputSchema: {
+            type: "object",
+            properties: {
+              cloudId: { type: "string", description: "Cloud ID" },
+              jql: { type: "string", description: "JQL query" },
+              maxResults: { type: "number", description: "Max results" },
+              nextPageToken: { type: "string", description: "Page token" },
+            },
+            required: ["cloudId", "jql"],
+          },
+          execute: async (): Promise<unknown> => "ok",
+        },
+      },
+      { serverName: "atlassian", outputDir },
+    );
+    try {
+      const script = transform.files.atlassian ?? "";
+      expect(script).toContain("--cloud-id <value>");
+      expect(script).toContain("--max-results <value>");
+      expect(script).toContain("--next-page-token <value>");
+      expect(script).not.toContain("--cloudId");
+      expect(script).not.toContain("--maxResults");
+    } finally {
+      transform.close();
+    }
+  });
+
   it("renders camelCase tool names as kebab-case CLI subcommands", async () => {
     const outputDir = join(tmpdir(), "mcp-cli-camel-subcommands");
     const transform = await transformToolsForCliMode(


### PR DESCRIPTION
## Summary
- render camelCase JSON schema properties as kebab-case CLI flags in generated command help
- map kebab-case flags back to original camelCase property names when parsing CLI args
- add Rust parser, generated CLI, and TypeScript host-transform regression coverage

## Validation
- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `cargo test -p mcp-compressor-core cli::parser::tests::kebab_flag_maps_to_camel_case_prop -- --nocapture`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test generated_clients generated_cli_help_renders_camel_case_properties_as_kebab_case_flags -- --nocapture`
- `PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts -t "camelCase schema properties|generated CLI clients|camelCase tool names"`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
