### PR TITLE
fix: shorten generated transform help summaries

### DIFF
--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -382,7 +382,7 @@ fn render_top_level_help(config: &GeneratorConfig) -> String {
         help.push_str(&format!(
             "  {:<35} {}\n",
             tool_name_to_subcommand(&tool.name),
-            first_line(tool.description.as_deref().unwrap_or("")),
+            short_tool_description(tool.description.as_deref()),
         ));
     }
     help.push_str(&format!(
@@ -471,7 +471,7 @@ fn format_tool_option_help(option: &ToolOption) -> String {
     let mut line = format!("  {flag:<28} <{}>  {requirement}", option.ty);
     let mut details = Vec::new();
     if let Some(description) = &option.description {
-        details.push(first_line(description).to_string());
+        details.push(short_tool_description(Some(description)));
     }
     if !option.enum_values.is_empty() {
         details.push(format!("values: {}", option.enum_values.join(", ")));
@@ -518,8 +518,61 @@ fn default_value_label(value: &serde_json::Value) -> String {
     }
 }
 
-fn first_line(value: &str) -> &str {
-    value.lines().next().unwrap_or("")
+fn short_tool_description(description: Option<&str>) -> String {
+    let trimmed = description.unwrap_or_default().trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let first_sentence = first_sentence(trimmed);
+    let candidate = if first_sentence.chars().count() >= 10 {
+        first_sentence
+    } else {
+        first_non_empty_line(trimmed)
+    };
+    truncate_clean(candidate, 200)
+}
+
+fn first_sentence(value: &str) -> &str {
+    for (index, ch) in value.char_indices() {
+        if matches!(ch, '.' | '!' | '?') {
+            return value[..=index].trim();
+        }
+    }
+    first_non_empty_line(value)
+}
+
+fn first_non_empty_line(value: &str) -> &str {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_default()
+}
+
+fn truncate_clean(value: &str, max_chars: usize) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+    let limit = max_chars.saturating_sub(3);
+    let mut end = 0;
+    for (count, (index, ch)) in compact.char_indices().enumerate() {
+        if count >= limit {
+            break;
+        }
+        end = index + ch.len_utf8();
+    }
+    let mut prefix = compact[..end]
+        .trim_end_matches(|ch: char| ch.is_whitespace() || ch == ',' || ch == ';' || ch == ':')
+        .to_string();
+    if let Some(space) = prefix.rfind(' ') {
+        if space >= max_chars / 2 {
+            prefix.truncate(space);
+        }
+    }
+    prefix.push_str("...");
+    prefix
 }
 
 fn shell_quote(value: &str) -> String {

--- a/crates/mcp-compressor-core/src/ffi/host_transform.rs
+++ b/crates/mcp-compressor-core/src/ffi/host_transform.rs
@@ -266,7 +266,7 @@ fn code_help_description(
         .collect::<Vec<_>>();
     let max_signature_len = signatures.iter().map(String::len).max().unwrap_or(0);
     for (tool, signature) in tools.iter().zip(signatures) {
-        let description = compact_description(tool.description.as_deref());
+        let description = short_tool_description(tool.description.as_deref());
         lines.push(
             format!(
                 "  {signature:<width$}{description}",
@@ -349,7 +349,7 @@ fn format_subcommands(tools: &[FfiTool], name_for_tool: fn(&str) -> String) -> V
         .iter()
         .zip(names)
         .map(|(tool, name)| {
-            let description = compact_description(tool.description.as_deref());
+            let description = short_tool_description(tool.description.as_deref());
             format!("  {name:<width$}{description}", width = max_name_len + 2)
                 .trim_end()
                 .to_string()
@@ -361,12 +361,61 @@ fn cli_subcommand_name(tool_name: &str) -> String {
     crate::cli::mapping::tool_name_to_subcommand(tool_name)
 }
 
-fn compact_description(description: Option<&str>) -> String {
-    description
-        .unwrap_or("")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+fn short_tool_description(description: Option<&str>) -> String {
+    let trimmed = description.unwrap_or_default().trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let first_sentence = first_sentence(trimmed);
+    let candidate = if first_sentence.chars().count() >= 10 {
+        first_sentence
+    } else {
+        first_non_empty_line(trimmed)
+    };
+    truncate_clean(candidate, 200)
+}
+
+fn first_sentence(value: &str) -> &str {
+    for (index, ch) in value.char_indices() {
+        if matches!(ch, '.' | '!' | '?') {
+            return value[..=index].trim();
+        }
+    }
+    first_non_empty_line(value)
+}
+
+fn first_non_empty_line(value: &str) -> &str {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_default()
+}
+
+fn truncate_clean(value: &str, max_chars: usize) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+    let limit = max_chars.saturating_sub(3);
+    let mut end = 0;
+    for (count, (index, ch)) in compact.char_indices().enumerate() {
+        if count >= limit {
+            break;
+        }
+        end = index + ch.len_utf8();
+    }
+    let mut prefix = compact[..end]
+        .trim_end_matches(|ch: char| ch.is_whitespace() || ch == ',' || ch == ';' || ch == ':')
+        .to_string();
+    if let Some(space) = prefix.rfind(' ') {
+        if space >= max_chars / 2 {
+            prefix.truncate(space);
+        }
+    }
+    prefix.push_str("...");
+    prefix
 }
 
 fn to_snake_case(name: &str) -> String {
@@ -489,6 +538,55 @@ mod tests {
         assert!(plan
             .help_description
             .contains("  echo-message  Echo a message."));
+    }
+
+    #[test]
+    fn help_summaries_use_first_sentence_and_trim_whitespace() {
+        let plan = build_host_transform_plan(FfiHostTransformConfig {
+            kind: FfiHostTransformKind::Cli,
+            server_name: "alpha".to_string(),
+            tools: vec![tool(
+                "verbose",
+                "  Get details for an item. This second sentence contains implementation guidance that should not appear.
+
+More details follow.",
+            )],
+            output_dir: Some(PathBuf::from("./target/tmp-host-plan-summary-cli")),
+            command_name: Some("alpha".to_string()),
+            bridge_url: Some("http://127.0.0.1:1".to_string()),
+            token: Some("token".to_string()),
+            session_pid: Some(1),
+        })
+        .unwrap();
+
+        assert!(plan
+            .help_description
+            .contains("  verbose  Get details for an item."));
+        assert!(!plan.help_description.contains("implementation guidance"));
+    }
+
+    #[test]
+    fn help_summaries_fall_back_to_first_line_for_tiny_first_sentence() {
+        assert_eq!(
+            short_tool_description(Some("OK. Use this tool to inspect status.")),
+            "OK. Use this tool to inspect status."
+        );
+        assert_eq!(
+            short_tool_description(Some(
+                "A.
+List accessible resources for the user."
+            )),
+            "A."
+        );
+    }
+
+    #[test]
+    fn help_summaries_truncate_cleanly() {
+        let description = format!("{}.", "word ".repeat(80));
+        let summary = short_tool_description(Some(&description));
+        assert!(summary.len() <= 200);
+        assert!(summary.ends_with("..."));
+        assert!(!summary.ends_with(" ..."));
     }
 
     #[test]

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -538,10 +538,66 @@ fn format_backend_help(backend: &ConnectedBackend) -> String {
     lines.push("SUBCOMMANDS:".to_string());
     for tool in &backend.tools {
         let subcommand = crate::cli::mapping::tool_name_to_subcommand(&tool.name);
-        let description = tool.description.as_deref().unwrap_or_default();
+        let description = short_tool_description(tool.description.as_deref());
         lines.push(format!("  {subcommand:<35} {description}"));
     }
     lines.join("\n")
+}
+
+fn short_tool_description(description: Option<&str>) -> String {
+    let trimmed = description.unwrap_or_default().trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let first_sentence = first_sentence(trimmed);
+    let candidate = if first_sentence.chars().count() >= 10 {
+        first_sentence
+    } else {
+        first_non_empty_line(trimmed)
+    };
+    truncate_clean(candidate, 200)
+}
+
+fn first_sentence(value: &str) -> &str {
+    for (index, ch) in value.char_indices() {
+        if matches!(ch, '.' | '!' | '?') {
+            return value[..=index].trim();
+        }
+    }
+    first_non_empty_line(value)
+}
+
+fn first_non_empty_line(value: &str) -> &str {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_default()
+}
+
+fn truncate_clean(value: &str, max_chars: usize) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+    let limit = max_chars.saturating_sub(3);
+    let mut end = 0;
+    for (count, (index, ch)) in compact.char_indices().enumerate() {
+        if count >= limit {
+            break;
+        }
+        end = index + ch.len_utf8();
+    }
+    let mut prefix = compact[..end]
+        .trim_end_matches(|ch: char| ch.is_whitespace() || ch == ',' || ch == ';' || ch == ':')
+        .to_string();
+    if let Some(space) = prefix.rfind(' ') {
+        if space >= max_chars / 2 {
+            prefix.truncate(space);
+        }
+    }
+    prefix.push_str("...");
+    prefix
 }
 
 fn get_tool_schema_wrapper_tool(name: String, description: &str) -> Tool {


### PR DESCRIPTION
## Summary

Shortens generated transform help summaries so `*_help` tool descriptions do not include full backend tool descriptions in subcommand/function lists.

Applies to:

- host-owned CLI/Just Bash help tools (`atlassian_help`, `slack_help`, etc.)
- host-owned Python/TypeScript code-mode help tools
- standalone Rust CLI-mode help tools
- generated CLI top-level help

New summary behavior:

- trims leading/trailing whitespace
- uses the first sentence
- if the first sentence is under 10 characters, falls back to the first non-empty line
- compacts internal whitespace
- caps each summary at 200 characters with a clean `...` truncation

## Example

Before:

```text
SUBCOMMANDS:
  get-accessible-atlassian-resources  Get cloudId to make tool calls. When a link is provided (e.g. https://site.atlassian.net/*), try passing the site hostname (e.g. site.atlassian.net) as cloudId to other tools first; if that fails, use this tool to list accessible resources.
  fetch                               Get details of a Jira issue or Confluence page by ARI (Atlassian Resource Identifier), if the id is not an ARI, then use a different tool to fetch the content
```

After:

```text
SUBCOMMANDS:
  get-accessible-atlassian-resources  Get cloudId to make tool calls.
  fetch                               Get details of a Jira issue or Confluence page by ARI (Atlassian Resource Identifier), if the id is not an ARI, then use a different tool to fetch the content
```

Long descriptions are capped cleanly, e.g.:

```text
  verbose-tool  word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word...
```

## Validation

- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test transform_modes -- --nocapture`
- `cargo test -p mcp-compressor-core ffi::host_transform -- --nocapture`
- `cargo test -p mcp-compressor-core client_gen::cli -- --nocapture`
- `cd typescript && PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/agent_facing_snapshots.test.ts tests/transforms_e2e.test.ts tests/rust_core.test.ts -t "CLI transform|Just Bash transform|generated CLI clients|direct Just Bash|snapshots CLI"`
- `cd typescript && bun run typecheck && bun run lint && bun run format:check`
- `git diff --check`
