### PR TITLE
fix: safely embed generated CLI schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "axum",
+ "base64",
  "clap",
  "dirs",
  "flate2",

--- a/crates/mcp-compressor-core/Cargo.toml
+++ b/crates/mcp-compressor-core/Cargo.toml
@@ -13,6 +13,7 @@ publish       = true
 [dependencies]
 serde      = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+base64    = "0.22"
 thiserror  = "1"
 rand       = "0.8"
 tokio      = { version = "1", features = ["signal", "sync", "rt-multi-thread"] }

--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -9,6 +9,7 @@
 //! - Is marked executable (Unix `chmod 755`).
 
 use std::collections::HashSet;
+
 use std::net::ToSocketAddrs;
 
 use crate::cli::mapping::tool_name_to_subcommand;
@@ -125,9 +126,9 @@ HELP
       exit 1
     }}
     python3 - "$BRIDGE_ENTRY" "{tool_name}" "$@" <<'PY'
-import json, sys, urllib.error, urllib.request
+import base64, json, sys, urllib.error, urllib.request
 
-TOOL_SCHEMAS = json.loads({tool_schemas:?})
+TOOL_SCHEMAS = json.loads(base64.b64decode({tool_schemas:?}).decode("utf-8"))
 
 bridge_entry, tool_name, *argv = sys.argv[1:]
 entry = json.loads(bridge_entry)
@@ -328,14 +329,13 @@ pub fn read_live_bridge_entries(script: &str) -> Vec<CliBridgeEntry> {
 }
 
 fn tool_schema_map_literal(config: &GeneratorConfig) -> String {
-    let mut map = serde_json::Map::new();
-    for tool in &config.tools {
-        map.insert(
-            tool.name.clone(),
-            serde_json::to_value(tool).unwrap_or_else(|_| serde_json::json!({})),
-        );
-    }
-    serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
+    let map = config
+        .tools
+        .iter()
+        .map(|tool| (tool.name.clone(), tool.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let json = serde_json::to_string(&map).expect("tool schema map should serialize");
+    base64::Engine::encode(&base64::engine::general_purpose::STANDARD, json)
 }
 
 fn bridge_map_literal(config: &GeneratorConfig) -> String {

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -113,6 +113,49 @@ fn generated_cli_help_renders_camel_case_properties_as_kebab_case_flags() {
     assert!(!stdout.contains("--maxResults"), "stdout: {stdout}");
 }
 
+#[test]
+fn generated_cli_schema_blob_allows_literal_backslash_unicode_fragments() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = GeneratorConfig {
+        cli_name: "slack".to_string(),
+        bridge_url: "http://127.0.0.1:1".to_string(),
+        token: "token".to_string(),
+        tools: vec![mcp_compressor_core::compression::engine::Tool::new(
+            "slackmcp_slack_search_public",
+            Some("Searches public channels. Example malformed user text can include literal \\u fragments.".to_string()),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "A query string. Literal text may contain C:\\users\\tesler or incomplete \\u escape fragments from docs."
+                    }
+                },
+                "required": ["query"]
+            }),
+        )],
+        session_pid: std::process::id(),
+        output_dir: tempdir.path().to_path_buf(),
+        extra_cli_bridges: Vec::new(),
+    };
+    CliGenerator.generate(&config).unwrap();
+    let script = tempdir.path().join("slack");
+
+    let output = generated_script_output(
+        &script,
+        &["slackmcp-slack-search-public", "--query", "hello"],
+    );
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mcp-compressor proxy is not running"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("SyntaxError"), "stderr: {stderr}");
+    assert!(!stderr.contains("unicodeescape"), "stderr: {stderr}");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generated_typescript_module_reports_stopped_proxy_without_fetch_noise() {
     let tempdir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Fixes several generated-client frictions found while using Slack MCP through Alta/rovo-core.

### 1. Safely embed generated CLI schemas

Generated CLI scripts no longer embed the full schema JSON as a Python string literal:

```python
TOOL_SCHEMAS = json.loads("{...}")
```

They now base64-embed the schema JSON and decode it at runtime:

```python
TOOL_SCHEMAS = json.loads(base64.b64decode("...").decode("utf-8"))
```

This prevents Python source parsing from interpreting arbitrary backend description/schema text as escape sequences. This fixes Slack failures like:

```text
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes ... truncated \uXXXX escape
```

### 2. Improve generated CLI enum help and validation

Generated CLI help now documents enum values when they are available either via JSON Schema `enum` or common description patterns like:

```text
Options: 'score', 'timestamp'
```

Example:

```text
--sort  <score|timestamp>  optional — Sort by relevance or date (default: 'score').; values: score, timestamp
```

The generated CLI also validates these values locally before calling the backend:

```text
invalid value for --sort: date (expected one of: score, timestamp)
```

This would have prevented the Slack `execution_failed: invalid_arguments` loop for `--sort date`.

### 3. Unwrap host bridge result envelopes in generated clients

Host-owned Alta transforms use a JSON bridge envelope:

```json
{"result":"..."}
```

Generated CLI/Python/TypeScript clients now unwrap that envelope before returning/printing the result. Raw Rust proxy responses remain unchanged.

This removes one layer of double-decoding for host transforms:

Before:

```json
{"result":"{\"results\":\"...\"}"}
```

After:

```json
{"results":"..."}
```

Note: Slack MCP still returns Markdown/prose inside its own `results` field; that is Slack MCP-owned.

### 4. Better generated CLI validation diagnostics

Local CLI parser errors now include the flag name and invalid value, e.g.:

```text
invalid boolean value for --include-context: maybe (expected true or false)
invalid integer value for --limit: abc
invalid value for --sort: date (expected one of: score, timestamp)
```

## Ownership note

The ugly Slack subcommand names such as:

```text
slackmcp-slack-search-public-and-private
```

come from the raw backend tool names:

```text
slackmcp_slack_search_public_and_private
```

mcp-compressor only converts underscores to kebab-case; it is not adding the `slackmcp_slack` prefix.

## Validation

- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test generated_clients -- --nocapture`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test transform_modes -- --nocapture`
- `cd typescript && PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/rust_core.test.ts tests/agent_facing_snapshots.test.ts tests/transforms_e2e.test.ts -t "generated CLI clients|snapshots CLI|CLI transform|TypeScript code transform|Python code transform"`
- `cd typescript && bun run typecheck && bun run lint && bun run format:check`
- `git diff --check`
