### PR TITLE
fix: avoid fetch shadowing in generated TypeScript clients

### DIFF
--- a/crates/mcp-compressor-core/src/client_gen/typescript.rs
+++ b/crates/mcp-compressor-core/src/client_gen/typescript.rs
@@ -38,7 +38,7 @@ const HEADERS = {{ Authorization: `Bearer ${{TOKEN}}`, "Content-Type": "applicat
 async function execTool(tool: string, input: Record<string, unknown>): Promise<string> {{
   let res: Response;
   try {{
-    res = await fetch(`${{BRIDGE}}/exec`, {{
+    res = await globalThis.fetch(`${{BRIDGE}}/exec`, {{
       method: "POST",
       headers: HEADERS,
       body: JSON.stringify({{ tool, input }}),
@@ -341,6 +341,25 @@ mod tests {
         );
     }
 
+    /// A backend tool named `fetch` must not shadow the HTTP fetch used by execTool.
+    #[test]
+    fn ts_exec_tool_uses_global_fetch_to_avoid_export_shadowing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = make_config(dir.path());
+        let paths = TypeScriptGenerator.generate(&config).unwrap();
+        let ts = find_ts(&paths);
+        let content = fs::read_to_string(ts).unwrap();
+
+        assert!(
+            content.contains("res = await globalThis.fetch(`${BRIDGE}/exec`, {"),
+            "execTool must use globalThis.fetch so exported tools named fetch do not shadow HTTP fetch"
+        );
+        assert!(
+            content.contains("export async function fetch("),
+            "fixture should keep exercising a tool exported as fetch"
+        );
+    }
+
     /// Functions return `Promise<string>`.
     #[test]
     fn ts_functions_return_promise_string() {
@@ -411,14 +430,14 @@ mod tests {
     /// Generated TypeScript intentionally uses Web-standard APIs only so the
     /// public client remains portable to future V8-isolate/WASM packaging.
     #[test]
-    fn ts_uses_fetch_and_avoids_node_native_imports() {
+    fn ts_uses_global_fetch_and_avoids_node_native_imports() {
         let dir = tempfile::tempdir().unwrap();
         let config = make_config(dir.path());
         let paths = TypeScriptGenerator.generate(&config).unwrap();
         let ts = find_ts(&paths);
         let content = fs::read_to_string(ts).unwrap();
 
-        assert!(content.contains("fetch("));
+        assert!(content.contains("globalThis.fetch("));
         for forbidden in [
             "from 'node:",
             "from \"node:",


### PR DESCRIPTION
## Summary

Fixes generated TypeScript code-mode clients when a backend MCP server has a tool named `fetch`. Previously the generated module could contain:

```ts
export async function fetch(...) { ... }
```

which shadowed the module-local call inside `execTool`:

```ts
await fetch(`/exec`, ...)
```

For Atlassian MCP this caused recursive calls to the generated `fetch` function and surfaced as:

```text
mcp-compressor proxy is not running ... details: mcp-compressor proxy is not running ...
```

The generated client now calls:

```ts
await globalThis.fetch(...)
```

so exported tool functions cannot shadow the HTTP API.

## Validation

- `cargo test -p mcp-compressor-core client_gen::typescript -- --nocapture`
- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `cd typescript && PYTHON=../.venv/bin/python bun run vitest run tests/rust_core.test.ts tests/transforms_e2e.test.ts -t "TypeScript code transform|generated code clients|generated TypeScript|MCP text content"`
- `cd typescript && bun run typecheck && bun run lint && bun run format:check`
- `git diff --check`