### PR TITLE
Fix compressed invoke tool schema for Gemini

### DIFF
--- a/crates/mcp-compressor-core/src/app/banner.rs
+++ b/crates/mcp-compressor-core/src/app/banner.rs
@@ -68,7 +68,12 @@ fn compressed_frontend_size(tools: &[Tool], level: &CompressionLevel) -> usize {
         "type": "object",
         "properties": {
             "tool_name": {"type": "string", "description": "Name of the backend tool"},
-            "tool_input": {"type": "object", "description": "JSON input for the backend tool"}
+            "tool_input": {
+                "type": "object",
+                "description": "JSON input for the backend tool",
+                "properties": {},
+                "additionalProperties": true
+            }
         },
         "required": ["tool_name", "tool_input"]
     });

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -187,16 +187,16 @@ impl CompressedServer {
         let mut tools = Vec::new();
         for backend in &self.backends {
             let prefix = self.wrapper_prefix(backend);
-            tools.push(wrapper_tool(
+            tools.push(get_tool_schema_wrapper_tool(
                 format!("{prefix}get_tool_schema"),
                 &self.get_tool_schema_description(backend),
             ));
-            tools.push(wrapper_tool(
+            tools.push(invoke_wrapper_tool(
                 format!("{prefix}invoke_tool"),
                 &self.invoke_tool_description(backend),
             ));
             if self.config.level == CompressionLevel::Max {
-                tools.push(wrapper_tool(
+                tools.push(list_wrapper_tool(
                     format!("{prefix}list_tools"),
                     "List compressed backend tools.",
                 ));
@@ -544,7 +544,41 @@ fn format_backend_help(backend: &ConnectedBackend) -> String {
     lines.join("\n")
 }
 
-fn wrapper_tool(name: String, description: &str) -> Tool {
+fn get_tool_schema_wrapper_tool(name: String, description: &str) -> Tool {
+    Tool::new(
+        name,
+        Some(description.to_string()),
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tool_name": { "type": "string", "description": "Name of the backend tool" }
+            },
+            "required": ["tool_name"]
+        }),
+    )
+}
+
+fn invoke_wrapper_tool(name: String, description: &str) -> Tool {
+    Tool::new(
+        name,
+        Some(description.to_string()),
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tool_name": { "type": "string", "description": "Name of the backend tool" },
+                "tool_input": {
+                    "type": "object",
+                    "description": "JSON input for the backend tool",
+                    "properties": {},
+                    "additionalProperties": true
+                }
+            },
+            "required": ["tool_name", "tool_input"]
+        }),
+    )
+}
+
+fn list_wrapper_tool(name: String, description: &str) -> Tool {
     Tool::new(
         name,
         Some(description.to_string()),

--- a/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
+++ b/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
@@ -31,6 +31,35 @@ async fn single_stdio_backend_exposes_only_compressed_wrapper_tools() {
 }
 
 #[tokio::test]
+async fn single_stdio_backend_invoke_wrapper_tool_input_schema_is_explicit_open_object() {
+    let server = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let tools = server.list_frontend_tools().await.unwrap();
+    let invoke_tool = tools
+        .iter()
+        .find(|tool| tool.name == "alpha_invoke_tool")
+        .unwrap();
+
+    assert_eq!(
+        invoke_tool
+            .input_schema
+            .pointer("/properties/tool_input")
+            .unwrap(),
+        &json!({
+            "type": "object",
+            "description": "JSON input for the backend tool",
+            "properties": {},
+            "additionalProperties": true
+        })
+    );
+}
+
+#[tokio::test]
 async fn single_stdio_backend_schema_listing_invocation_resources_and_prompts_work() {
     let server = CompressedServer::connect_stdio(
         common::max_config(Some("alpha")),

--- a/typescript/src/local_tools.ts
+++ b/typescript/src/local_tools.ts
@@ -92,7 +92,12 @@ export function compressTools(
       type: "object",
       properties: {
         tool_name: { type: "string", description: "Name of the tool" },
-        tool_input: { type: "object", description: "JSON input for the tool" },
+        tool_input: {
+          type: "object",
+          description: "JSON input for the tool",
+          properties: {},
+          additionalProperties: true,
+        },
       },
       required: ["tool_name", "tool_input"],
     },

--- a/typescript/tests/local_tools_schema.test.ts
+++ b/typescript/tests/local_tools_schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/rust_core.js", () => ({
+  compressToolListing: () => "",
+  formatToolSchemaResponse: () => "",
+}));
+
+import { compressTools } from "../src/local_tools.js";
+
+const tools = {
+  echo: {
+    description: "Echo a message.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        message: { type: "string" },
+      },
+      required: ["message"],
+    },
+    execute: async (): Promise<string> => "ok",
+  },
+};
+
+describe("local compressed tool schemas", () => {
+  it("exposes invoke wrapper tool_input as an explicit open object schema", () => {
+    expect(compressTools(tools).invoke_tool?.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        tool_input: {
+          type: "object",
+          properties: {},
+          additionalProperties: true,
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expose `invoke_tool.tool_input` as an explicit open object schema in the TypeScript compressed tool wrapper
- expose concrete Rust frontend wrapper schemas for `get_tool_schema` and `invoke_tool`
- add TypeScript and Rust regression coverage for the `tool_input` schema shape

## Why
Gemini/Vertex rejects function declarations when a nested parameter schema is missing `type`. Downstream schema compatibility layers can drop `type` from a bare `{ type: "object" }` schema, so this makes `tool_input` explicit with `properties: {}` and `additionalProperties: true`.

## Testing
- `make -C /Users/fciner/code/atlassian/mcp-compressor check test`
