### PR TITLE
fix: support JSON string compressed tool input

### DIFF
--- a/crates/mcp-compressor-core/src/app/banner.rs
+++ b/crates/mcp-compressor-core/src/app/banner.rs
@@ -54,7 +54,7 @@ fn compressed_frontend_size(tools: &[Tool], level: &CompressionLevel) -> usize {
     let get_tool_schema_description = format!(
         "Get the complete schema and description for one backend tool. Available tools:\n{listing}"
     );
-    let invoke_tool_description = "Invoke one backend tool by name with JSON input.";
+    let invoke_tool_description = "Invoke one backend tool by name with JSON input. Provide backend arguments as tool_input, or as JSON in tool_input_json if nested object properties are dropped.";
     let list_tools_description = "List backend tools available through this compressed MCP server.";
 
     let schema_wrapper = serde_json::json!({
@@ -73,9 +73,13 @@ fn compressed_frontend_size(tools: &[Tool], level: &CompressionLevel) -> usize {
                 "description": "JSON input for the backend tool",
                 "properties": {},
                 "additionalProperties": true
+            },
+            "tool_input_json": {
+                "type": "string",
+                "description": "JSON-serialized input object for the backend tool"
             }
         },
-        "required": ["tool_name", "tool_input"]
+        "required": ["tool_name"]
     });
     let list_wrapper = serde_json::json!({
         "type": "object",

--- a/crates/mcp-compressor-core/src/proxy/server.rs
+++ b/crates/mcp-compressor-core/src/proxy/server.rs
@@ -45,8 +45,27 @@ struct ExecRequest {
 #[derive(Debug, Deserialize)]
 struct WrapperInvokeInput {
     tool_name: String,
-    #[serde(default)]
-    tool_input: Value,
+    tool_input: Option<Value>,
+    tool_input_json: Option<String>,
+}
+
+impl WrapperInvokeInput {
+    fn parse_tool_input(&self) -> Result<Value, Error> {
+        if let Some(json) = &self.tool_input_json {
+            let value: Value = serde_json::from_str(json)
+                .map_err(|error| Error::Validation(format!("invalid tool_input_json: {error}")))?;
+            if !value.is_object() {
+                return Err(Error::Validation(
+                    "tool_input_json must decode to a JSON object".to_string(),
+                ));
+            }
+            return Ok(value);
+        }
+        Ok(self
+            .tool_input
+            .clone()
+            .unwrap_or_else(|| serde_json::json!({})))
+    }
 }
 
 impl ToolProxyServer {
@@ -99,17 +118,19 @@ async fn exec(
 
 fn close_response(status: StatusCode, body: impl Into<String>) -> Response {
     let mut response = (status, body.into()).into_response();
-    response
-        .headers_mut()
-        .insert(header::CONNECTION, header::HeaderValue::from_static("close"));
+    response.headers_mut().insert(
+        header::CONNECTION,
+        header::HeaderValue::from_static("close"),
+    );
     response
 }
 
 async fn dispatch_exec(server: &CompressedServer, request: ExecRequest) -> Result<String, Error> {
     if request.tool.ends_with("_invoke_tool") || request.tool == "invoke_tool" {
         let wrapper_input: WrapperInvokeInput = serde_json::from_value(request.input)?;
+        let tool_input = wrapper_input.parse_tool_input()?;
         server
-            .invoke_tool(&request.tool, &wrapper_input.tool_name, wrapper_input.tool_input)
+            .invoke_tool(&request.tool, &wrapper_input.tool_name, tool_input)
             .await
     } else {
         server

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -215,7 +215,7 @@ impl CompressedServer {
 
     fn invoke_tool_description(&self, backend: &ConnectedBackend) -> String {
         format!(
-            "Invoke a tool from the {} toolset. Use get_tool_schema first when you need the full input schema.",
+            "Invoke a tool from the {} toolset. Use get_tool_schema first when you need the full input schema. Provide backend arguments as tool_input. If your tool-calling API drops nested object properties, provide the same backend arguments as a JSON string in tool_input_json instead.",
             backend.public_name
         )
     }
@@ -568,12 +568,16 @@ fn invoke_wrapper_tool(name: String, description: &str) -> Tool {
                 "tool_name": { "type": "string", "description": "Name of the backend tool" },
                 "tool_input": {
                     "type": "object",
-                    "description": "JSON input for the backend tool",
+                    "description": "JSON input for the backend tool. Use this when your tool-calling API preserves nested object properties.",
                     "properties": {},
                     "additionalProperties": true
+                },
+                "tool_input_json": {
+                    "type": "string",
+                    "description": "JSON-serialized input object for the backend tool. Use this instead of tool_input if your tool-calling API drops nested object properties."
                 }
             },
-            "required": ["tool_name", "tool_input"]
+            "required": ["tool_name"]
         }),
     )
 }

--- a/crates/mcp-compressor-core/src/server/registration.rs
+++ b/crates/mcp-compressor-core/src/server/registration.rs
@@ -6,9 +6,8 @@ use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
     Annotated, CallToolRequestParams, CallToolResult, Content, ErrorCode, GetPromptRequestParams,
     GetPromptResult, InitializeResult, ListPromptsResult, ListResourcesResult, ListToolsResult,
-    PaginatedRequestParams, Prompt,
-    RawResource, ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents,
-    ServerCapabilities, Tool,
+    PaginatedRequestParams, Prompt, RawResource, ReadResourceRequestParams, ReadResourceResult,
+    Resource, ResourceContents, ServerCapabilities, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData as McpError, RoleServer};
@@ -77,10 +76,7 @@ impl ServerHandler for FrontendServer {
                 .await
         } else if wrapper_name.ends_with("invoke_tool") {
             let tool_name = required_string(&arguments, "tool_name")?;
-            let tool_input = arguments
-                .get("tool_input")
-                .cloned()
-                .unwrap_or_else(|| Value::Object(Map::new()));
+            let tool_input = parse_tool_input(arguments)?;
             self.compressed
                 .invoke_tool(&wrapper_name, &tool_name, tool_input)
                 .await
@@ -120,9 +116,10 @@ impl ServerHandler for FrontendServer {
             .read_resource(&request.uri)
             .await
             .map_err(mcp_error)?;
-        Ok(ReadResourceResult::new(vec![
-            ResourceContents::text(text, request.uri),
-        ]))
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(
+            text,
+            request.uri,
+        )]))
     }
 
     async fn list_prompts(
@@ -170,16 +167,51 @@ fn convert_tool(tool: crate::compression::engine::Tool) -> Tool {
 }
 
 fn convert_resource(uri: String) -> Resource {
-    Annotated::new(RawResource {
-        name: uri.clone(),
-        uri,
-        title: None,
-        description: None,
-        mime_type: None,
-        icons: None,
-        size: None,
-        meta: None,
-    }, None)
+    Annotated::new(
+        RawResource {
+            name: uri.clone(),
+            uri,
+            title: None,
+            description: None,
+            mime_type: None,
+            icons: None,
+            size: None,
+            meta: None,
+        },
+        None,
+    )
+}
+
+fn parse_tool_input(arguments: Map<String, Value>) -> Result<Value, McpError> {
+    if let Some(value) = arguments.get("tool_input_json") {
+        let json = value.as_str().ok_or_else(|| {
+            McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "tool_input_json must be a JSON string",
+                None,
+            )
+        })?;
+        let parsed = serde_json::from_str::<Value>(json).map_err(|error| {
+            McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                format!("invalid tool_input_json: {error}"),
+                None,
+            )
+        })?;
+        if !parsed.is_object() {
+            return Err(McpError::new(
+                ErrorCode::INVALID_PARAMS,
+                "tool_input_json must decode to a JSON object",
+                None,
+            ));
+        }
+        return Ok(parsed);
+    }
+
+    Ok(arguments
+        .get("tool_input")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(Map::new())))
 }
 
 fn required_string(arguments: &Map<String, Value>, name: &str) -> Result<String, McpError> {
@@ -192,4 +224,49 @@ fn required_string(arguments: &Map<String, Value>, name: &str) -> Result<String,
 
 fn mcp_error(error: crate::Error) -> McpError {
     McpError::new(ErrorCode::INTERNAL_ERROR, error.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_tool_input_accepts_object_input() {
+        let mut args = Map::new();
+        args.insert("tool_input".to_string(), json!({ "message": "object" }));
+        assert_eq!(
+            parse_tool_input(args).unwrap(),
+            json!({ "message": "object" })
+        );
+    }
+
+    #[test]
+    fn parse_tool_input_accepts_json_string_input() {
+        let mut args = Map::new();
+        args.insert(
+            "tool_input_json".to_string(),
+            Value::String("{\"message\":\"json\"}".to_string()),
+        );
+        assert_eq!(
+            parse_tool_input(args).unwrap(),
+            json!({ "message": "json" })
+        );
+    }
+
+    #[test]
+    fn parse_tool_input_rejects_invalid_json_string() {
+        let mut args = Map::new();
+        args.insert(
+            "tool_input_json".to_string(),
+            Value::String("{".to_string()),
+        );
+        let error = parse_tool_input(args).unwrap_err();
+        assert!(error.to_string().contains("invalid tool_input_json"));
+    }
+
+    #[test]
+    fn parse_tool_input_defaults_missing_input_to_empty_object() {
+        assert_eq!(parse_tool_input(Map::new()).unwrap(), json!({}));
+    }
 }

--- a/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
+++ b/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
@@ -52,11 +52,50 @@ async fn single_stdio_backend_invoke_wrapper_tool_input_schema_is_explicit_open_
             .unwrap(),
         &json!({
             "type": "object",
-            "description": "JSON input for the backend tool",
+            "description": "JSON input for the backend tool. Use this when your tool-calling API preserves nested object properties.",
             "properties": {},
             "additionalProperties": true
         })
     );
+    assert_eq!(
+        invoke_tool
+            .input_schema
+            .pointer("/properties/tool_input_json")
+            .unwrap(),
+        &json!({
+            "type": "string",
+            "description": "JSON-serialized input object for the backend tool. Use this instead of tool_input if your tool-calling API drops nested object properties."
+        })
+    );
+    assert_eq!(
+        invoke_tool.input_schema.pointer("/required").unwrap(),
+        &json!(["tool_name"])
+    );
+    assert!(invoke_tool
+        .description
+        .as_deref()
+        .unwrap_or_default()
+        .contains("tool_input_json"));
+}
+
+#[tokio::test]
+async fn single_stdio_backend_accepts_tool_input_json_escape_hatch() {
+    let server = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let echo = server
+        .invoke_tool(
+            "alpha_invoke_tool",
+            "echo",
+            json!({ "message": "json-string" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(echo, "alpha:json-string");
 }
 
 #[tokio::test]

--- a/crates/mcp-compressor-core/tests/proxy_http.rs
+++ b/crates/mcp-compressor-core/tests/proxy_http.rs
@@ -107,3 +107,29 @@ async fn proxy_exec_dispatches_to_real_backend_with_session_token() {
     assert!((200..300).contains(&response.status));
     assert_eq!(response.body.trim(), "alpha:hello");
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proxy_exec_accepts_tool_input_json_escape_hatch() {
+    let compressed = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+    let proxy = ToolProxyServer::start(compressed).await.unwrap();
+
+    let body = json!({
+        "tool": "alpha_invoke_tool",
+        "input": { "tool_name": "echo", "tool_input_json": "{\"message\":\"json\"}" }
+    })
+    .to_string();
+    let response = send_raw_http(
+        "POST",
+        &proxy.exec_url(),
+        Some(proxy.token_value()),
+        Some(&body),
+    );
+
+    assert!((200..300).contains(&response.status), "{}", response.body);
+    assert_eq!(response.body.trim(), "alpha:json");
+}

--- a/testdata/golden/agent-facing/compressed/alpha-tool-descriptions.json
+++ b/testdata/golden/agent-facing/compressed/alpha-tool-descriptions.json
@@ -1,4 +1,4 @@
 {
   "alpha_get_tool_schema": "Get the complete schema and description for one tool. Available tools:\n<tool>echo(message): Echo a message</tool>\n<tool>add(a, b): Add two integers</tool>\n<tool>summarize_payload(items, metadata, include_details): Summarize a structured payload</tool>",
-  "alpha_invoke_tool": "Invoke one tool by name with JSON input."
+  "alpha_invoke_tool": "Invoke one tool by name with JSON input. Provide backend arguments as tool_input. If your tool-calling API drops nested object properties, provide the same backend arguments as a JSON string in tool_input_json instead."
 }

--- a/typescript/src/local_tools.ts
+++ b/typescript/src/local_tools.ts
@@ -43,6 +43,37 @@ function normalizeResult(value: unknown, toonify: boolean): string {
   return json;
 }
 
+function parseToolInput(input: Record<string, unknown>): Record<string, unknown> {
+  if (input.tool_input_json !== undefined) {
+    if (typeof input.tool_input_json !== "string") {
+      throw new Error("tool_input_json must be a JSON string");
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(input.tool_input_json);
+    } catch (error) {
+      throw new Error(
+        `invalid tool_input_json: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("tool_input_json must decode to a JSON object");
+    }
+    return parsed as Record<string, unknown>;
+  }
+  if (input.tool_input === undefined) {
+    return {};
+  }
+  if (
+    input.tool_input === null ||
+    typeof input.tool_input !== "object" ||
+    Array.isArray(input.tool_input)
+  ) {
+    throw new Error("tool_input must be a JSON object");
+  }
+  return input.tool_input as Record<string, unknown>;
+}
+
 export function compressTools(
   tools: Record<string, LocalTool>,
   options: CompressToolsOptions = {},
@@ -87,25 +118,33 @@ export function compressTools(
 
   result[wrapperName(options.namePrefix, "invoke_tool")] = {
     name: wrapperName(options.namePrefix, "invoke_tool"),
-    description: "Invoke one tool by name with JSON input.",
+    description:
+      "Invoke one tool by name with JSON input. Provide backend arguments as tool_input. If your tool-calling API drops nested object properties, provide the same backend arguments as a JSON string in tool_input_json instead.",
     inputSchema: {
       type: "object",
       properties: {
         tool_name: { type: "string", description: "Name of the tool" },
         tool_input: {
           type: "object",
-          description: "JSON input for the tool",
+          description:
+            "JSON input for the tool. Use this when your tool-calling API preserves nested object properties.",
           properties: {},
           additionalProperties: true,
         },
+        tool_input_json: {
+          type: "string",
+          description:
+            "JSON-serialized input object for the tool. Use this instead of tool_input if your tool-calling API drops nested object properties.",
+        },
       },
-      required: ["tool_name", "tool_input"],
+      required: ["tool_name"],
     },
     execute: async (input = {}) => {
       const toolName = String(input.tool_name ?? "");
       const tool = toolByName.get(toolName);
       if (!tool) throw new Error(`Tool not found: ${toolName}`);
-      const output = await tool.execute((input.tool_input ?? {}) as never);
+      const toolInput = parseToolInput(input);
+      const output = await tool.execute(toolInput as never);
       return normalizeResult(output, options.toonify ?? false);
     },
   };

--- a/typescript/tests/agent_facing_snapshots.test.ts
+++ b/typescript/tests/agent_facing_snapshots.test.ts
@@ -280,5 +280,12 @@ describe("agent-facing alpha snapshots", () => {
         tool_input: { message: "snapshot" },
       }),
     ).resolves.toBe(golden("agent-facing/compressed/alpha-invoke-echo.txt"));
+
+    await expect(
+      compressed.alpha_invoke_tool?.execute({
+        tool_name: "echo",
+        tool_input_json: '{"message":"snapshot"}',
+      }),
+    ).resolves.toBe(golden("agent-facing/compressed/alpha-invoke-echo.txt"));
   });
 });

--- a/typescript/tests/local_tools_schema.test.ts
+++ b/typescript/tests/local_tools_schema.test.ts
@@ -22,7 +22,7 @@ const tools = {
 };
 
 describe("local compressed tool schemas", () => {
-  it("exposes invoke wrapper tool_input as an explicit open object schema", () => {
+  it("exposes invoke wrapper tool_input and tool_input_json schemas", () => {
     expect(compressTools(tools).invoke_tool?.inputSchema).toMatchObject({
       type: "object",
       properties: {
@@ -31,7 +31,59 @@ describe("local compressed tool schemas", () => {
           properties: {},
           additionalProperties: true,
         },
+        tool_input_json: {
+          type: "string",
+        },
+      },
+      required: ["tool_name"],
+    });
+  });
+
+  it("invokes tools with object or JSON-string input", async () => {
+    const execute = vi.fn(async (input: unknown): Promise<unknown> => input);
+    const compressed = compressTools({
+      echo: {
+        ...tools.echo,
+        execute,
       },
     });
+
+    await expect(
+      compressed.invoke_tool?.execute({
+        tool_name: "echo",
+        tool_input: { message: "object" },
+      }),
+    ).resolves.toBe('{"message":"object"}');
+    expect(execute).toHaveBeenLastCalledWith({ message: "object" });
+
+    await expect(
+      compressed.invoke_tool?.execute({
+        tool_name: "echo",
+        tool_input_json: '{"message":"json"}',
+      }),
+    ).resolves.toBe('{"message":"json"}');
+    expect(execute).toHaveBeenLastCalledWith({ message: "json" });
+  });
+
+  it("reports invalid JSON-string input clearly", async () => {
+    const compressed = compressTools(tools);
+    await expect(
+      compressed.invoke_tool?.execute({
+        tool_name: "echo",
+        tool_input_json: "{",
+      }),
+    ).rejects.toThrow("invalid tool_input_json");
+  });
+
+  it("defaults missing input to an empty object", async () => {
+    const execute = vi.fn(async (input: unknown): Promise<unknown> => input);
+    const compressed = compressTools({
+      echo: {
+        ...tools.echo,
+        execute,
+      },
+    });
+    await expect(compressed.invoke_tool?.execute({ tool_name: "echo" })).resolves.toBe("{}");
+    expect(execute).toHaveBeenLastCalledWith({});
   });
 });


### PR DESCRIPTION
## Summary

- adds `tool_input_json` as a JSON-string escape hatch for compressed invoke wrappers
- keeps existing `tool_input` object support and preserves missing-input compatibility by defaulting to `{}`
- updates Rust MCP frontend wrapper schema/description and HTTP proxy dispatch
- updates TypeScript `compressTools(...)` schema/execution path
- adds Rust and TypeScript regression coverage plus agent-facing snapshot updates

## Why

Slack thread: https://atlassian.slack.com/archives/C0APPAVP2LB/p1780572192124339

OpenAI Responses API appears to drop nested arbitrary object properties for the generic compressed wrapper schema, resulting in calls like:

```json
{
  "tool_name": "searchConfluenceUsingCql",
  "tool_input": {}
}
```

`tool_input_json` gives models/clients a Responses-compatible path:

```json
{
  "tool_name": "searchConfluenceUsingCql",
  "tool_input_json": "{\"cloudId\":\"...\",\"cql\":\"...\"}"
}
```

## Validation

- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture`
- `cargo test -p mcp-compressor-core server::registration -- --nocapture`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test proxy_http -- --nocapture`
- `cd typescript && PYTHON="$PWD/../.venv/bin/python" bun run check`
- `git diff --check`
