### PR TITLE
fix: keep host transforms filesystem pure

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/host_transform.rs
+++ b/crates/mcp-compressor-core/src/ffi/host_transform.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::client_gen::cli::CliGenerator;
 use crate::client_gen::generator::{
-    artifact_map, write_artifacts, ClientGenerator, GeneratorConfig,
+    artifact_map, ClientGenerator, GeneratedArtifact, GeneratorConfig,
 };
 use crate::client_gen::python::PythonGenerator;
 use crate::client_gen::typescript::TypeScriptGenerator;
@@ -114,7 +114,7 @@ pub fn build_host_transform_plan(
             );
             let artifacts = CliGenerator.render(&generator_config)?;
             let files = artifact_map(&artifacts);
-            let paths = write_artifacts(&artifacts, &output_dir)?;
+            let paths = artifact_paths(&artifacts, &output_dir);
             let help_description =
                 shell_tool_help_description(&command_name, &server_name, &config.tools);
             Ok(FfiHostTransformPlan {
@@ -150,7 +150,7 @@ pub fn build_host_transform_plan(
                 FfiClientArtifactKind::Cli => unreachable!(),
             };
             let files = artifact_map(&artifacts);
-            let paths = write_artifacts(&artifacts, &output_dir)?;
+            let paths = artifact_paths(&artifacts, &output_dir);
             let help_description =
                 code_help_description(artifact_kind, &server_name, &output_dir, &config.tools);
             let environment = match config.kind {
@@ -203,6 +203,13 @@ fn generator_config(
         output_dir: output_dir.to_path_buf(),
     }
     .into()
+}
+
+fn artifact_paths(artifacts: &[GeneratedArtifact], output_dir: &std::path::Path) -> Vec<PathBuf> {
+    artifacts
+        .iter()
+        .map(|artifact| output_dir.join(&artifact.file_name))
+        .collect()
 }
 
 fn shell_tool_help_description(command: &str, cli_name: &str, tools: &[FfiTool]) -> String {
@@ -362,7 +369,6 @@ fn compact_description(description: Option<&str>) -> String {
         .join(" ")
 }
 
-
 fn to_snake_case(name: &str) -> String {
     let mut output = String::new();
     let mut previous_was_separator = false;
@@ -407,16 +413,6 @@ fn normalize_server_name(name: Option<String>) -> String {
 }
 
 fn default_cli_output_dir() -> PathBuf {
-    if let Ok(value) = std::env::var("MCP_COMPRESSOR_CLI_OUTPUT_DIR") {
-        if !value.is_empty() {
-            return PathBuf::from(value);
-        }
-    }
-    if let Ok(home) = std::env::var("HOME") {
-        if !home.is_empty() {
-            return PathBuf::from(home).join(".local/bin");
-        }
-    }
     PathBuf::from("./dist")
 }
 
@@ -522,6 +518,54 @@ mod tests {
         assert!(!plan
             .help_description
             .contains("getAccessibleAtlassianResources"));
+    }
+
+    #[test]
+    fn host_cli_plan_defaults_to_dist_and_does_not_write_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let previous_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+        let plan = build_host_transform_plan(FfiHostTransformConfig {
+            kind: FfiHostTransformKind::Cli,
+            server_name: "alpha".to_string(),
+            tools: vec![tool("echo", "Echo a message.")],
+            output_dir: None,
+            command_name: Some("alpha".to_string()),
+            bridge_url: Some("http://127.0.0.1:1".to_string()),
+            token: Some("token".to_string()),
+            session_pid: Some(1),
+        })
+        .unwrap();
+        std::env::set_current_dir(previous_cwd).unwrap();
+
+        assert_eq!(plan.output_dir, Some(PathBuf::from("./dist")));
+        assert_eq!(plan.paths, vec![PathBuf::from("./dist/alpha")]);
+        assert_eq!(
+            plan.environment.get("PATH"),
+            Some(&"./dist:$PATH".to_string())
+        );
+        assert!(plan.files.contains_key("alpha"));
+        assert!(!temp.path().join("dist/alpha").exists());
+    }
+
+    #[test]
+    fn host_python_plan_returns_artifacts_without_writing_files() {
+        let output_dir = tempfile::tempdir().unwrap().path().join("python-out");
+        let plan = build_host_transform_plan(FfiHostTransformConfig {
+            kind: FfiHostTransformKind::Python,
+            server_name: "alpha".to_string(),
+            tools: vec![tool("echo", "Echo a message.")],
+            output_dir: Some(output_dir.clone()),
+            command_name: None,
+            bridge_url: Some("http://127.0.0.1:1".to_string()),
+            token: Some("token".to_string()),
+            session_pid: Some(1),
+        })
+        .unwrap();
+
+        assert!(plan.files.contains_key("alpha.py"));
+        assert!(plan.paths.contains(&output_dir.join("alpha.py")));
+        assert!(!output_dir.join("alpha.py").exists());
     }
 
     #[test]

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::process::Command;
+use std::{io, process::Command, thread, time::Duration};
 
 use mcp_compressor_core::client_gen::cli::CliGenerator;
 use mcp_compressor_core::client_gen::python::PythonGenerator;
@@ -48,6 +48,25 @@ async fn running_proxy_config(output_dir: &std::path::Path) -> (GeneratorConfig,
     (config, proxy)
 }
 
+fn generated_script_output(script: &std::path::Path, args: &[&str]) -> std::process::Output {
+    let mut last_error = None;
+    for attempt in 0..5 {
+        match Command::new(script).args(args).output() {
+            Ok(output) => return output,
+            Err(error) if error.raw_os_error() == Some(26) && attempt < 4 => {
+                last_error = Some(error);
+                thread::sleep(Duration::from_millis(25 * (attempt + 1) as u64));
+            }
+            Err(error) => panic!("failed to execute {}: {error}", script.display()),
+        }
+    }
+    let error =
+        last_error.unwrap_or_else(|| io::Error::other("unknown generated script execution error"));
+    panic!(
+        "failed to execute {} after retrying ETXTBSY: {error}",
+        script.display()
+    );
+}
 
 #[test]
 fn generated_cli_help_renders_camel_case_properties_as_kebab_case_flags() {
@@ -76,10 +95,7 @@ fn generated_cli_help_renders_camel_case_properties_as_kebab_case_flags() {
     };
     CliGenerator.generate(&config).unwrap();
     let script = tempdir.path().join("atlassian");
-    let output = Command::new(&script)
-        .args(["search-jira-issues-using-jql", "--help"])
-        .output()
-        .unwrap();
+    let output = generated_script_output(&script, &["search-jira-issues-using-jql", "--help"]);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -89,7 +105,10 @@ fn generated_cli_help_renders_camel_case_properties_as_kebab_case_flags() {
     assert!(stdout.contains("--cloud-id <value>"), "stdout: {stdout}");
     assert!(stdout.contains("--jql <value>"), "stdout: {stdout}");
     assert!(stdout.contains("--max-results <value>"), "stdout: {stdout}");
-    assert!(stdout.contains("--next-page-token <value>"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("--next-page-token <value>"),
+        "stdout: {stdout}"
+    );
     assert!(!stdout.contains("--cloudId"), "stdout: {stdout}");
     assert!(!stdout.contains("--maxResults"), "stdout: {stdout}");
 }
@@ -205,10 +224,7 @@ async fn generated_cli_script_matches_legacy_argument_parser_features() {
     assert!(stdout.contains("escape"));
     assert!(stdout.contains("json"));
 
-    let unknown = std::process::Command::new(&script)
-        .args(["echo", "--unknown", "value"])
-        .output()
-        .unwrap();
+    let unknown = generated_script_output(&script, &["echo", "--unknown", "value"]);
     assert!(!unknown.status.success());
     assert!(String::from_utf8_lossy(&unknown.stderr).contains("unknown flag"));
 }
@@ -225,10 +241,7 @@ async fn generated_cli_script_invokes_real_proxy_and_backend() {
         .find(|path| path.file_name().unwrap() == "alpha")
         .unwrap();
 
-    let output = Command::new(script)
-        .args(["echo", "--message", "hello"])
-        .output()
-        .unwrap();
+    let output = generated_script_output(script, &["echo", "--message", "hello"]);
 
     assert!(
         output.status.success(),
@@ -255,10 +268,7 @@ async fn generated_cli_script_reports_stopped_proxy_without_traceback() {
 
     drop(proxy);
 
-    let output = Command::new(script)
-        .args(["echo", "--message", "hello"])
-        .output()
-        .unwrap();
+    let output = generated_script_output(script, &["echo", "--message", "hello"]);
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -420,7 +430,10 @@ fn atlassian_like_golden_tools() -> Vec<mcp_compressor_core::compression::engine
     )]
 }
 
-fn generate_cli_script(cli_name: &str, tools: Vec<mcp_compressor_core::compression::engine::Tool>) -> tempfile::TempDir {
+fn generate_cli_script(
+    cli_name: &str,
+    tools: Vec<mcp_compressor_core::compression::engine::Tool>,
+) -> tempfile::TempDir {
     let tempdir = tempfile::tempdir().unwrap();
     let config = GeneratorConfig {
         cli_name: cli_name.to_string(),
@@ -436,20 +449,26 @@ fn generate_cli_script(cli_name: &str, tools: Vec<mcp_compressor_core::compressi
 }
 
 fn run_generated_script(script: &std::path::Path, args: &[&str]) -> String {
-    let output = Command::new(script).args(args).output().unwrap();
+    let output = generated_script_output(script, args);
     assert!(
         output.status.success(),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    String::from_utf8(output.stdout).unwrap().trim_end().to_string()
+    String::from_utf8(output.stdout)
+        .unwrap()
+        .trim_end()
+        .to_string()
 }
 
 #[test]
 fn rust_generated_alpha_cli_matches_shared_golden_help() {
     let tempdir = generate_cli_script("alpha", alpha_golden_tools());
     let script = tempdir.path().join("alpha");
-    assert_eq!(run_generated_script(&script, &["--help"]), golden("agent-facing/cli/alpha-help.txt"));
+    assert_eq!(
+        run_generated_script(&script, &["--help"]),
+        golden("agent-facing/cli/alpha-help.txt")
+    );
     assert_eq!(
         run_generated_script(&script, &["echo", "--help"]),
         golden("agent-facing/cli/alpha-echo-help.txt")

--- a/typescript/tests/agent_facing_snapshots.test.ts
+++ b/typescript/tests/agent_facing_snapshots.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -76,6 +76,21 @@ function runScript(scriptPath: string, args: readonly string[]): string {
   return execFileSync(scriptPath, [...args], { encoding: "utf8" }).trimEnd();
 }
 
+function materializeFiles(
+  outputDir: string,
+  files: Record<string, string>,
+  executableNames: readonly string[] = [],
+): void {
+  mkdirSync(outputDir, { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    const path = join(outputDir, name);
+    writeFileSync(path, contents);
+    if (executableNames.includes(name)) {
+      chmodSync(path, 0o755);
+    }
+  }
+}
+
 function golden(relativePath: string): string {
   return readFileSync(
     join(process.cwd(), "..", "testdata", "golden", relativePath),
@@ -95,6 +110,7 @@ describe("agent-facing alpha snapshots", () => {
       outputDir,
     });
     try {
+      materializeFiles(outputDir, transform.files, ["alpha"]);
       const scriptPath = join(outputDir, "alpha");
       expect(runScript(scriptPath, ["--help"])).toBe(golden("agent-facing/cli/alpha-help.txt"));
       expect(runScript(scriptPath, ["echo", "--help"])).toBe(
@@ -150,6 +166,7 @@ describe("agent-facing alpha snapshots", () => {
       { serverName: "atlassian", outputDir },
     );
     try {
+      materializeFiles(outputDir, transform.files, ["atlassian"]);
       const scriptPath = join(outputDir, "atlassian");
       expect(runScript(scriptPath, ["--help"])).toBe(
         golden("agent-facing/atlassian-like/atlassian-help.txt"),
@@ -176,6 +193,8 @@ describe("agent-facing alpha snapshots", () => {
       outputDir: tsDir,
     });
     try {
+      materializeFiles(pythonDir, python.files);
+      materializeFiles(tsDir, typescript.files);
       expect(
         normalizePaths(python.tools.alpha_help?.description ?? "", { [pythonDir]: "<python-dir>" }),
       ).toBe(golden("agent-facing/code/alpha-python-help-tool-description.txt"));
@@ -220,6 +239,7 @@ describe("agent-facing alpha snapshots", () => {
       { serverName: "atlassian", language: "python", outputDir: pythonDir },
     );
     try {
+      materializeFiles(pythonDir, transform.files);
       expect(
         normalizePaths(transform.tools.atlassian_help?.description ?? "", {
           [pythonDir]: "<python-dir>",

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { request } from "node:http";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -742,10 +742,13 @@ describe("local TypeScript tool compression", () => {
     }
   });
 
-  it("defaults CLI transform output to a user PATH directory", async () => {
+  it("defaults host CLI transform output to ./dist without writing files", async () => {
     const previousHome = process.env.HOME;
+    const previousCwd = process.cwd();
     const home = mkdtempSync(join(tmpdir(), "mcp-cli-home-"));
+    const cwd = mkdtempSync(join(tmpdir(), "mcp-cli-cwd-"));
     process.env.HOME = home;
+    process.chdir(cwd);
     const transform = await transformToolsForCliMode(
       {
         echo: {
@@ -758,13 +761,16 @@ describe("local TypeScript tool compression", () => {
       { serverName: "alpha" },
     );
     try {
-      const expectedDir = join(home, ".local", "bin");
-      expect(transform.paths).toEqual([join(expectedDir, "alpha")]);
-      expect(transform.environment.PATH).toBe(`${expectedDir}:$PATH`);
+      expect(transform.paths).toEqual(["./dist/alpha"]);
+      expect(transform.files.alpha).toContain("alpha - the alpha toolset");
+      expect(transform.environment.PATH).toBe("./dist:$PATH");
       expect(transform.tools.alpha_help?.description).toContain("`alpha` CLI");
       expect(transform.tools.alpha_help?.description).not.toContain("PATH hint");
+      expect(existsSync(join(home, ".local", "bin", "alpha"))).toBe(false);
+      expect(existsSync(join(cwd, "dist", "alpha"))).toBe(false);
     } finally {
       transform.close();
+      process.chdir(previousCwd);
       if (previousHome === undefined) {
         delete process.env.HOME;
       } else {

--- a/typescript/tests/transforms_e2e.test.ts
+++ b/typescript/tests/transforms_e2e.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -46,7 +46,7 @@ const alphaTools: Record<string, ExecutableTool<unknown>> = {
 };
 
 describe("host-owned transform e2e", () => {
-  it("CLI transform writes a self-contained command with legacy-style structured parsing", async () => {
+  it("CLI transform returns a self-contained command with legacy-style structured parsing", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "mcp-cli-transform-"));
     const transform = await transformToolsForCliMode(alphaTools, {
       serverName: "alpha",
@@ -63,8 +63,11 @@ describe("host-owned transform e2e", () => {
       expect(helpDescription).not.toContain("CLI Mode");
       expect(helpDescription).not.toContain("PATH hint");
 
-      expect(transform.paths).toHaveLength(1);
+      expect(transform.paths).toEqual([join(outputDir, "alpha")]);
       expect(transform.files).toHaveProperty("alpha");
+      expect(transform.files.alpha).toContain("alpha - the alpha toolset");
+      expect(transform.environment.PATH).toBe(`${outputDir}:$PATH`);
+      expect(existsSync(join(outputDir, "alpha"))).toBe(false);
     } finally {
       transform.close();
     }
@@ -114,9 +117,8 @@ describe("host-owned transform e2e", () => {
         "summarize_payload(items, metadata=None, include_details=None)  Summarize a structured payload.",
       );
       expect(pythonHelp).not.toContain("Code Mode");
-      expect(readFileSync(join(pythonDir, "alpha.py"), "utf8")).toContain(
-        '"""Summarize a structured payload."""',
-      );
+      expect(python.files["alpha.py"]).toContain('"""Summarize a structured payload."""');
+      expect(existsSync(join(pythonDir, "alpha.py"))).toBe(false);
 
       const tsHelp = typescript.tools.alpha_help?.description ?? "";
       expect(tsHelp).toContain("provided via a TypeScript module");
@@ -125,9 +127,8 @@ describe("host-owned transform e2e", () => {
         "summarizePayload(items, metadata?, include_details?)  Summarize a structured payload.",
       );
       expect(tsHelp).not.toContain("Code Mode");
-      expect(readFileSync(join(tsDir, "alpha.d.ts"), "utf8")).toContain(
-        "Summarize a structured payload.",
-      );
+      expect(typescript.files["alpha.d.ts"]).toContain("Summarize a structured payload.");
+      expect(existsSync(join(tsDir, "alpha.d.ts"))).toBe(false);
     } finally {
       python.close();
       typescript.close();


### PR DESCRIPTION
## Summary

- makes host-owned transform planning pure: no generated artifacts are written by `build_host_transform_plan`
- changes host CLI transform default output dir to `./dist` and returns `PATH=./dist:$PATH`
- keeps generated artifacts available in-memory through `files` and intended locations through `paths`
- updates tests to assert host transforms return artifacts without writing to `~/.local/bin`, cwd, or explicit output dirs

Standalone client generation / CLI-mode paths that explicitly call artifact-writing APIs are unchanged.

## Validation

- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `cargo test -p mcp-compressor-core ffi::host_transform -- --nocapture`
- `PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts tests/transforms_e2e.test.ts -t "host CLI transform|generated CLI clients|generated code clients|CLI transform|Python code transform|TypeScript code transform"`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`

## Notes

The previous host transform behavior was unsafe for Alta because calling the TypeScript host transform APIs could write files to the service node filesystem, including `~/.local/bin`. After this change, mcp-compressor host transforms only return a plan/artifacts; Alta or another host is responsible for materializing them into the active workspace or sandbox.
