### PR TITLE
feat: expose executable tool bridge

### DIFF
--- a/typescript/src/executable_tool_bridge.ts
+++ b/typescript/src/executable_tool_bridge.ts
@@ -1,0 +1,71 @@
+import type { ExecutableTool } from "./adapters.js";
+import { startLocalToolBridge } from "./local_tool_bridge.js";
+import type { ToolSpec } from "./rust_core.js";
+import { executableToolsToSpecs } from "./tool_specs.js";
+
+export interface ExecutableToolBridgeServer {
+  name: string;
+  tools: ToolSpec[];
+  bridgeUrl: string;
+}
+
+export interface ExecutableToolBridgeRuntime {
+  serverName: string;
+  server: ExecutableToolBridgeServer;
+  invokeTool(toolName: string, input?: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface ExecutableToolBridge extends ExecutableToolBridgeRuntime {
+  bridgeUrl: string;
+  token: string;
+  close(): void;
+}
+
+export interface CreateExecutableToolBridgeOptions {
+  serverName: string;
+}
+
+export async function createExecutableToolBridge(
+  tools: Record<string, ExecutableTool<unknown>>,
+  options: CreateExecutableToolBridgeOptions,
+): Promise<ExecutableToolBridge> {
+  const bridge = await startLocalToolBridge(tools);
+  const server: ExecutableToolBridgeServer = {
+    name: options.serverName,
+    tools: executableToolsToSpecs(tools),
+    bridgeUrl: bridge.bridgeUrl,
+  };
+
+  return {
+    serverName: options.serverName,
+    server,
+    bridgeUrl: bridge.bridgeUrl,
+    token: bridge.token,
+    close: bridge.close,
+    invokeTool: async (toolName, input = {}) =>
+      invokeBridgeTool(bridge.bridgeUrl, bridge.token, toolName, input),
+  };
+}
+
+async function invokeBridgeTool(
+  bridgeUrl: string,
+  token: string,
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<unknown> {
+  const response = await fetch(`${bridgeUrl}/exec`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ tool: toolName, input }),
+  });
+  const payload = (await response.json()) as { result?: unknown; error?: unknown };
+  if (!response.ok) {
+    throw new Error(
+      typeof payload.error === "string" ? payload.error : JSON.stringify(payload.error),
+    );
+  }
+  return payload.result;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -7,6 +7,7 @@ export * from "./local_tools.js";
 export * from "./generated_clients.js";
 export * from "./just_bash_commands.js";
 export * from "./local_tool_bridge.js";
+export * from "./executable_tool_bridge.js";
 export * from "./tool_specs.js";
 export * from "./transforms.js";
 export {

--- a/typescript/tests/executable_tool_bridge.test.ts
+++ b/typescript/tests/executable_tool_bridge.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createExecutableToolBridge,
+  type ExecutableToolBridge,
+} from "../src/executable_tool_bridge.js";
+import type { ExecutableTool } from "../src/index.js";
+
+const bridges: ExecutableToolBridge[] = [];
+
+afterEach(() => {
+  for (const bridge of bridges.splice(0)) bridge.close();
+});
+
+function fixtureTools(): Record<string, ExecutableTool<unknown>> {
+  return {
+    echo: {
+      name: "echo",
+      description: "Echo a message.",
+      inputSchema: {
+        type: "object",
+        properties: { message: { type: "string", description: "Message to echo." } },
+        required: ["message"],
+      },
+      execute: async (input: Record<string, unknown>) => ({
+        result: `echo:${String(input.message ?? "")}`,
+      }),
+    },
+  };
+}
+
+describe("createExecutableToolBridge", () => {
+  it("creates a bridge with stable server metadata and invokeTool", async () => {
+    const bridge = await createExecutableToolBridge(fixtureTools(), { serverName: "alpha" });
+    bridges.push(bridge);
+
+    expect(bridge.serverName).toBe("alpha");
+    expect(bridge.server).toMatchObject({
+      name: "alpha",
+      bridgeUrl: bridge.bridgeUrl,
+      tools: [
+        {
+          name: "echo",
+          description: "Echo a message.",
+        },
+      ],
+    });
+    expect(bridge.bridgeUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(bridge.token).toHaveLength(36);
+
+    await expect(
+      fetch(`${bridge.bridgeUrl}/health`).then((response) => response.text()),
+    ).resolves.toBe("ok");
+    await expect(bridge.invokeTool("echo", { message: "hello" })).resolves.toBe("echo:hello");
+  });
+
+  it("uses the same /exec bearer bridge contract as generated clients", async () => {
+    const bridge = await createExecutableToolBridge(fixtureTools(), { serverName: "alpha" });
+    bridges.push(bridge);
+
+    const response = await fetch(`${bridge.bridgeUrl}/exec`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bridge.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ tool: "echo", input: { message: "direct" } }),
+    });
+
+    await expect(response.json()).resolves.toEqual({ result: "echo:direct" });
+  });
+});


### PR DESCRIPTION
## Summary

Expose a generic TypeScript primitive for creating a standardized executable-tool bridge from already-discovered tools:

- `createExecutableToolBridge(tools, { serverName })`
- returns stable tool server metadata, bridge URL/token, `invokeTool(...)`, and `close()`
- uses the same `/health` + bearer `/exec` local bridge contract as generated clients

This gives host applications like Alta a generic mcp-compressor-owned bridge primitive that can back `transform: proxy` as well as CLI/Python/TypeScript transform runtimes, without introducing Alta-specific types into mcp-compressor.

## Test plan

```bash
cd typescript
bun run build:native
bun run lint
bun run typecheck
bun run format:check
bun run vitest run tests/executable_tool_bridge.test.ts tests/rust_core.test.ts tests/transforms_e2e.test.ts tests/agent_facing_snapshots.test.ts
```
