### PR TITLE
fix: improve generated client CLI ergonomics

### DIFF
--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -141,6 +141,14 @@ properties = properties.get("properties", {{}}) if isinstance(properties, dict) 
 def schema_type(schema):
     return schema.get("type") if isinstance(schema, dict) else None
 
+def enum_values(schema):
+    if not isinstance(schema, dict):
+        return []
+    explicit = schema.get("enum")
+    if isinstance(explicit, list):
+        return [str(value) for value in explicit]
+    return []
+
 def canonical_name(value):
     return value.replace("-", "_").replace("_", "").lower()
 
@@ -159,7 +167,7 @@ def flag_to_property(flag):
             return prop
     return raw
 
-def coerce_value(schema, raw_value, forced_bool=None):
+def coerce_value(flag, schema, raw_value, forced_bool=None):
     if forced_bool is not None:
         return forced_bool
     typ = schema_type(schema)
@@ -170,17 +178,17 @@ def coerce_value(schema, raw_value, forced_bool=None):
             return True
         if raw_value == "false":
             return False
-        raise SystemExit(f"invalid boolean value: {{raw_value}}")
+        raise SystemExit(f"invalid boolean value for {{flag}}: {{raw_value}} (expected true or false)")
     if typ == "integer":
         try:
             return int(raw_value)
         except Exception:
-            raise SystemExit(f"invalid integer value: {{raw_value}}")
+            raise SystemExit(f"invalid integer value for {{flag}}: {{raw_value}}")
     if typ == "number":
         try:
             return float(raw_value)
         except Exception:
-            raise SystemExit(f"invalid number value: {{raw_value}}")
+            raise SystemExit(f"invalid number value for {{flag}}: {{raw_value}}")
     if typ == "array":
         try:
             parsed = json.loads(raw_value)
@@ -188,11 +196,22 @@ def coerce_value(schema, raw_value, forced_bool=None):
                 return parsed
         except Exception:
             pass
-        return coerce_value(schema.get("items", {{}}), raw_value)
+        return coerce_value(flag, schema.get("items", {{}}), raw_value)
     try:
         return json.loads(raw_value or "")
     except Exception:
         return raw_value or ""
+
+def validate_value(flag, schema, value):
+    allowed = enum_values(schema)
+    if not allowed:
+        return
+    values = value if isinstance(value, list) else [value]
+    for candidate in values:
+        if str(candidate) not in allowed:
+            raise SystemExit(
+                f"invalid value for {{flag}}: {{candidate}} (expected one of: {{', '.join(allowed)}})"
+            )
 
 def insert_value(output, key, schema, value):
     if schema_type(schema) == "array":
@@ -237,7 +256,9 @@ def parse_args(argv):
                 raise SystemExit(f"{{flag}} requires a value")
             raw_value = argv[index + 1]
             consumed = 2
-        insert_value(output, prop, schema, coerce_value(schema, raw_value, forced_bool))
+        value = coerce_value(flag, schema, raw_value, forced_bool)
+        validate_value(flag, schema, value)
+        insert_value(output, prop, schema, value)
         index += consumed
     return output
 
@@ -249,9 +270,19 @@ req = urllib.request.Request(
     headers={{"Content-Type": "application/json", "Authorization": "Bearer " + token}},
     method="POST",
 )
+def unwrap_proxy_response(body):
+    try:
+        parsed = json.loads(body)
+    except Exception:
+        return body
+    if isinstance(parsed, dict) and set(parsed.keys()) == {{"result"}}:
+        result = parsed["result"]
+        return result if isinstance(result, str) else json.dumps(result, separators=(",", ":"))
+    return body
+
 try:
     with urllib.request.urlopen(req, timeout=30) as resp:
-        sys.stdout.write(resp.read().decode())
+        sys.stdout.write(unwrap_proxy_response(resp.read().decode()))
 except urllib.error.HTTPError as exc:
     message = exc.read().decode(errors="replace") or exc.reason
     print(f"mcp-compressor proxy returned HTTP {{exc.code}}: {{message}}", file=sys.stderr)
