### PR TITLE
feat: support deferred Just Bash transform planning

### DIFF
--- a/typescript/src/transforms.ts
+++ b/typescript/src/transforms.ts
@@ -21,6 +21,8 @@ export interface TransformToolsForJustBashOptions extends TransformToolOptions {
   bash: unknown;
 }
 
+export interface PlanToolsForJustBashOptions extends TransformToolOptions {}
+
 export interface JustBashTransformResult {
   tools: Record<string, ExecutableTool>;
   registrations: JustBashCommandRegistration[];
@@ -47,9 +49,9 @@ export interface GeneratedToolTransformResult {
   close(): void;
 }
 
-export function transformToolsForJustBash(
+export function planToolsForJustBash(
   tools: Record<string, ExecutableTool<unknown>>,
-  options: TransformToolsForJustBashOptions,
+  options: PlanToolsForJustBashOptions = {},
 ): JustBashTransformResult {
   const serverName = normalizeServerName(options.serverName);
   const toolSpecs = executableToolsToSpecs(tools);
@@ -59,7 +61,6 @@ export function transformToolsForJustBash(
       justBashSource(serverName, command.commandName, command.backendToolName, tools),
     ),
   );
-  installJustBashRegistrations(options.bash, registrations);
   return {
     registrations,
     tools: helpTools({
@@ -68,6 +69,15 @@ export function transformToolsForJustBash(
       output: plan.helpDescription,
     }),
   };
+}
+
+export function transformToolsForJustBash(
+  tools: Record<string, ExecutableTool<unknown>>,
+  options: TransformToolsForJustBashOptions,
+): JustBashTransformResult {
+  const result = planToolsForJustBash(tools, options);
+  installJustBashRegistrations(options.bash, result.registrations);
+  return result;
 }
 
 export async function transformToolsForCodeMode(

--- a/typescript/tests/transforms_e2e.test.ts
+++ b/typescript/tests/transforms_e2e.test.ts
@@ -6,10 +6,12 @@ import { Bash } from "just-bash";
 import { describe, expect, it } from "vitest";
 
 import {
+  planToolsForJustBash,
   transformToolsForCliMode,
   transformToolsForCodeMode,
   transformToolsForJustBash,
 } from "../src/transforms.js";
+import { installJustBashRegistrations } from "../src/just_bash_commands.js";
 import type { ExecutableTool } from "../src/adapters.js";
 
 const alphaTools: Record<string, ExecutableTool<unknown>> = {
@@ -93,6 +95,31 @@ describe("host-owned transform e2e", () => {
     expect(result.stdout).toContain("itemCount: 2");
     expect(result.stdout).toContain("source: bash");
     expect(result.stdout).toContain("includeDetails: false");
+  });
+
+  it("Just Bash transform can be planned before the Bash instance is available", async () => {
+    const transform = planToolsForJustBash(alphaTools, { serverName: "alpha" });
+    expect(transform.registrations.map((registration) => registration.commandName)).toEqual([
+      "alpha",
+    ]);
+    const helpDescription = transform.tools.alpha_help?.description ?? "";
+    expect(helpDescription).toContain(
+      "Functionality associated with the alpha toolset is provided via the `alpha` CLI.",
+    );
+    expect(helpDescription).toContain("summarize-payload  Summarize a structured payload.");
+
+    const bash = new Bash({ customCommands: [] });
+    let beforeInstall = await bash.exec("alpha --help");
+    expect(beforeInstall.exitCode).not.toBe(0);
+
+    installJustBashRegistrations(bash, transform.registrations);
+    const result = await bash.exec("alpha echo --message deferred");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("alpha:deferred");
+
+    beforeInstall = await bash.exec("alpha summarize-payload --items one --items two");
+    expect(beforeInstall.exitCode).toBe(0);
+    expect(beforeInstall.stdout).toContain("itemCount: 2");
   });
 
   it("Python and TypeScript code transforms expose module/function descriptions", async () => {


### PR DESCRIPTION
## Summary

- adds `planToolsForJustBash(...)` to build Just Bash help tools and command registrations without requiring or mutating a Bash instance
- keeps existing `transformToolsForJustBash(...)` behavior by delegating to the planner and then installing registrations immediately
- adds e2e coverage proving registrations can be planned before the Bash instance exists and installed later into the actual Bash instance

## Why

Alta needs semantic `transform: cli` to work when the agent bash tool is backed by Just Bash. The MCP tools are loaded in the agent runtime before the actual Just Bash workspace object exists. This API lets Alta create a deferred command-registration plan during MCP transform application, then install those registrations later into the same Just Bash object used by agent bash commands.

## Validation

- `cd typescript && bun run typecheck`
- `cd typescript && bun run lint`
- `cd typescript && bun run format:check`
- `cd typescript && PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/transforms_e2e.test.ts tests/rust_core.test.ts -t "Just Bash transform|high-level native CLI and Bash transform surfaces"`
- `cd typescript && PYTHON="$PWD/../.venv/bin/python" bun run check`
- `git diff --check`
