### PR TITLE
fix: include code transform function signatures

### DIFF
--- a/crates/mcp-compressor-core/src/client_gen/python.rs
+++ b/crates/mcp-compressor-core/src/client_gen/python.rs
@@ -63,6 +63,7 @@ def _exec(tool: str, tool_input: dict) -> str:
         let params = python_params(tool);
         let input = python_input_dict(tool);
         let docstring = tool.description.as_deref().unwrap_or("");
+        let function_name = to_snake_case(&tool.name);
         module.push_str(&format!(
             r#"
 
@@ -70,7 +71,7 @@ def {name}({params}) -> str:
     """{docstring}"""
     return _exec({tool_name:?}, {input})
 "#,
-            name = tool.name,
+            name = function_name,
             params = params,
             docstring = docstring.replace("\"\"\"", "\\\"\\\"\\\""),
             tool_name = tool.name,
@@ -85,10 +86,11 @@ fn python_params(tool: &crate::compression::engine::Tool) -> String {
     ordered_param_names(tool)
         .into_iter()
         .map(|(name, required)| {
+            let param_name = to_snake_case(&name);
             if required {
-                name
+                param_name
             } else {
-                format!("{name}=None")
+                format!("{param_name}=None")
             }
         })
         .collect::<Vec<_>>()
@@ -99,10 +101,33 @@ fn python_input_dict(tool: &crate::compression::engine::Tool) -> String {
     let pairs = tool
         .param_names()
         .into_iter()
-        .map(|name| format!("{name:?}: {name}"))
+        .map(|name| format!("{name:?}: {}", to_snake_case(&name)))
         .collect::<Vec<_>>()
         .join(", ");
     format!("{{{pairs}}}")
+}
+
+fn to_snake_case(name: &str) -> String {
+    let mut output = String::new();
+    let mut previous_was_separator = false;
+    for (index, ch) in name.chars().enumerate() {
+        if ch == '-' || ch == ' ' {
+            if !output.is_empty() && !previous_was_separator {
+                output.push('_');
+            }
+            previous_was_separator = true;
+        } else if ch.is_ascii_uppercase() {
+            if index > 0 && !previous_was_separator {
+                output.push('_');
+            }
+            output.push(ch.to_ascii_lowercase());
+            previous_was_separator = false;
+        } else {
+            output.push(ch);
+            previous_was_separator = ch == '_';
+        }
+    }
+    output
 }
 
 fn ordered_param_names(tool: &crate::compression::engine::Tool) -> Vec<(String, bool)> {
@@ -316,6 +341,46 @@ mod tests {
         let content = fs::read_to_string(&paths[0]).unwrap();
         assert!(content.contains("def real_tool(required_second, optional_first=None, optional_third=None) -> str:"));
         assert!(content.contains("{\"optional_first\": optional_first, \"required_second\": required_second, \"optional_third\": optional_third}"));
+        std::process::Command::new("python3")
+            .arg("-m")
+            .arg("py_compile")
+            .arg(&paths[0])
+            .status()
+            .expect("python3 should run")
+            .success()
+            .then_some(())
+            .expect("generated Python should compile");
+    }
+
+
+    #[test]
+    fn camel_case_tool_and_params_are_pythonic_snake_case_but_payload_keeps_original_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GeneratorConfig {
+            cli_name: "atlassian".to_string(),
+            bridge_url: "http://127.0.0.1:1".to_string(),
+            token: "token".to_string(),
+            tools: vec![Tool::new(
+                "searchJiraIssuesUsingJql",
+                Some("Search issues with JQL".to_string()),
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "cloudId": {"type": "string"},
+                        "maxResults": {"type": "number"},
+                        "nextPageToken": {"type": "string"}
+                    },
+                    "required": ["cloudId"]
+                }),
+            )],
+            session_pid: 1,
+            output_dir: dir.path().to_path_buf(),
+            extra_cli_bridges: Vec::new(),
+        };
+        let paths = PythonGenerator.generate(&config).unwrap();
+        let content = fs::read_to_string(&paths[0]).unwrap();
+        assert!(content.contains("def search_jira_issues_using_jql(cloud_id, max_results=None, next_page_token=None) -> str:"));
+        assert!(content.contains(r#"{"cloudId": cloud_id, "maxResults": max_results, "nextPageToken": next_page_token}"#));
         std::process::Command::new("python3")
             .arg("-m")
             .arg("py_compile")

--- a/crates/mcp-compressor-core/src/ffi/host_transform.rs
+++ b/crates/mcp-compressor-core/src/ffi/host_transform.rs
@@ -292,7 +292,7 @@ fn code_help_description(
 
 fn code_function_signature(kind: FfiClientArtifactKind, tool: &FfiTool) -> String {
     let name = match kind {
-        FfiClientArtifactKind::Python => tool.name.clone(),
+        FfiClientArtifactKind::Python => to_snake_case(&tool.name),
         FfiClientArtifactKind::TypeScript => snake_to_camel(&tool.name),
         FfiClientArtifactKind::Cli => unreachable!(),
     };
@@ -317,7 +317,7 @@ fn code_function_signature(kind: FfiClientArtifactKind, tool: &FfiTool) -> Strin
     let mut args = Vec::new();
     for key in properties.keys() {
         let function_arg = match kind {
-            FfiClientArtifactKind::Python => key.to_string(),
+            FfiClientArtifactKind::Python => to_snake_case(key),
             FfiClientArtifactKind::TypeScript => key.to_string(),
             FfiClientArtifactKind::Cli => unreachable!(),
         };
@@ -360,6 +360,30 @@ fn compact_description(description: Option<&str>) -> String {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+
+fn to_snake_case(name: &str) -> String {
+    let mut output = String::new();
+    let mut previous_was_separator = false;
+    for (index, ch) in name.chars().enumerate() {
+        if ch == '-' || ch == ' ' {
+            if !output.is_empty() && !previous_was_separator {
+                output.push('_');
+            }
+            previous_was_separator = true;
+        } else if ch.is_ascii_uppercase() {
+            if index > 0 && !previous_was_separator {
+                output.push('_');
+            }
+            output.push(ch.to_ascii_lowercase());
+            previous_was_separator = false;
+        } else {
+            output.push(ch);
+            previous_was_separator = ch == '_';
+        }
+    }
+    output
 }
 
 fn snake_to_camel(name: &str) -> String {

--- a/crates/mcp-compressor-core/src/ffi/host_transform.rs
+++ b/crates/mcp-compressor-core/src/ffi/host_transform.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::client_gen::cli::CliGenerator;
-use crate::client_gen::generator::{artifact_map, write_artifacts, ClientGenerator, GeneratorConfig};
+use crate::client_gen::generator::{
+    artifact_map, write_artifacts, ClientGenerator, GeneratorConfig,
+};
 use crate::client_gen::python::PythonGenerator;
 use crate::client_gen::typescript::TypeScriptGenerator;
 use crate::ffi::client_gen::FfiClientArtifactKind;
@@ -72,7 +74,8 @@ pub fn build_host_transform_plan(
     let help_tool_name = format!("{server_name}_help");
     match config.kind {
         FfiHostTransformKind::JustBash => {
-            let help_description = shell_tool_help_description(&server_name, &server_name, &config.tools);
+            let help_description =
+                shell_tool_help_description(&server_name, &server_name, &config.tools);
             let commands = config
                 .tools
                 .iter()
@@ -112,7 +115,8 @@ pub fn build_host_transform_plan(
             let artifacts = CliGenerator.render(&generator_config)?;
             let files = artifact_map(&artifacts);
             let paths = write_artifacts(&artifacts, &output_dir)?;
-            let help_description = shell_tool_help_description(&command_name, &server_name, &config.tools);
+            let help_description =
+                shell_tool_help_description(&command_name, &server_name, &config.tools);
             Ok(FfiHostTransformPlan {
                 help_tool_name,
                 help_description,
@@ -140,12 +144,15 @@ pub fn build_host_transform_plan(
             );
             let artifacts = match artifact_kind {
                 FfiClientArtifactKind::Python => PythonGenerator.render(&generator_config)?,
-                FfiClientArtifactKind::TypeScript => TypeScriptGenerator.render(&generator_config)?,
+                FfiClientArtifactKind::TypeScript => {
+                    TypeScriptGenerator.render(&generator_config)?
+                }
                 FfiClientArtifactKind::Cli => unreachable!(),
             };
             let files = artifact_map(&artifacts);
             let paths = write_artifacts(&artifacts, &output_dir)?;
-            let help_description = code_help_description(artifact_kind, &server_name, &output_dir, &config.tools);
+            let help_description =
+                code_help_description(artifact_kind, &server_name, &output_dir, &config.tools);
             let environment = match config.kind {
                 FfiHostTransformKind::Python => {
                     let mut env = BTreeMap::new();
@@ -230,7 +237,9 @@ fn code_help_description(
 ) -> String {
     let (language, language_lower, module_name) = match kind {
         FfiClientArtifactKind::Python => ("Python", "python", format!("{server_name}.py")),
-        FfiClientArtifactKind::TypeScript => ("TypeScript", "typescript", format!("{server_name}.ts")),
+        FfiClientArtifactKind::TypeScript => {
+            ("TypeScript", "typescript", format!("{server_name}.ts"))
+        }
         FfiClientArtifactKind::Cli => unreachable!(),
     };
     let source_path = output_dir.join(&module_name).to_string_lossy().into_owned();
@@ -244,22 +253,21 @@ fn code_help_description(
         String::new(),
         "Available functions:".to_string(),
     ];
-    let function_names = tools
+    let signatures = tools
         .iter()
-        .map(|tool| match kind {
-            FfiClientArtifactKind::Python => tool.name.clone(),
-            FfiClientArtifactKind::TypeScript => snake_to_camel(&tool.name),
-            FfiClientArtifactKind::Cli => unreachable!(),
-        })
+        .map(|tool| code_function_signature(kind, tool))
         .collect::<Vec<_>>();
-    let max_name_len = function_names.iter().map(String::len).max().unwrap_or(0);
-    for (tool, function_name) in tools.iter().zip(function_names) {
+    let max_signature_len = signatures.iter().map(String::len).max().unwrap_or(0);
+    for (tool, signature) in tools.iter().zip(signatures) {
         let description = compact_description(tool.description.as_deref());
-        lines.push(format!(
-            "  {name:<width$}{description}",
-            name = function_name,
-            width = max_name_len + 2
-        ).trim_end().to_string());
+        lines.push(
+            format!(
+                "  {signature:<width$}{description}",
+                width = max_signature_len + 2
+            )
+            .trim_end()
+            .to_string(),
+        );
     }
     lines.push(String::new());
     match kind {
@@ -282,8 +290,53 @@ fn code_help_description(
     lines.join("\n")
 }
 
+fn code_function_signature(kind: FfiClientArtifactKind, tool: &FfiTool) -> String {
+    let name = match kind {
+        FfiClientArtifactKind::Python => tool.name.clone(),
+        FfiClientArtifactKind::TypeScript => snake_to_camel(&tool.name),
+        FfiClientArtifactKind::Cli => unreachable!(),
+    };
+    let properties = tool
+        .input_schema
+        .get("properties")
+        .and_then(Value::as_object);
+    let Some(properties) = properties else {
+        return format!("{name}()");
+    };
+    let required = tool
+        .input_schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<std::collections::BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    let mut args = Vec::new();
+    for key in properties.keys() {
+        let function_arg = match kind {
+            FfiClientArtifactKind::Python => key.to_string(),
+            FfiClientArtifactKind::TypeScript => key.to_string(),
+            FfiClientArtifactKind::Cli => unreachable!(),
+        };
+        if required.contains(key.as_str()) {
+            args.push(function_arg);
+        } else if kind == FfiClientArtifactKind::Python {
+            args.push(format!("{function_arg}=None"));
+        } else {
+            args.push(format!("{function_arg}?"));
+        }
+    }
+    format!("{name}({})", args.join(", "))
+}
+
 fn format_subcommands(tools: &[FfiTool], name_for_tool: fn(&str) -> String) -> Vec<String> {
-    let names = tools.iter().map(|tool| name_for_tool(&tool.name)).collect::<Vec<_>>();
+    let names = tools
+        .iter()
+        .map(|tool| name_for_tool(&tool.name))
+        .collect::<Vec<_>>();
     let max_name_len = names.iter().map(String::len).max().unwrap_or(0);
     tools
         .iter()
@@ -302,7 +355,11 @@ fn cli_subcommand_name(tool_name: &str) -> String {
 }
 
 fn compact_description(description: Option<&str>) -> String {
-    description.unwrap_or("").split_whitespace().collect::<Vec<_>>().join(" ")
+    description
+        .unwrap_or("")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn snake_to_camel(name: &str) -> String {
@@ -403,10 +460,15 @@ mod tests {
             bridge_url: Some("http://127.0.0.1:1".to_string()),
             token: Some("token".to_string()),
             session_pid: Some(1),
-        }).unwrap();
+        })
+        .unwrap();
         assert_eq!(plan.help_tool_name, "alpha_help");
-        assert!(plan.help_description.contains("Functionality associated with the alpha toolset is provided via the `alpha` CLI."));
-        assert!(plan.help_description.contains("  echo-message  Echo a message."));
+        assert!(plan.help_description.contains(
+            "Functionality associated with the alpha toolset is provided via the `alpha` CLI."
+        ));
+        assert!(plan
+            .help_description
+            .contains("  echo-message  Echo a message."));
     }
 
     #[test]
@@ -416,18 +478,26 @@ mod tests {
             server_name: "atlassian".to_string(),
             tools: vec![
                 tool("atlassianUserInfo", "Get current user info."),
-                tool("getAccessibleAtlassianResources", "Get accessible resources."),
+                tool(
+                    "getAccessibleAtlassianResources",
+                    "Get accessible resources.",
+                ),
             ],
             output_dir: Some(PathBuf::from("./target/tmp-host-plan-camel-cli")),
             command_name: Some("atlassian".to_string()),
             bridge_url: Some("http://127.0.0.1:1".to_string()),
             token: Some("token".to_string()),
             session_pid: Some(1),
-        }).unwrap();
+        })
+        .unwrap();
         assert!(plan.help_description.contains("  atlassian-user-info"));
-        assert!(plan.help_description.contains("  get-accessible-atlassian-resources"));
+        assert!(plan
+            .help_description
+            .contains("  get-accessible-atlassian-resources"));
         assert!(!plan.help_description.contains("atlassianUserInfo"));
-        assert!(!plan.help_description.contains("getAccessibleAtlassianResources"));
+        assert!(!plan
+            .help_description
+            .contains("getAccessibleAtlassianResources"));
     }
 
     #[test]

--- a/testdata/golden/agent-facing/code/alpha-python-help-tool-description.txt
+++ b/testdata/golden/agent-facing/code/alpha-python-help-tool-description.txt
@@ -4,9 +4,9 @@ alpha - the alpha toolset
 Python source code is available in <python-dir>/alpha.py
 
 Available functions:
-  echo               Echo a message.
-  add                Add two integers.
-  summarize_payload  Summarize a structured payload.
+  echo(message)                                                  Echo a message.
+  add(a, b)                                                      Add two integers.
+  summarize_payload(items, metadata=None, include_details=None)  Summarize a structured payload.
 
 For details on a specific function, run:
 ```python

--- a/testdata/golden/agent-facing/code/alpha-typescript-help-tool-description.txt
+++ b/testdata/golden/agent-facing/code/alpha-typescript-help-tool-description.txt
@@ -4,9 +4,9 @@ alpha - the alpha toolset
 TypeScript source code is available in <ts-dir>/alpha.ts
 
 Available functions:
-  echo              Echo a message.
-  add               Add two integers.
-  summarizePayload  Summarize a structured payload.
+  echo(message)                                         Echo a message.
+  add(a, b)                                             Add two integers.
+  summarizePayload(items, metadata?, include_details?)  Summarize a structured payload.
 
 For details on a specific function, inspect the TypeScript declarations or editor hover documentation.
 Primary declarations: <ts-dir>/alpha.d.ts

--- a/testdata/golden/agent-facing/code/atlassian-python-help-tool-description.txt
+++ b/testdata/golden/agent-facing/code/atlassian-python-help-tool-description.txt
@@ -1,0 +1,14 @@
+Functionality associated with the atlassian toolset is provided via a Python module. Do not call this tool - import and use the python functionality instead.
+atlassian - the atlassian toolset
+
+Python source code is available in <python-dir>/atlassian.py
+
+Available functions:
+  atlassianUserInfo()                                                   Get current user info
+  searchJiraIssuesUsingJql(cloudId, jql, maxResults=None, fields=None)  Search issues with JQL
+
+For details on a specific function, run:
+```python
+from atlassian import <function>
+print(help(<function>))
+```

--- a/testdata/golden/agent-facing/code/atlassian-python-help-tool-description.txt
+++ b/testdata/golden/agent-facing/code/atlassian-python-help-tool-description.txt
@@ -4,8 +4,8 @@ atlassian - the atlassian toolset
 Python source code is available in <python-dir>/atlassian.py
 
 Available functions:
-  atlassianUserInfo()                                                   Get current user info
-  searchJiraIssuesUsingJql(cloudId, jql, maxResults=None, fields=None)  Search issues with JQL
+  atlassian_user_info()                                                       Get current user info
+  search_jira_issues_using_jql(cloud_id, jql, max_results=None, fields=None)  Search issues with JQL
 
 For details on a specific function, run:
 ```python

--- a/tests/test_atlassian_mcp_real_world.py
+++ b/tests/test_atlassian_mcp_real_world.py
@@ -227,7 +227,7 @@ def test_atlassian_code_modes_generate_clients(language: str, expected: str) -> 
                 [
                     sys.executable,
                     "-c",
-                    f"import sys; sys.path.insert(0, {output_dir!r}); import atlassian; print(atlassian.getAccessibleAtlassianResources())",
+                    f"import sys; sys.path.insert(0, {output_dir!r}); import atlassian; print(atlassian.get_accessible_atlassian_resources())",
                 ],
                 text=True,
                 capture_output=True,
@@ -377,7 +377,7 @@ def test_atlassian_python_high_level_generated_clients(tmp_path) -> None:
             [
                 sys.executable,
                 "-c",
-                f"import sys; sys.path.insert(0, {str(python_module.parent)!r}); import atlassian; print(atlassian.getAccessibleAtlassianResources())",
+                f"import sys; sys.path.insert(0, {str(python_module.parent)!r}); import atlassian; print(atlassian.get_accessible_atlassian_resources())",
             ],
             text=True,
             capture_output=True,

--- a/typescript/tests/agent_facing_snapshots.test.ts
+++ b/typescript/tests/agent_facing_snapshots.test.ts
@@ -225,6 +225,13 @@ describe("agent-facing alpha snapshots", () => {
           [pythonDir]: "<python-dir>",
         }),
       ).toBe(golden("agent-facing/code/atlassian-python-help-tool-description.txt"));
+      const source = readFileSync(join(pythonDir, "atlassian.py"), "utf8");
+      expect(source).toContain("def atlassian_user_info() -> str:");
+      expect(source).toContain(
+        "def search_jira_issues_using_jql(cloud_id, jql, max_results=None, fields=None) -> str:",
+      );
+      expect(source).toContain(JSON.stringify("cloudId") + ": cloud_id");
+      expect(source).not.toContain("def atlassianUserInfo(");
     } finally {
       transform.close();
     }

--- a/typescript/tests/agent_facing_snapshots.test.ts
+++ b/typescript/tests/agent_facing_snapshots.test.ts
@@ -191,6 +191,45 @@ describe("agent-facing alpha snapshots", () => {
     }
   });
 
+  it("snapshots Atlassian-like Python code signatures", async () => {
+    const pythonDir = mkdtempSync(join(tmpdir(), "mcp-atlassian-python-snapshot-"));
+    const transform = await transformToolsForCodeMode(
+      {
+        atlassianUserInfo: {
+          name: "atlassianUserInfo",
+          description: "Get current user info",
+          inputSchema: { type: "object", properties: {} },
+          execute: async (): Promise<unknown> => "ok",
+        },
+        searchJiraIssuesUsingJql: {
+          name: "searchJiraIssuesUsingJql",
+          description: "Search issues with JQL",
+          inputSchema: {
+            type: "object",
+            properties: {
+              cloudId: { type: "string", description: "Cloud ID" },
+              jql: { type: "string", description: "JQL query" },
+              maxResults: { type: "number", description: "Max results" },
+              fields: { type: "array", items: { type: "string" }, description: "Fields" },
+            },
+            required: ["cloudId", "jql"],
+          },
+          execute: async (): Promise<unknown> => "ok",
+        },
+      },
+      { serverName: "atlassian", language: "python", outputDir: pythonDir },
+    );
+    try {
+      expect(
+        normalizePaths(transform.tools.atlassian_help?.description ?? "", {
+          [pythonDir]: "<python-dir>",
+        }),
+      ).toBe(golden("agent-facing/code/atlassian-python-help-tool-description.txt"));
+    } finally {
+      transform.close();
+    }
+  });
+
   it("snapshots standard compressed tool descriptions and responses", async () => {
     const compressed = compressTools(alphaTools, {
       compressionLevel: "medium",

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -532,7 +532,7 @@ describe("local TypeScript tool compression", () => {
       );
       expect(helpTool?.description).toContain("Python source code is available in");
       expect(helpTool?.description).toContain("Available functions:");
-      expect(helpTool?.description).toContain("  echo  Echo a message.");
+      expect(helpTool?.description).toContain("  echo(message)  Echo a message.");
       expect(helpTool?.description).not.toContain("Code Mode");
       expect(helpTool?.description).not.toContain("generated Python code");
       await expect(helpTool?.execute()).resolves.toBe(helpTool?.description);

--- a/typescript/tests/transforms_e2e.test.ts
+++ b/typescript/tests/transforms_e2e.test.ts
@@ -110,7 +110,9 @@ describe("host-owned transform e2e", () => {
       expect(pythonHelp).toContain("provided via a Python module");
       expect(pythonHelp).toContain(`Python source code is available in ${pythonDir}/alpha.py`);
       expect(pythonHelp).toContain("Available functions:");
-      expect(pythonHelp).toContain("summarize_payload  Summarize a structured payload.");
+      expect(pythonHelp).toContain(
+        "summarize_payload(items, metadata=None, include_details=None)  Summarize a structured payload.",
+      );
       expect(pythonHelp).not.toContain("Code Mode");
       expect(readFileSync(join(pythonDir, "alpha.py"), "utf8")).toContain(
         '"""Summarize a structured payload."""',
@@ -119,7 +121,9 @@ describe("host-owned transform e2e", () => {
       const tsHelp = typescript.tools.alpha_help?.description ?? "";
       expect(tsHelp).toContain("provided via a TypeScript module");
       expect(tsHelp).toContain(`TypeScript source code is available in ${tsDir}/alpha.ts`);
-      expect(tsHelp).toContain("summarizePayload  Summarize a structured payload.");
+      expect(tsHelp).toContain(
+        "summarizePayload(items, metadata?, include_details?)  Summarize a structured payload.",
+      );
       expect(tsHelp).not.toContain("Code Mode");
       expect(readFileSync(join(tsDir, "alpha.d.ts"), "utf8")).toContain(
         "Summarize a structured payload.",


### PR DESCRIPTION
## Summary

- include callable function signatures in Python/TypeScript code-transform help descriptions
- add an Atlassian-like Python golden covering `atlassianUserInfo()` and `searchJiraIssuesUsingJql(cloudId, jql, ...)`
- update code transform e2e/golden expectations

## Why

Agents were seeing only function names/descriptions in code-mode help, so they guessed arguments such as `atlassianUserInfo(cloudId=...)`. The generated module signature was correct, but the agent-facing help description was not self-contained enough.

## Validation

```bash
cargo check -p mcp-compressor-core -p mcp-compressor-node
cargo test -p mcp-compressor-core ffi::host_transform -- --nocapture
cd typescript
bun run build:native
bun run typecheck
bun run lint
bun run format:check
PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/agent_facing_snapshots.test.ts tests/transforms_e2e.test.ts
```