@@ -450,11 +481,7 @@ fn tool_options(tool: &crate::compression::engine::Tool) -> Vec<ToolOption> {
                         .and_then(|value| value.as_str())
                         .map(str::to_string),
                     default: schema.get("default").map(default_value_label),
-                    enum_values: schema
-                        .get("enum")
-                        .and_then(|value| value.as_array())
-                        .map(|values| values.iter().map(default_value_label).collect())
-                        .unwrap_or_default(),
+                    enum_values: schema_enum_values(schema),
                 })
                 .collect()
         })
@@ -487,15 +514,18 @@ fn format_tool_option_help(option: &ToolOption) -> String {
     line
 }
 
+fn schema_enum_values(schema: &serde_json::Value) -> Vec<String> {
+    schema
+        .get("enum")
+        .and_then(|value| value.as_array())
+        .map(|values| values.iter().map(default_value_label).collect())
+        .unwrap_or_default()
+}
+
 fn schema_type_label(schema: &serde_json::Value) -> String {
-    if let Some(values) = schema.get("enum").and_then(|value| value.as_array()) {
-        let labels = values
-            .iter()
-            .filter_map(|value| value.as_str().map(str::to_string))
-            .collect::<Vec<_>>();
-        if !labels.is_empty() {
-            return labels.join("|");
-        }
+    let labels = schema_enum_values(schema);
+    if !labels.is_empty() {
+        return labels.join("|");
     }
     match schema.get("type").and_then(|value| value.as_str()) {
         Some("integer") => "integer".to_string(),

--- a/crates/mcp-compressor-core/src/client_gen/python.rs
+++ b/crates/mcp-compressor-core/src/client_gen/python.rs
@@ -39,12 +39,25 @@ _SESSION_PID = {pid}
 _HEADERS = {{"Content-Type": "application/json", "Authorization": f"Bearer {{_TOKEN}}"}}
 
 
+
+
+def _unwrap_proxy_response(body: str) -> str:
+    try:
+        parsed = json.loads(body)
+    except Exception:
+        return body
+    if isinstance(parsed, dict) and set(parsed.keys()) == {{"result"}}:
+        result = parsed["result"]
+        return result if isinstance(result, str) else json.dumps(result, separators=(",", ":"))
+    return body
+
+
 def _exec(tool: str, tool_input: dict) -> str:
     payload = json.dumps({{"tool": tool, "input": tool_input}}).encode()
     request = urllib.request.Request(_BRIDGE + "/exec", data=payload, headers=_HEADERS, method="POST")
     try:
         with urllib.request.urlopen(request) as response:
-            return response.read().decode()
+            return _unwrap_proxy_response(response.read().decode())
     except urllib.error.HTTPError as exc:
         message = exc.read().decode(errors="replace") or exc.reason
         raise RuntimeError(f"mcp-compressor proxy returned HTTP {{exc.code}}: {{message}}") from None
@@ -148,7 +161,13 @@ fn required_params(tool: &crate::compression::engine::Tool) -> Vec<String> {
     tool.input_schema
         .get("required")
         .and_then(serde_json::Value::as_array)
-        .map(|values| values.iter().filter_map(serde_json::Value::as_str).map(ToString::to_string).collect())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
         .unwrap_or_default()
 }
 
@@ -248,7 +267,10 @@ mod tests {
         let config = make_config(dir.path());
         let paths = PythonGenerator.generate(&config).unwrap();
         let content = fs::read_to_string(&paths[0]).unwrap();
-        assert!(content.contains(&config.bridge_url), "bridge URL not found in file");
+        assert!(
+            content.contains(&config.bridge_url),
+            "bridge URL not found in file"
+        );
         assert!(content.contains("_BRIDGE"), "_BRIDGE constant not found");
     }
 
@@ -274,8 +296,14 @@ mod tests {
         let config = make_config(dir.path());
         let paths = PythonGenerator.generate(&config).unwrap();
         let content = fs::read_to_string(&paths[0]).unwrap();
-        assert!(content.contains("Fetch a URL"), "tool description not found in docstring");
-        assert!(content.contains("Search the web"), "tool description not found in docstring");
+        assert!(
+            content.contains("Fetch a URL"),
+            "tool description not found in docstring"
+        );
+        assert!(
+            content.contains("Search the web"),
+            "tool description not found in docstring"
+        );
     }
 
     /// Function parameters match the tool's schema properties.
@@ -297,7 +325,10 @@ mod tests {
         let config = make_config(dir.path());
         let paths = PythonGenerator.generate(&config).unwrap();
         let content = fs::read_to_string(&paths[0]).unwrap();
-        assert!(content.contains("-> str"), "-> str return annotation not found");
+        assert!(
+            content.contains("-> str"),
+            "-> str return annotation not found"
+        );
     }
 
     /// Required params appear without a default value; optional params use `None`.
@@ -310,7 +341,10 @@ mod tests {
         let content = fs::read_to_string(&paths[0]).unwrap();
         // "url" is required → no "= None" for url
         // (this test verifies the function signature handles optionality)
-        assert!(content.contains("url"), "'url' param not found in generated file");
+        assert!(
+            content.contains("url"),
+            "'url' param not found in generated file"
+        );
     }
 
     #[test]
@@ -339,7 +373,9 @@ mod tests {
         };
         let paths = PythonGenerator.generate(&config).unwrap();
         let content = fs::read_to_string(&paths[0]).unwrap();
-        assert!(content.contains("def real_tool(required_second, optional_first=None, optional_third=None) -> str:"));
+        assert!(content.contains(
+            "def real_tool(required_second, optional_first=None, optional_third=None) -> str:"
+        ));
         assert!(content.contains("{\"optional_first\": optional_first, \"required_second\": required_second, \"optional_third\": optional_third}"));
         std::process::Command::new("python3")
             .arg("-m")
@@ -351,7 +387,6 @@ mod tests {
             .then_some(())
             .expect("generated Python should compile");
     }
-
 
     #[test]
     fn camel_case_tool_and_params_are_pythonic_snake_case_but_payload_keeps_original_keys() {
@@ -380,7 +415,9 @@ mod tests {
         let paths = PythonGenerator.generate(&config).unwrap();
         let content = fs::read_to_string(&paths[0]).unwrap();
         assert!(content.contains("def search_jira_issues_using_jql(cloud_id, max_results=None, next_page_token=None) -> str:"));
-        assert!(content.contains(r#"{"cloudId": cloud_id, "maxResults": max_results, "nextPageToken": next_page_token}"#));
+        assert!(content.contains(
+            r#"{"cloudId": cloud_id, "maxResults": max_results, "nextPageToken": next_page_token}"#
+        ));
         std::process::Command::new("python3")
             .arg("-m")
             .arg("py_compile")

--- a/crates/mcp-compressor-core/src/client_gen/typescript.rs
+++ b/crates/mcp-compressor-core/src/client_gen/typescript.rs
@@ -46,10 +46,30 @@ async function execTool(tool: string, input: Record<string, unknown>): Promise<s
   }} catch (error) {{
     throw new Error(`mcp-compressor proxy is not running; restart the mcp-compressor process and try again. details: ${{error instanceof Error ? error.message : String(error)}}`);
   }}
+  const body = await res.text();
   if (!res.ok) {{
-    throw new Error(`mcp-compressor proxy returned HTTP ${{res.status}}: ${{await res.text()}}`);
+    throw new Error(`mcp-compressor proxy returned HTTP ${{res.status}}: ${{body}}`);
   }}
-  return res.text();
+  return unwrapProxyResponse(body);
+}}
+
+function unwrapProxyResponse(body: string): string {{
+  try {{
+    const parsed = JSON.parse(body) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      Object.keys(parsed).length === 1 &&
+      Object.prototype.hasOwnProperty.call(parsed, "result")
+    ) {{
+      const result = (parsed as {{ result: unknown }}).result;
+      return typeof result === "string" ? result : JSON.stringify(result);
+    }}
+  }} catch {{
+    // Rust proxy responses are raw strings; preserve them as-is.
+  }}
+  return body;
 }}
 "#,
         bridge = config.bridge_url,

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::{io, process::Command, thread, time::Duration};
+use std::{io, net::TcpListener, process::Command, thread, time::Duration};
 
 use mcp_compressor_core::client_gen::cli::CliGenerator;
 use mcp_compressor_core::client_gen::python::PythonGenerator;
@@ -415,6 +415,189 @@ fn golden(relative_path: &str) -> String {
     .unwrap()
     .trim_end()
     .to_string()
+}
+
+#[test]
+fn generated_cli_help_documents_and_validates_schema_enums() {
+    let bridge = start_json_result_bridge("unused");
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = GeneratorConfig {
+        cli_name: "slack".to_string(),
+        bridge_url: bridge.url.clone(),
+        token: "token".to_string(),
+        tools: vec![mcp_compressor_core::compression::engine::Tool::new(
+            "slackmcp_slack_search_public_and_private",
+            Some("Search Slack.".to_string()),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "Search query" },
+                    "sort": { "type": "string", "enum": ["score", "timestamp"], "description": "Sort by relevance or date." }
+                },
+                "required": ["query"]
+            }),
+        )],
+        session_pid: std::process::id(),
+        output_dir: tempdir.path().to_path_buf(),
+        extra_cli_bridges: Vec::new(),
+    };
+    CliGenerator.generate(&config).unwrap();
+    let script = tempdir.path().join("slack");
+
+    let help = run_generated_script(
+        &script,
+        &["slackmcp-slack-search-public-and-private", "--help"],
+    );
+    assert!(help.contains("--sort"), "help: {help}");
+    assert!(help.contains("<score|timestamp>"), "help: {help}");
+    assert!(help.contains("values: score, timestamp"), "help: {help}");
+
+    let output = generated_script_output(
+        &script,
+        &[
+            "slackmcp-slack-search-public-and-private",
+            "--query",
+            "hello",
+            "--sort",
+            "date",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid value for --sort: date (expected one of: score, timestamp)"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn generated_cli_prints_raw_host_bridge_result() {
+    let bridge = start_json_result_bridge("{\"results\":\"ok\"}");
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = GeneratorConfig {
+        cli_name: "alpha".to_string(),
+        bridge_url: bridge.url.clone(),
+        token: "token".to_string(),
+        tools: vec![mcp_compressor_core::compression::engine::Tool::new(
+            "echo",
+            Some("Echo.".to_string()),
+            serde_json::json!({"type":"object","properties":{"message":{"type":"string"}}}),
+        )],
+        session_pid: std::process::id(),
+        output_dir: tempdir.path().to_path_buf(),
+        extra_cli_bridges: Vec::new(),
+    };
+    CliGenerator.generate(&config).unwrap();
+    let script = tempdir.path().join("alpha");
+
+    assert_eq!(
+        run_generated_script(&script, &["echo", "--message", "hello"]),
+        "{\"results\":\"ok\"}"
+    );
+}
+
+#[test]
+fn generated_python_module_returns_raw_host_bridge_result() {
+    let bridge = start_json_result_bridge("python-ok");
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = simple_generator_config("alpha", &bridge.url, tempdir.path());
+    PythonGenerator.generate(&config).unwrap();
+
+    let output = Command::new(common::python_command())
+        .env("PYTHONPATH", tempdir.path())
+        .args(["-c", "import alpha; print(alpha.echo('hello'))"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "python-ok");
+}
+
+#[test]
+fn generated_typescript_module_returns_raw_host_bridge_result() {
+    let bridge = start_json_result_bridge("typescript-ok");
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = simple_generator_config("alpha", &bridge.url, tempdir.path());
+    TypeScriptGenerator.generate(&config).unwrap();
+
+    let code = format!(
+        "import * as alpha from {module:?}; console.log(await alpha.echo('hello'));",
+        module = tempdir.path().join("alpha.ts").display().to_string()
+    );
+    let output = Command::new("bun")
+        .arg("--eval")
+        .arg(&code)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "typescript-ok"
+    );
+}
+
+struct TestBridge {
+    url: String,
+}
+
+fn start_json_result_bridge(result: &str) -> TestBridge {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let result = result.to_string();
+    thread::spawn(move || {
+        for stream in listener.incoming().take(8) {
+            let mut stream = stream.unwrap();
+            let mut buffer = [0_u8; 4096];
+            let read = std::io::Read::read(&mut stream, &mut buffer).unwrap_or(0);
+            let request = String::from_utf8_lossy(&buffer[..read]);
+            let body = if request.starts_with("GET /health") {
+                "ok".to_string()
+            } else {
+                serde_json::json!({ "result": result }).to_string()
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(), body
+            );
+            let _ = std::io::Write::write_all(&mut stream, response.as_bytes());
+        }
+    });
+    TestBridge {
+        url: format!("http://{addr}"),
+    }
+}
+
+fn simple_generator_config(
+    cli_name: &str,
+    bridge_url: &str,
+    output_dir: &std::path::Path,
+) -> GeneratorConfig {
+    GeneratorConfig {
+        cli_name: cli_name.to_string(),
+        bridge_url: bridge_url.to_string(),
+        token: "token".to_string(),
+        tools: vec![mcp_compressor_core::compression::engine::Tool::new(
+            "echo",
+            Some("Echo.".to_string()),
+            serde_json::json!({
+                "type": "object",
+                "properties": { "message": { "type": "string" } },
+                "required": ["message"]
+            }),
+        )],
+        session_pid: std::process::id(),
+        output_dir: output_dir.to_path_buf(),
+        extra_cli_bridges: Vec::new(),
+    }
 }
 
 fn alpha_golden_tools() -> Vec<mcp_compressor_core::compression::engine::Tool> {

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -688,11 +688,11 @@ describe("local TypeScript tool compression", () => {
         body: JSON.stringify({ tool: "user_info", input: {} }),
       });
       expect(execResponse.status).toBe(200);
-      const execBody = (await execResponse.json()) as { result: string };
-      expect(execBody.result).not.toContain("[object Object]");
-      expect(execBody.result).not.toContain('"content"');
-      expect(execBody.result).toContain("abc-123");
-      expect(execBody.result).toContain("Ada Lovelace");
+      const execBody = await execResponse.text();
+      expect(execBody).not.toContain("[object Object]");
+      expect(execBody).not.toContain('"content"');
+      expect(execBody).toContain("abc-123");
+      expect(execBody).toContain("Ada Lovelace");
     } finally {
       transform.close();
     }


### PR DESCRIPTION
## Summary

Follow-up to #222 with generated-client ergonomics fixes found while using Slack MCP through Alta/rovo-core.

### Private HTTP bridge can use JSON; public surfaces return upstream results

The TypeScript host-owned local bridge keeps a JSON transport envelope for `/exec`:

```json
{"result":"..."}
```

But agent-facing/generated surfaces unwrap that private transport envelope and return/print the faithful upstream-normalized tool result:

- generated CLI
- generated Python
- generated TypeScript
- `createExecutableToolBridge(...).invokeTool(...)`

So if the upstream MCP tool returns plain text, those surfaces return plain text.

The Rust proxy already returns raw text directly; generated clients preserve that behavior.

### JSON Schema enum help and validation

Generated CLI help now shows enum values when they are represented correctly in JSON Schema `enum`.

Example:

```text
--sort  <score|timestamp>  optional — Sort by relevance or date.; values: score, timestamp
```

Generated CLI also validates those schema enum values locally:

```text
invalid value for --sort: date (expected one of: score, timestamp)
```

If a server only documents possible values in prose rather than JSON Schema, mcp-compressor does not guess; the agent must rely on the tool/subcommand description.

### Better validation diagnostics

Generated CLI local parser errors now include flag name and invalid value:

```text
invalid boolean value for --include-context: maybe (expected true or false)
invalid integer value for --limit: abc
invalid value for --sort: date (expected one of: score, timestamp)
```

## Ownership note

The ugly Slack subcommand names such as:

```text
slackmcp-slack-search-public-and-private
```

come from raw backend tool names like:

```text
slackmcp_slack_search_public_and_private
```

mcp-compressor only converts underscores to kebab-case.

## Validation

- `cargo check -p mcp-compressor-core -p mcp-compressor-node`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test generated_clients -- --nocapture`
- `PYTHON="$PWD/.venv/bin/python" cargo test -p mcp-compressor-core --test transform_modes -- --nocapture`
- `cd typescript && PYTHON="$PWD/../.venv/bin/python" bun run vitest run tests/executable_tool_bridge.test.ts tests/rust_core.test.ts tests/agent_facing_snapshots.test.ts tests/transforms_e2e.test.ts -t "bridge|generated CLI clients|snapshots CLI|CLI transform|TypeScript code transform|Python code transform|high-level native CLI|stringifies MCP text content"`
- `cd typescript && bun run typecheck && bun run lint && bun run format:check`
- `git diff --check`
