### PR TITLE
refactor: unify CLI/Just Bash help + arg parsing in one renderer

### DIFF
--- a/crates/mcp-compressor-core/src/cli/help.rs
+++ b/crates/mcp-compressor-core/src/cli/help.rs
@@ -1,0 +1,600 @@
+//! Shared CLI help renderer — the single source of truth for help text used by
+//! every transform mode (generated CLI script, Just Bash commands, and the
+//! `*_help` MCP tool description).
+//!
+//! Historically there were three separate implementations of "render the
+//! top-level help" and "render a subcommand's help" — one embedded in the
+//! generated CLI shell script ([`crate::client_gen::cli`]), one in the host
+//! transform plan ([`crate::ffi::host_transform`]), and one in the TypeScript
+//! Just Bash command builder. They drifted (different column widths, footers,
+//! and the Just Bash path was missing subcommand `--help` entirely).
+//!
+//! This module centralizes all of that logic so that:
+//!
+//! - The top-level `<cli> --help` output and the `<cli>_help` tool description
+//!   share an **identical body** and differ only by an explicit
+//!   [`HelpFraming`] prefix/footer.
+//! - The rich per-subcommand `<cli> <subcommand> --help` output is rendered
+//!   from one place and is therefore identical across CLI and Just Bash modes.
+
+use std::collections::HashSet;
+
+use crate::cli::mapping::tool_name_to_subcommand;
+use crate::compression::engine::Tool;
+
+/// The TOON-format note shown in every top-level help body.
+pub const TOON_NOTE: &str =
+    "When relevant, outputs from this CLI will prefer using the TOON format for more efficient representation of data.";
+
+/// Framing applied around the shared top-level help body. The body itself is
+/// always identical; only this prefix/footer may differ between the shell
+/// `--help` output and the `*_help` tool description.
+#[derive(Debug, Clone, Default)]
+pub struct HelpFraming {
+    /// Optional lines prepended before the shared body (followed by a blank
+    /// line). Used by the `*_help` tool description to tell the model to use
+    /// the CLI rather than calling the tool.
+    pub prefix: Vec<String>,
+    /// Optional lines appended after the shared body (preceded by a blank
+    /// line).
+    pub footer: Vec<String>,
+}
+
+impl HelpFraming {
+    /// Framing for the generated shell script's top-level `--help`.
+    pub fn shell(command: &str) -> Self {
+        Self {
+            prefix: Vec::new(),
+            footer: vec![format!(
+                "Run '{command} <subcommand> --help' for subcommand usage."
+            )],
+        }
+    }
+
+    /// Framing for the `<cli>_help` MCP tool description.
+    pub fn help_tool(command: &str, cli_name: &str) -> Self {
+        Self {
+            prefix: vec![format!(
+                "Functionality associated with the {cli_name} toolset is provided via the `{command}` CLI. Do not call this tool - use the CLI instead."
+            )],
+            footer: vec![
+                format!("Run '{command} --help' in the shell for usage."),
+                format!("Run '{command} <subcommand> --help' for per-command help."),
+                format!("Run '{command} <subcommand> [options]' to invoke a tool."),
+            ],
+        }
+    }
+}
+
+/// Render the shared top-level help body (without framing): the toolset header,
+/// the TOON note, the USAGE line, and the SUBCOMMANDS listing with concise
+/// per-subcommand summaries.
+pub fn render_top_level_body(command: &str, cli_name: &str, tools: &[Tool]) -> String {
+    let mut lines = vec![
+        format!("{cli_name} - the {cli_name} toolset"),
+        String::new(),
+        TOON_NOTE.to_string(),
+        String::new(),
+        "USAGE:".to_string(),
+        format!("  {command} <subcommand> [options]"),
+        String::new(),
+        "SUBCOMMANDS:".to_string(),
+    ];
+    lines.extend(render_subcommands_block(tools));
+    lines.join("\n")
+}
+
+/// Render the full top-level help text: framing prefix, the shared body, then
+/// framing footer.
+pub fn render_top_level_help(
+    command: &str,
+    cli_name: &str,
+    tools: &[Tool],
+    framing: &HelpFraming,
+) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    if !framing.prefix.is_empty() {
+        lines.extend(framing.prefix.iter().cloned());
+    }
+    lines.push(render_top_level_body(command, cli_name, tools));
+    if !framing.footer.is_empty() {
+        lines.push(String::new());
+        lines.extend(framing.footer.iter().cloned());
+    }
+    lines.join("\n")
+}
+
+/// Render the `SUBCOMMANDS:` listing lines (kebab-case subcommand + concise
+/// summary), dynamically aligned to the longest subcommand name.
+pub fn render_subcommands_block(tools: &[Tool]) -> Vec<String> {
+    let names = tools
+        .iter()
+        .map(|tool| tool_name_to_subcommand(&tool.name))
+        .collect::<Vec<_>>();
+    let max_name_len = names.iter().map(String::len).max().unwrap_or(0);
+    tools
+        .iter()
+        .zip(names)
+        .map(|(tool, name)| {
+            let description = short_tool_description(tool.description.as_deref());
+            format!("  {name:<width$}{description}", width = max_name_len + 2)
+                .trim_end()
+                .to_string()
+        })
+        .collect()
+}
+
+/// Render the rich per-subcommand help: description block, usage line, and the
+/// REQUIRED / OPTIONAL / COMPLEX / GLOBAL option sections derived from the
+/// tool's input schema.
+pub fn render_subcommand_help(cli_name: &str, tool: &Tool) -> String {
+    let subcommand = tool_name_to_subcommand(&tool.name);
+    let mut help = format!(
+        "{cli_name} {subcommand}\n\n{}\n\nUSAGE:\n  {cli_name} {subcommand} [options]\n",
+        tool_description_block(tool.description.as_deref().unwrap_or("Invoke this tool.")),
+    );
+
+    let options = tool_options(tool);
+    let required = options
+        .iter()
+        .filter(|option| option.required && !option.is_complex)
+        .collect::<Vec<_>>();
+    let optional = options
+        .iter()
+        .filter(|option| !option.required && !option.is_complex)
+        .collect::<Vec<_>>();
+    let complex = options
+        .iter()
+        .filter(|option| option.is_complex)
+        .collect::<Vec<_>>();
+
+    append_option_section(&mut help, "REQUIRED", &required);
+    append_option_section(&mut help, "OPTIONAL", &optional);
+    append_option_section(&mut help, "COMPLEX / JSON OPTIONS", &complex);
+
+    help.push_str("\nGLOBAL OPTIONS:\n");
+    help.push_str("  --json <json object>\n");
+    help.push_str("      Provide the entire tool input as JSON. This bypasses flag parsing.\n");
+    help.push_str("\n  --help\n");
+    help.push_str("      Show this help message.\n");
+
+    help
+}
+
+// ---------------------------------------------------------------------------
+// Concise summary helpers (shared by top-level help and code-mode help).
+// ---------------------------------------------------------------------------
+
+/// Produce a concise one-line summary of a tool description: the first
+/// sentence (unless under 10 chars, in which case the first non-empty line),
+/// cleanly truncated to 200 characters.
+pub fn short_tool_description(description: Option<&str>) -> String {
+    let trimmed = description.unwrap_or_default().trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let first_sentence = first_sentence(trimmed);
+    let candidate = if first_sentence.chars().count() >= 10 {
+        first_sentence
+    } else {
+        first_non_empty_line(trimmed)
+    };
+    truncate_clean(candidate, 200)
+}
+
+fn first_sentence(value: &str) -> &str {
+    for (index, ch) in value.char_indices() {
+        if matches!(ch, '.' | '!' | '?') {
+            return value[..=index].trim();
+        }
+    }
+    first_non_empty_line(value)
+}
+
+fn first_non_empty_line(value: &str) -> &str {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_default()
+}
+
+fn truncate_clean(value: &str, max_chars: usize) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+    let limit = max_chars.saturating_sub(3);
+    let mut end = 0;
+    for (count, (index, ch)) in compact.char_indices().enumerate() {
+        if count >= limit {
+            break;
+        }
+        end = index + ch.len_utf8();
+    }
+    let mut prefix = compact[..end]
+        .trim_end_matches(|ch: char| ch.is_whitespace() || ch == ',' || ch == ';' || ch == ':')
+        .to_string();
+    if let Some(space) = prefix.rfind(' ') {
+        if space >= max_chars / 2 {
+            prefix.truncate(space);
+        }
+    }
+    prefix.push_str("...");
+    prefix
+}
+
+/// Collapse internal whitespace runs into single spaces, keeping the text on a
+/// single line.
+pub fn full_description(description: &str) -> String {
+    description.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Render a tool's top-level description while preserving its original line
+/// structure. Each line is trimmed and has internal whitespace runs collapsed,
+/// but newlines (including blank lines between paragraphs) are kept so the
+/// description does not get flattened into a single massive line. Leading and
+/// trailing blank lines are removed, and runs of 3+ blank lines are collapsed
+/// to a single blank line.
+pub fn tool_description_block(description: &str) -> String {
+    let lines: Vec<String> = description
+        .lines()
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+        .collect();
+
+    // Collapse multiple consecutive blank lines into a single blank line.
+    let mut collapsed: Vec<String> = Vec::with_capacity(lines.len());
+    let mut previous_blank = false;
+    for line in lines {
+        let is_blank = line.is_empty();
+        if is_blank && previous_blank {
+            continue;
+        }
+        previous_blank = is_blank;
+        collapsed.push(line);
+    }
+
+    // Trim leading/trailing blank lines.
+    while collapsed.first().is_some_and(|line| line.is_empty()) {
+        collapsed.remove(0);
+    }
+    while collapsed.last().is_some_and(|line| line.is_empty()) {
+        collapsed.pop();
+    }
+
+    if collapsed.is_empty() {
+        return "Invoke this tool.".to_string();
+    }
+
+    collapsed.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Per-subcommand option rendering.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolOption {
+    name: String,
+    ty: String,
+    required: bool,
+    description: Option<String>,
+    default: Option<String>,
+    enum_values: Vec<String>,
+    minimum: Option<String>,
+    maximum: Option<String>,
+    min_length: Option<String>,
+    max_length: Option<String>,
+    min_items: Option<String>,
+    max_items: Option<String>,
+    is_complex: bool,
+    complex_hint: Option<String>,
+}
+
+fn tool_options(tool: &Tool) -> Vec<ToolOption> {
+    let required = tool
+        .input_schema
+        .get("required")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default();
+
+    tool.input_schema
+        .get("properties")
+        .and_then(|value| value.as_object())
+        .map(|properties| {
+            properties
+                .iter()
+                .map(|(name, schema)| {
+                    let (ty, is_complex, complex_hint) = schema_type_details(schema);
+                    ToolOption {
+                        name: name.clone(),
+                        ty,
+                        required: required.contains(name),
+                        description: schema
+                            .get("description")
+                            .and_then(|value| value.as_str())
+                            .map(full_description),
+                        default: schema.get("default").map(default_value_label),
+                        enum_values: schema_enum_values(schema),
+                        minimum: schema_number_constraint(schema, "minimum"),
+                        maximum: schema_number_constraint(schema, "maximum"),
+                        min_length: schema_number_constraint(schema, "minLength"),
+                        max_length: schema_number_constraint(schema, "maxLength"),
+                        min_items: schema_number_constraint(schema, "minItems"),
+                        max_items: schema_number_constraint(schema, "maxItems"),
+                        is_complex,
+                        complex_hint,
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn append_option_section(help: &mut String, title: &str, options: &[&ToolOption]) {
+    if options.is_empty() {
+        return;
+    }
+    help.push('\n');
+    help.push_str(title);
+    help.push_str(":\n");
+    for option in options {
+        help.push_str(&format_tool_option_help(option));
+    }
+}
+
+fn format_tool_option_help(option: &ToolOption) -> String {
+    let flag = format!("--{}", tool_name_to_subcommand(&option.name));
+    let mut output = format!("  {flag} <{}>\n", option.ty);
+    let mut details = Vec::new();
+    if option.required {
+        details.push("Required.".to_string());
+    }
+    if let Some(description) = &option.description {
+        details.push(description.clone());
+    }
+    if !option.enum_values.is_empty() {
+        details.push(format!(
+            "Allowed values: {}.",
+            option.enum_values.join(", ")
+        ));
+    }
+    if let Some(default) = &option.default {
+        details.push(format!("Default: {default}."));
+    }
+    if let Some(minimum) = &option.minimum {
+        details.push(format!("Minimum: {minimum}."));
+    }
+    if let Some(maximum) = &option.maximum {
+        details.push(format!("Maximum: {maximum}."));
+    }
+    if let Some(min_length) = &option.min_length {
+        details.push(format!("Minimum length: {min_length}."));
+    }
+    if let Some(max_length) = &option.max_length {
+        details.push(format!("Maximum length: {max_length}."));
+    }
+    if let Some(min_items) = &option.min_items {
+        details.push(format!("Minimum items: {min_items}."));
+    }
+    if let Some(max_items) = &option.max_items {
+        details.push(format!("Maximum items: {max_items}."));
+    }
+    if option.ty == "boolean" {
+        details.push("Accepted values: true, false.".to_string());
+        details.push(format!(
+            "Also supports: {flag} and --no-{}.",
+            tool_name_to_subcommand(&option.name)
+        ));
+    }
+    if let Some(hint) = &option.complex_hint {
+        details.push(hint.clone());
+    }
+    for detail in details {
+        output.push_str(&wrap_indented(&detail, 6, 100));
+    }
+    output
+}
+
+fn schema_number_constraint(schema: &serde_json::Value, key: &str) -> Option<String> {
+    schema.get(key).map(default_value_label)
+}
+
+fn schema_type_details(schema: &serde_json::Value) -> (String, bool, Option<String>) {
+    let labels = schema_enum_values(schema);
+    if !labels.is_empty() {
+        return (labels.join("|"), false, None);
+    }
+    if schema.get("oneOf").is_some()
+        || schema.get("anyOf").is_some()
+        || schema.get("allOf").is_some()
+    {
+        return (
+            "json".to_string(),
+            true,
+            Some("Schema contains oneOf/anyOf/allOf; use --json for complex input.".to_string()),
+        );
+    }
+    match schema.get("type").and_then(|value| value.as_str()) {
+        Some("integer") => ("integer".to_string(), false, None),
+        Some("number") => ("number".to_string(), false, None),
+        Some("boolean") => ("boolean".to_string(), false, None),
+        Some("array") => match schema.get("items") {
+            Some(items) => {
+                let (item_ty, item_complex, _) = schema_type_details(items);
+                if item_complex
+                    || matches!(
+                        items.get("type").and_then(|value| value.as_str()),
+                        Some("object" | "array")
+                    )
+                {
+                    (
+                        "json array".to_string(),
+                        true,
+                        Some("Pass as a JSON array string.".to_string()),
+                    )
+                } else {
+                    (
+                        format!("{item_ty}[]"),
+                        false,
+                        Some("Repeat this flag or pass a JSON array.".to_string()),
+                    )
+                }
+            }
+            None => (
+                "json array".to_string(),
+                true,
+                Some("Pass as a JSON array string.".to_string()),
+            ),
+        },
+        Some("object") => (
+            "json object".to_string(),
+            true,
+            Some("Pass as a JSON object string.".to_string()),
+        ),
+        Some("string") | None => ("string".to_string(), false, None),
+        Some(other) => (other.to_string(), false, None),
+    }
+}
+
+fn schema_enum_values(schema: &serde_json::Value) -> Vec<String> {
+    schema
+        .get("enum")
+        .and_then(|value| value.as_array())
+        .map(|values| values.iter().map(default_value_label).collect())
+        .unwrap_or_default()
+}
+
+fn default_value_label(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn wrap_indented(value: &str, indent: usize, width: usize) -> String {
+    let prefix = " ".repeat(indent);
+    let mut output = String::new();
+    let mut line = String::new();
+    for word in value.split_whitespace() {
+        if !line.is_empty() && line.len() + 1 + word.len() > width.saturating_sub(indent) {
+            output.push_str(&prefix);
+            output.push_str(line.trim_end());
+            output.push('\n');
+            line.clear();
+        }
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    if !line.is_empty() {
+        output.push_str(&prefix);
+        output.push_str(line.trim_end());
+        output.push('\n');
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tool(name: &str, description: &str) -> Tool {
+        Tool {
+            name: name.to_string(),
+            description: Some(description.to_string()),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "Search query." },
+                    "sort": {
+                        "type": "string",
+                        "description": "Sort order.",
+                        "enum": ["score", "timestamp"]
+                    }
+                },
+                "required": ["query"]
+            }),
+        }
+    }
+
+    /// The `*_help` tool description must equal the shell `--help` body plus the
+    /// documented framing prefix/footer — nothing else may differ.
+    #[test]
+    fn help_tool_description_equals_shell_help_modulo_framing() {
+        let tools = vec![tool(
+            "search",
+            "Search things. Extra detail after the sentence.",
+        )];
+        let command = "atlassian";
+        let cli_name = "atlassian";
+
+        let body = render_top_level_body(command, cli_name, &tools);
+        let shell = render_top_level_help(command, cli_name, &tools, &HelpFraming::shell(command));
+        let help_tool = render_top_level_help(
+            command,
+            cli_name,
+            &tools,
+            &HelpFraming::help_tool(command, cli_name),
+        );
+
+        // Both renderings contain the identical shared body.
+        assert!(shell.contains(&body), "shell help must contain shared body");
+        assert!(
+            help_tool.contains(&body),
+            "help-tool description must contain the identical shared body"
+        );
+
+        // The help-tool description is exactly: prefix + body + footer.
+        let framing = HelpFraming::help_tool(command, cli_name);
+        let expected = format!(
+            "{}\n{}\n\n{}",
+            framing.prefix.join("\n"),
+            body,
+            framing.footer.join("\n")
+        );
+        assert_eq!(help_tool, expected);
+    }
+
+    #[test]
+    fn top_level_help_uses_concise_summaries() {
+        let long = "First sentence is short. ".to_string() + &"word ".repeat(80);
+        let tools = vec![tool("search", &long)];
+        let body = render_top_level_body("svc", "svc", &tools);
+        // Concise: only the first sentence should appear, not the 80-word tail.
+        assert!(body.contains("First sentence is short."));
+        assert!(!body.contains("word word word word word word"));
+    }
+
+    #[test]
+    fn subcommand_help_includes_enum_and_required_sections() {
+        let help = render_subcommand_help("svc", &tool("search", "Search things."));
+        assert!(help.contains("REQUIRED:"));
+        assert!(help.contains("--query"));
+        assert!(help.contains("OPTIONAL:"));
+        assert!(help.contains("--sort"));
+        assert!(help.contains("Allowed values: score, timestamp."));
+        assert!(help.contains("GLOBAL OPTIONS:"));
+        assert!(help.contains("--json"));
+    }
+
+    #[test]
+    fn tool_description_block_preserves_line_structure() {
+        let input = "  First line.  \n\nSecond  paragraph    with   spaces.\nThird line.\n\n\n";
+        let rendered = tool_description_block(input);
+        assert_eq!(
+            rendered,
+            "First line.\n\nSecond paragraph with spaces.\nThird line."
+        );
+        assert!(rendered.contains('\n'));
+    }
+}

--- a/crates/mcp-compressor-core/src/cli/mod.rs
+++ b/crates/mcp-compressor-core/src/cli/mod.rs
@@ -1,2 +1,3 @@
+pub mod help;
 pub mod mapping;
 pub mod parser;

--- a/crates/mcp-compressor-core/src/cli/parser.rs
+++ b/crates/mcp-compressor-core/src/cli/parser.rs
@@ -86,6 +86,7 @@ pub fn parse_argv(argv: &[String], tool: &Tool) -> Result<serde_json::Value, Err
         };
 
         let value = coerce_value(&property_name, schema, raw_value, forced_bool)?;
+        validate_enum(arg, schema, &value)?;
         insert_value(&mut output, &property_name, schema, value);
         index += consumed;
     }
@@ -198,6 +199,51 @@ fn coerce_json_or_string(raw_value: Option<&str>) -> Result<Value, Error> {
     Ok(serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_string())))
 }
 
+/// Enforce JSON Schema `enum` constraints. Mirrors the validation performed by
+/// the generated CLI script so that the native parser (used by Just Bash) and
+/// the generated CLI behave identically. `flag` is the raw argument (e.g.
+/// `--sort`) so the error message matches what the user typed.
+fn validate_enum(flag: &str, schema: &Value, value: &Value) -> Result<(), Error> {
+    let allowed = schema_enum_values(schema);
+    if allowed.is_empty() {
+        return Ok(());
+    }
+    let candidates = match value {
+        Value::Array(values) => values.clone(),
+        other => vec![other.clone()],
+    };
+    for candidate in &candidates {
+        let candidate_label = json_scalar_label(candidate);
+        if !allowed.iter().any(|allowed| allowed == &candidate_label) {
+            // Use `Error::Parse` so this surfaces with the same `parse error:`
+            // prefix as the other CLI argument errors (invalid integer, unknown
+            // flag, etc.) for consistent output across all transform modes.
+            return Err(Error::Parse(format!(
+                "invalid value for {flag}: {candidate_label} (expected one of: {})",
+                allowed.join(", ")
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn schema_enum_values(schema: &Value) -> Vec<String> {
+    schema
+        .get("enum")
+        .and_then(Value::as_array)
+        .map(|values| values.iter().map(json_scalar_label).collect())
+        .unwrap_or_default()
+}
+
+/// Render a scalar JSON value the way it appears in CLI enum comparisons:
+/// strings without quotes, everything else via its JSON representation.
+fn json_scalar_label(value: &Value) -> String {
+    match value {
+        Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
+}
+
 fn coerce_bool(property_name: &str, raw_value: Option<&str>) -> Result<Value, Error> {
     match raw_value {
         None => Ok(Value::Bool(true)),
@@ -275,6 +321,36 @@ mod tests {
     // ------------------------------------------------------------------
     // String arguments
     // ------------------------------------------------------------------
+
+    /// Enum-constrained values are accepted when valid.
+    #[test]
+    fn enum_value_accepted_when_valid() {
+        let tool = tool_with_schema(json!({
+            "type": "object",
+            "properties": {
+                "sort": { "type": "string", "enum": ["score", "timestamp"] }
+            }
+        }));
+        let result = parse_argv(&args(&["--sort", "timestamp"]), &tool).unwrap();
+        assert_eq!(result, json!({ "sort": "timestamp" }));
+    }
+
+    /// Enum-constrained values are rejected with a clear, flag-named error,
+    /// matching the generated CLI script's message.
+    #[test]
+    fn enum_value_rejected_when_invalid() {
+        let tool = tool_with_schema(json!({
+            "type": "object",
+            "properties": {
+                "sort": { "type": "string", "enum": ["score", "timestamp"] }
+            }
+        }));
+        let error = parse_argv(&args(&["--sort", "date"]), &tool).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "parse error: invalid value for --sort: date (expected one of: score, timestamp)"
+        );
+    }
 
     /// A simple `--flag value` pair produces a string in the output dict.
     #[test]

--- a/crates/mcp-compressor-core/src/client_gen/cli.rs
+++ b/crates/mcp-compressor-core/src/client_gen/cli.rs
@@ -8,10 +8,9 @@
 //! - Passes `Authorization: Bearer <session token>` on every `POST /exec` request.
 //! - Is marked executable (Unix `chmod 755`).
 
-use std::collections::HashSet;
-
 use std::net::ToSocketAddrs;
 
+use crate::cli::help::{self, HelpFraming};
 use crate::cli::mapping::tool_name_to_subcommand;
 use crate::client_gen::generator::{
     CliBridgeEntry, ClientGenerator, GeneratedArtifact, GeneratorConfig,
@@ -43,7 +42,12 @@ fn render_cli_artifacts(config: &GeneratorConfig) -> Vec<GeneratedArtifact> {
 }
 
 fn render_unix_script(config: &GeneratorConfig) -> String {
-    let help = render_top_level_help(config);
+    let help = help::render_top_level_help(
+        &config.cli_name,
+        &config.cli_name,
+        &config.tools,
+        &HelpFraming::shell(&config.cli_name),
+    );
     let bridges = bridge_map_literal(config);
     let mut script = format!(
         r#"#!/usr/bin/env sh
@@ -111,7 +115,7 @@ case "$1" in
 
     for tool in &config.tools {
         let subcommand = tool_name_to_subcommand(&tool.name);
-        let tool_help = render_tool_help(&config.cli_name, tool);
+        let tool_help = help::render_subcommand_help(&config.cli_name, tool);
         script.push_str(&format!(
             r#"  {subcommand})
     shift
@@ -404,388 +408,6 @@ fn bridge_is_live(bridge_url: &str) -> bool {
         })
 }
 
-fn render_top_level_help(config: &GeneratorConfig) -> String {
-    let mut help = format!(
-        "{name} - the {name} toolset\n\nWhen relevant, outputs from this CLI will prefer using the TOON format for more efficient representation of data.\n\nUSAGE:\n  {name} <subcommand> [options]\n\nSUBCOMMANDS:\n",
-        name = config.cli_name,
-    );
-    for tool in &config.tools {
-        help.push_str(&format!(
-            "  {:<35} {}\n",
-            tool_name_to_subcommand(&tool.name),
-            short_tool_description(tool.description.as_deref()),
-        ));
-    }
-    help.push_str(&format!(
-        "\nRun '{} <subcommand> --help' for subcommand usage.",
-        config.cli_name
-    ));
-    help
-}
-
-fn render_tool_help(cli_name: &str, tool: &crate::compression::engine::Tool) -> String {
-    let subcommand = tool_name_to_subcommand(&tool.name);
-    let mut help = format!(
-        "{cli_name} {subcommand}\n\n{}\n\nUSAGE:\n  {cli_name} {subcommand} [options]\n",
-        tool_description_block(tool.description.as_deref().unwrap_or("Invoke this tool.")),
-    );
-
-    let options = tool_options(tool);
-    let required = options
-        .iter()
-        .filter(|option| option.required && !option.is_complex)
-        .collect::<Vec<_>>();
-    let optional = options
-        .iter()
-        .filter(|option| !option.required && !option.is_complex)
-        .collect::<Vec<_>>();
-    let complex = options
-        .iter()
-        .filter(|option| option.is_complex)
-        .collect::<Vec<_>>();
-
-    append_option_section(&mut help, "REQUIRED", &required);
-    append_option_section(&mut help, "OPTIONAL", &optional);
-    append_option_section(&mut help, "COMPLEX / JSON OPTIONS", &complex);
-
-    help.push_str("\nGLOBAL OPTIONS:\n");
-    help.push_str("  --json <json object>\n");
-    help.push_str("      Provide the entire tool input as JSON. This bypasses flag parsing.\n");
-    help.push_str("\n  --help\n");
-    help.push_str("      Show this help message.\n");
-
-    help
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ToolOption {
-    name: String,
-    ty: String,
-    required: bool,
-    description: Option<String>,
-    default: Option<String>,
-    enum_values: Vec<String>,
-    minimum: Option<String>,
-    maximum: Option<String>,
-    min_length: Option<String>,
-    max_length: Option<String>,
-    min_items: Option<String>,
-    max_items: Option<String>,
-    is_complex: bool,
-    complex_hint: Option<String>,
-}
-
-fn tool_options(tool: &crate::compression::engine::Tool) -> Vec<ToolOption> {
-    let required = tool
-        .input_schema
-        .get("required")
-        .and_then(|value| value.as_array())
-        .map(|values| {
-            values
-                .iter()
-                .filter_map(|value| value.as_str().map(str::to_string))
-                .collect::<HashSet<_>>()
-        })
-        .unwrap_or_default();
-
-    tool.input_schema
-        .get("properties")
-        .and_then(|value| value.as_object())
-        .map(|properties| {
-            properties
-                .iter()
-                .map(|(name, schema)| {
-                    let (ty, is_complex, complex_hint) = schema_type_details(schema);
-                    ToolOption {
-                        name: name.clone(),
-                        ty,
-                        required: required.contains(name),
-                        description: schema
-                            .get("description")
-                            .and_then(|value| value.as_str())
-                            .map(full_description),
-                        default: schema.get("default").map(default_value_label),
-                        enum_values: schema_enum_values(schema),
-                        minimum: schema_number_constraint(schema, "minimum"),
-                        maximum: schema_number_constraint(schema, "maximum"),
-                        min_length: schema_number_constraint(schema, "minLength"),
-                        max_length: schema_number_constraint(schema, "maxLength"),
-                        min_items: schema_number_constraint(schema, "minItems"),
-                        max_items: schema_number_constraint(schema, "maxItems"),
-                        is_complex,
-                        complex_hint,
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn append_option_section(help: &mut String, title: &str, options: &[&ToolOption]) {
-    if options.is_empty() {
-        return;
-    }
-    help.push('\n');
-    help.push_str(title);
-    help.push_str(":\n");
-    for option in options {
-        help.push_str(&format_tool_option_help(option));
-    }
-}
-
-fn format_tool_option_help(option: &ToolOption) -> String {
-    let flag = format!("--{}", tool_name_to_subcommand(&option.name));
-    let mut output = format!("  {flag} <{}>\n", option.ty);
-    let mut details = Vec::new();
-    if option.required {
-        details.push("Required.".to_string());
-    }
-    if let Some(description) = &option.description {
-        details.push(description.clone());
-    }
-    if !option.enum_values.is_empty() {
-        details.push(format!(
-            "Allowed values: {}.",
-            option.enum_values.join(", ")
-        ));
-    }
-    if let Some(default) = &option.default {
-        details.push(format!("Default: {default}."));
-    }
-    if let Some(minimum) = &option.minimum {
-        details.push(format!("Minimum: {minimum}."));
-    }
-    if let Some(maximum) = &option.maximum {
-        details.push(format!("Maximum: {maximum}."));
-    }
-    if let Some(min_length) = &option.min_length {
-        details.push(format!("Minimum length: {min_length}."));
-    }
-    if let Some(max_length) = &option.max_length {
-        details.push(format!("Maximum length: {max_length}."));
-    }
-    if let Some(min_items) = &option.min_items {
-        details.push(format!("Minimum items: {min_items}."));
-    }
-    if let Some(max_items) = &option.max_items {
-        details.push(format!("Maximum items: {max_items}."));
-    }
-    if option.ty == "boolean" {
-        details.push("Accepted values: true, false.".to_string());
-        details.push(format!(
-            "Also supports: {flag} and --no-{}.",
-            tool_name_to_subcommand(&option.name)
-        ));
-    }
-    if let Some(hint) = &option.complex_hint {
-        details.push(hint.clone());
-    }
-    for detail in details {
-        output.push_str(&wrap_indented(&detail, 6, 100));
-    }
-    output
-}
-
-fn schema_number_constraint(schema: &serde_json::Value, key: &str) -> Option<String> {
-    schema.get(key).map(default_value_label)
-}
-
-fn schema_type_details(schema: &serde_json::Value) -> (String, bool, Option<String>) {
-    let labels = schema_enum_values(schema);
-    if !labels.is_empty() {
-        return (labels.join("|"), false, None);
-    }
-    if schema.get("oneOf").is_some()
-        || schema.get("anyOf").is_some()
-        || schema.get("allOf").is_some()
-    {
-        return (
-            "json".to_string(),
-            true,
-            Some("Schema contains oneOf/anyOf/allOf; use --json for complex input.".to_string()),
-        );
-    }
-    match schema.get("type").and_then(|value| value.as_str()) {
-        Some("integer") => ("integer".to_string(), false, None),
-        Some("number") => ("number".to_string(), false, None),
-        Some("boolean") => ("boolean".to_string(), false, None),
-        Some("array") => match schema.get("items") {
-            Some(items) => {
-                let (item_ty, item_complex, _) = schema_type_details(items);
-                if item_complex
-                    || matches!(
-                        items.get("type").and_then(|value| value.as_str()),
-                        Some("object" | "array")
-                    )
-                {
-                    (
-                        "json array".to_string(),
-                        true,
-                        Some("Pass as a JSON array string.".to_string()),
-                    )
-                } else {
-                    (
-                        format!("{item_ty}[]"),
-                        false,
-                        Some("Repeat this flag or pass a JSON array.".to_string()),
-                    )
-                }
-            }
-            None => (
-                "json array".to_string(),
-                true,
-                Some("Pass as a JSON array string.".to_string()),
-            ),
-        },
-        Some("object") => (
-            "json object".to_string(),
-            true,
-            Some("Pass as a JSON object string.".to_string()),
-        ),
-        Some("string") | None => ("string".to_string(), false, None),
-        Some(other) => (other.to_string(), false, None),
-    }
-}
-
-fn full_description(description: &str) -> String {
-    description.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-/// Render a tool's top-level description while preserving its original line
-/// structure. Each line is trimmed and has internal whitespace runs collapsed,
-/// but newlines (including blank lines between paragraphs) are kept so the
-/// description does not get flattened into a single massive line. Leading and
-/// trailing blank lines are removed, and runs of 3+ blank lines are collapsed
-/// to a single blank line.
-fn tool_description_block(description: &str) -> String {
-    let mut lines: Vec<String> = description
-        .lines()
-        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
-        .collect();
-
-    // Collapse multiple consecutive blank lines into a single blank line.
-    let mut collapsed: Vec<String> = Vec::with_capacity(lines.len());
-    let mut previous_blank = false;
-    for line in lines.drain(..) {
-        let is_blank = line.is_empty();
-        if is_blank && previous_blank {
-            continue;
-        }
-        previous_blank = is_blank;
-        collapsed.push(line);
-    }
-
-    // Trim leading/trailing blank lines.
-    while collapsed.first().is_some_and(|line| line.is_empty()) {
-        collapsed.remove(0);
-    }
-    while collapsed.last().is_some_and(|line| line.is_empty()) {
-        collapsed.pop();
-    }
-
-    if collapsed.is_empty() {
-        return "Invoke this tool.".to_string();
-    }
-
-    collapsed.join("\n")
-}
-
-fn wrap_indented(value: &str, indent: usize, width: usize) -> String {
-    let prefix = " ".repeat(indent);
-    let mut output = String::new();
-    let mut line = String::new();
-    for word in value.split_whitespace() {
-        if !line.is_empty() && line.len() + 1 + word.len() > width.saturating_sub(indent) {
-            output.push_str(&prefix);
-            output.push_str(line.trim_end());
-            output.push('\n');
-            line.clear();
-        }
-        if !line.is_empty() {
-            line.push(' ');
-        }
-        line.push_str(word);
-    }
-    if !line.is_empty() {
-        output.push_str(&prefix);
-        output.push_str(line.trim_end());
-        output.push('\n');
-    }
-    output
-}
-
-fn schema_enum_values(schema: &serde_json::Value) -> Vec<String> {
-    schema
-        .get("enum")
-        .and_then(|value| value.as_array())
-        .map(|values| values.iter().map(default_value_label).collect())
-        .unwrap_or_default()
-}
-
-fn default_value_label(value: &serde_json::Value) -> String {
-    match value {
-        serde_json::Value::String(value) => value.clone(),
-        other => other.to_string(),
-    }
-}
-
-fn short_tool_description(description: Option<&str>) -> String {
-    let trimmed = description.unwrap_or_default().trim();
-    if trimmed.is_empty() {
-        return String::new();
-    }
-
-    let first_sentence = first_sentence(trimmed);
-    let candidate = if first_sentence.chars().count() >= 10 {
-        first_sentence
-    } else {
-        first_non_empty_line(trimmed)
-    };
-    truncate_clean(candidate, 200)
-}
-
-fn first_sentence(value: &str) -> &str {
-    for (index, ch) in value.char_indices() {
-        if matches!(ch, '.' | '!' | '?') {
-            return value[..=index].trim();
-        }
-    }
-    first_non_empty_line(value)
-}
-
-fn first_non_empty_line(value: &str) -> &str {
-    value
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .unwrap_or_default()
-}
-
-fn truncate_clean(value: &str, max_chars: usize) -> String {
-    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
-    if compact.chars().count() <= max_chars {
-        return compact;
-    }
-    let limit = max_chars.saturating_sub(3);
-    let mut end = 0;
-    for (count, (index, ch)) in compact.char_indices().enumerate() {
-        if count >= limit {
-            break;
-        }
-        end = index + ch.len_utf8();
-    }
-    let mut prefix = compact[..end]
-        .trim_end_matches(|ch: char| ch.is_whitespace() || ch == ',' || ch == ';' || ch == ':')
-        .to_string();
-    if let Some(space) = prefix.rfind(' ') {
-        if space >= max_chars / 2 {
-            prefix.truncate(space);
-        }
-    }
-    prefix.push_str("...");
-    prefix
-}
-
 fn shell_quote(value: &str) -> String {
     value.replace('\'', "'\\''")
 }
@@ -989,21 +611,6 @@ mod tests {
         assert!(content.contains("Default: 30."));
         assert!(content.contains("--method"));
         assert!(content.contains("Allowed values: GET, POST."));
-    }
-
-    /// The top-level tool description preserves its multi-line structure rather
-    /// than being flattened into one long line, and drops the noisy OUTPUT
-    /// section.
-    #[test]
-    fn tool_description_block_preserves_line_structure() {
-        let input = "  First line.  \n\nSecond  paragraph    with   spaces.\nThird line.\n\n\n";
-        let rendered = tool_description_block(input);
-        assert_eq!(
-            rendered,
-            "First line.\n\nSecond paragraph with spaces.\nThird line."
-        );
-        // Multi-line descriptions must keep newlines (not collapse to one line).
-        assert!(rendered.contains('\n'));
     }
 
     /// Subcommand help no longer emits the redundant OUTPUT section.

--- a/crates/mcp-compressor-core/src/ffi/host_transform.rs
+++ b/crates/mcp-compressor-core/src/ffi/host_transform.rs
@@ -213,27 +213,19 @@ fn artifact_paths(artifacts: &[GeneratedArtifact], output_dir: &std::path::Path)
 }
 
 fn shell_tool_help_description(command: &str, cli_name: &str, tools: &[FfiTool]) -> String {
-    let mut lines = vec![
-        format!(
-            "Functionality associated with the {cli_name} toolset is provided via the `{command}` CLI. Do not call this tool - use the CLI instead."
-        ),
-        format!("{cli_name} - the {cli_name} toolset"),
-        String::new(),
-        "When relevant, outputs from this CLI will prefer using the TOON format for more efficient representation of data.".to_string(),
-        String::new(),
-        "USAGE:".to_string(),
-        format!("  {command} <subcommand> [options]"),
-        String::new(),
-        "SUBCOMMANDS:".to_string(),
-    ];
-    lines.extend(format_subcommands(tools, cli_subcommand_name));
-    lines.extend([
-        String::new(),
-        format!("Run '{command} --help' in the shell for usage."),
-        format!("Run '{command} <subcommand> --help' for per-command help."),
-        format!("Run '{command} <subcommand> [options]' to invoke a tool."),
-    ]);
-    lines.join("\n")
+    let tools = ffi_tools_to_engine(tools);
+    crate::cli::help::render_top_level_help(
+        command,
+        cli_name,
+        &tools,
+        &crate::cli::help::HelpFraming::help_tool(command, cli_name),
+    )
+}
+
+/// Convert FFI tool DTOs into the engine `Tool` type used by the shared help
+/// renderer.
+fn ffi_tools_to_engine(tools: &[FfiTool]) -> Vec<crate::compression::engine::Tool> {
+    tools.iter().cloned().map(Into::into).collect()
 }
 
 fn code_help_description(
@@ -266,7 +258,7 @@ fn code_help_description(
         .collect::<Vec<_>>();
     let max_signature_len = signatures.iter().map(String::len).max().unwrap_or(0);
     for (tool, signature) in tools.iter().zip(signatures) {
-        let description = short_tool_description(tool.description.as_deref());
+        let description = crate::cli::help::short_tool_description(tool.description.as_deref());
         lines.push(
             format!(
                 "  {signature:<width$}{description}",
@@ -339,83 +331,8 @@ fn code_function_signature(kind: FfiClientArtifactKind, tool: &FfiTool) -> Strin
     format!("{name}({})", args.join(", "))
 }
 
-fn format_subcommands(tools: &[FfiTool], name_for_tool: fn(&str) -> String) -> Vec<String> {
-    let names = tools
-        .iter()
-        .map(|tool| name_for_tool(&tool.name))
-        .collect::<Vec<_>>();
-    let max_name_len = names.iter().map(String::len).max().unwrap_or(0);
-    tools
-        .iter()
-        .zip(names)
-        .map(|(tool, name)| {
-            let description = short_tool_description(tool.description.as_deref());
-            format!("  {name:<width$}{description}", width = max_name_len + 2)
-                .trim_end()
-                .to_string()
-        })
-        .collect()
-}
-
 fn cli_subcommand_name(tool_name: &str) -> String {
     crate::cli::mapping::tool_name_to_subcommand(tool_name)
-}
-
-fn short_tool_description(description: Option<&str>) -> String {
-    let trimmed = description.unwrap_or_default().trim();
-    if trimmed.is_empty() {
-        return String::new();
-    }
-
-    let first_sentence = first_sentence(trimmed);
-    let candidate = if first_sentence.chars().count() >= 10 {
-        first_sentence
-    } else {
-        first_non_empty_line(trimmed)
-    };
-    truncate_clean(candidate, 200)
-}
-
-fn first_sentence(value: &str) -> &str {
-    for (index, ch) in value.char_indices() {
-        if matches!(ch, '.' | '!' | '?') {
-            return value[..=index].trim();
-        }
-    }
-    first_non_empty_line(value)
-}
-
-fn first_non_empty_line(value: &str) -> &str {
-    value
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .unwrap_or_default()
-}
-
-fn truncate_clean(value: &str, max_chars: usize) -> String {
-    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
-    if compact.chars().count() <= max_chars {
-        return compact;
-    }
-    let limit = max_chars.saturating_sub(3);
-    let mut end = 0;
-    for (count, (index, ch)) in compact.char_indices().enumerate() {
-        if count >= limit {
-            break;
-        }
-        end = index + ch.len_utf8();
-    }
-    let mut prefix = compact[..end]
-        .trim_end_matches(|ch: char| ch.is_whitespace() || ch == ',' || ch == ';' || ch == ':')
-        .to_string();
-    if let Some(space) = prefix.rfind(' ') {
-        if space >= max_chars / 2 {
-            prefix.truncate(space);
-        }
-    }
-    prefix.push_str("...");
-    prefix
 }
 
 fn to_snake_case(name: &str) -> String {
@@ -568,11 +485,11 @@ More details follow.",
     #[test]
     fn help_summaries_fall_back_to_first_line_for_tiny_first_sentence() {
         assert_eq!(
-            short_tool_description(Some("OK. Use this tool to inspect status.")),
+            crate::cli::help::short_tool_description(Some("OK. Use this tool to inspect status.")),
             "OK. Use this tool to inspect status."
         );
         assert_eq!(
-            short_tool_description(Some(
+            crate::cli::help::short_tool_description(Some(
                 "A.
 List accessible resources for the user."
             )),
@@ -583,7 +500,7 @@ List accessible resources for the user."
     #[test]
     fn help_summaries_truncate_cleanly() {
         let description = format!("{}.", "word ".repeat(80));
-        let summary = short_tool_description(Some(&description));
+        let summary = crate::cli::help::short_tool_description(Some(&description));
         assert!(summary.len() <= 200);
         assert!(summary.ends_with("..."));
         assert!(!summary.ends_with(" ..."));

--- a/crates/mcp-compressor-core/src/ffi/mod.rs
+++ b/crates/mcp-compressor-core/src/ffi/mod.rs
@@ -17,14 +17,14 @@ pub use client_gen::{
     generate_client_artifact_files, generate_client_artifacts, maybe_toonify_output,
     render_client_artifacts, FfiClientArtifactKind,
 };
-pub use host_transform::{
-    build_host_transform_plan, normalize_host_tool_result, FfiHostJustBashCommandPlan,
-    FfiHostJustBashPlan, FfiHostTransformConfig, FfiHostTransformKind, FfiHostTransformPlan,
-};
 pub use dto::{
     FfiBackendConfig, FfiCompressedSessionConfig, FfiCompressedSessionInfo, FfiGeneratorConfig,
     FfiJustBashCommandSpec, FfiJustBashProviderSpec, FfiMcpServer, FfiSdkServerConfig,
     FfiSdkServersConfig, FfiTool,
+};
+pub use host_transform::{
+    build_host_transform_plan, normalize_host_tool_result, FfiHostJustBashCommandPlan,
+    FfiHostJustBashPlan, FfiHostTransformConfig, FfiHostTransformKind, FfiHostTransformPlan,
 };
 pub use oauth::{
     clear_oauth_credentials, list_oauth_credentials, oauth_store_path, remember_oauth_backend,
@@ -32,6 +32,7 @@ pub use oauth::{
 };
 pub use pure::{
     compress_tool_listing, format_tool_schema_response, parse_mcp_config, parse_tool_argv,
+    render_cli_subcommand_help, render_cli_top_level_help,
 };
 pub use session::{
     normalize_sdk_servers, start_compressed_session, start_compressed_session_from_mcp_config,

--- a/crates/mcp-compressor-core/src/ffi/pure.rs
+++ b/crates/mcp-compressor-core/src/ffi/pure.rs
@@ -21,6 +21,27 @@ pub fn parse_tool_argv(tool: FfiTool, argv: Vec<String>) -> Result<Value, Error>
     parse_argv(&argv, &tool.into())
 }
 
+/// Render the shared top-level CLI help text (`<command> --help`). Used by the
+/// Just Bash command dispatcher so its output matches the generated CLI and the
+/// `*_help` tool description.
+pub fn render_cli_top_level_help(command: String, cli_name: String, tools: Vec<FfiTool>) -> String {
+    let tools = tools.into_iter().map(Into::into).collect::<Vec<Tool>>();
+    crate::cli::help::render_top_level_help(
+        &command,
+        &cli_name,
+        &tools,
+        &crate::cli::help::HelpFraming::shell(&command),
+    )
+}
+
+/// Render the shared rich per-subcommand CLI help text
+/// (`<command> <subcommand> --help`). Used by the Just Bash command dispatcher
+/// so its output matches the generated CLI.
+pub fn render_cli_subcommand_help(cli_name: String, tool: FfiTool) -> String {
+    let tool: Tool = tool.into();
+    crate::cli::help::render_subcommand_help(&cli_name, &tool)
+}
+
 pub fn parse_mcp_config(config_json: &str) -> Result<Vec<FfiMcpServer>, Error> {
     let config = MCPConfig::from_json(config_json)?;
     Ok(config

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -104,7 +104,10 @@ fn generated_cli_help_renders_camel_case_properties_as_kebab_case_flags() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--cloud-id <string>"), "stdout: {stdout}");
     assert!(stdout.contains("--jql <string>"), "stdout: {stdout}");
-    assert!(stdout.contains("--max-results <number>"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("--max-results <number>"),
+        "stdout: {stdout}"
+    );
     assert!(
         stdout.contains("--next-page-token <string>"),
         "stdout: {stdout}"

--- a/crates/mcp-compressor-node/src/lib.rs
+++ b/crates/mcp-compressor-node/src/lib.rs
@@ -9,13 +9,14 @@ use serde_json::Value;
 
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::ffi::{
-    clear_oauth_credentials, compress_tool_listing, format_tool_schema_response,
-    build_host_transform_plan, generate_client_artifact_files, generate_client_artifacts,
+    build_host_transform_plan, clear_oauth_credentials, compress_tool_listing,
+    format_tool_schema_response, generate_client_artifact_files, generate_client_artifacts,
     list_oauth_credentials, maybe_toonify_output, normalize_host_tool_result,
-    normalize_sdk_servers, parse_mcp_config, parse_tool_argv,
-    remember_oauth_backend, start_compressed_session, start_compressed_session_from_mcp_config,
-    FfiBackendConfig, FfiClientArtifactKind, FfiCompressedSession, FfiCompressedSessionConfig,
-    FfiGeneratorConfig, FfiHostTransformConfig, FfiSdkServersConfig, FfiTool,
+    normalize_sdk_servers, parse_mcp_config, parse_tool_argv, remember_oauth_backend,
+    render_cli_subcommand_help, render_cli_top_level_help, start_compressed_session,
+    start_compressed_session_from_mcp_config, FfiBackendConfig, FfiClientArtifactKind,
+    FfiCompressedSession, FfiCompressedSessionConfig, FfiGeneratorConfig, FfiHostTransformConfig,
+    FfiSdkServersConfig, FfiTool,
 };
 
 fn napi_error(error: impl std::fmt::Display) -> NapiError {
@@ -74,6 +75,25 @@ pub fn maybe_toonify_output_json(output: String) -> String {
     maybe_toonify_output(&output)
 }
 
+#[napi]
+pub fn render_cli_top_level_help_json(
+    command: String,
+    cli_name: String,
+    tools_json: String,
+) -> napi::Result<String> {
+    let tools = parse_json::<Vec<FfiTool>>(&tools_json)?;
+    Ok(render_cli_top_level_help(command, cli_name, tools))
+}
+
+#[napi]
+pub fn render_cli_subcommand_help_json(
+    cli_name: String,
+    tool_json: String,
+) -> napi::Result<String> {
+    let tool = parse_json::<FfiTool>(&tool_json)?;
+    Ok(render_cli_subcommand_help(cli_name, tool))
+}
+
 fn parse_client_artifact_kind(kind: &str) -> napi::Result<FfiClientArtifactKind> {
     match kind {
         "cli" => Ok(FfiClientArtifactKind::Cli),
@@ -105,7 +125,6 @@ pub fn generate_client_artifact_files_json(
     let files = generate_client_artifact_files(kind, config).map_err(napi_error)?;
     serde_json::to_string(&files).map_err(napi_error)
 }
-
 
 #[napi]
 pub fn build_host_transform_plan_json(config_json: String) -> napi::Result<String> {

--- a/testdata/golden/agent-facing/atlassian-like/atlassian-help.txt
+++ b/testdata/golden/agent-facing/atlassian-like/atlassian-help.txt
@@ -6,6 +6,6 @@ USAGE:
   atlassian <subcommand> [options]
 
 SUBCOMMANDS:
-  search-jira-issues-using-jql        Search issues with JQL
+  search-jira-issues-using-jql  Search issues with JQL
 
 Run 'atlassian <subcommand> --help' for subcommand usage.

--- a/testdata/golden/agent-facing/cli/alpha-help.txt
+++ b/testdata/golden/agent-facing/cli/alpha-help.txt
@@ -6,8 +6,8 @@ USAGE:
   alpha <subcommand> [options]
 
 SUBCOMMANDS:
-  echo                                Echo a message.
-  add                                 Add two integers.
-  summarize-payload                   Summarize a structured payload.
+  echo               Echo a message.
+  add                Add two integers.
+  summarize-payload  Summarize a structured payload.
 
 Run 'alpha <subcommand> --help' for subcommand usage.

--- a/typescript/src/just_bash_commands.ts
+++ b/typescript/src/just_bash_commands.ts
@@ -1,7 +1,12 @@
 import { defineCommand } from "just-bash";
 import type { Command, ExecResult } from "just-bash";
 
-import { parseToolArgv, type ToolSpec } from "./rust_core.js";
+import {
+  parseToolArgv,
+  renderCliSubcommandHelp,
+  renderCliTopLevelHelp,
+  type ToolSpec,
+} from "./rust_core.js";
 import { normalizeStructuredArgValues } from "./tool_specs.js";
 
 export interface JustBashCommandRegistration {
@@ -46,12 +51,28 @@ export function createJustBashCommandRegistrations(
       command: defineCommand(providerName, async (args) => {
         try {
           const [subcommand, ...toolArgs] = args;
-          if (subcommand === undefined || subcommand === "--help" || subcommand === "-h") {
-            return output(dispatcherHelp(providerName, providerSources));
+          if (
+            subcommand === undefined ||
+            subcommand === "--help" ||
+            subcommand === "-h" ||
+            subcommand === "help"
+          ) {
+            return output(
+              renderCliTopLevelHelp(
+                providerName,
+                providerName,
+                providerSources.map((source) => source.tool),
+              ),
+            );
           }
           const source = bySubcommand.get(subcommand);
           if (source === undefined) {
             throw new Error(`Unknown ${providerName} subcommand: ${subcommand}`);
+          }
+          // Per-subcommand help must match the generated CLI's rich `--help`
+          // output, so render it from the shared Rust renderer.
+          if (toolArgs.includes("--help") || toolArgs.includes("-h")) {
+            return output(renderCliSubcommandHelp(providerName, source.tool));
           }
           const parsedInput = parseToolArgv(source.tool, toolArgs);
           const toolInput = normalizeStructuredArgValues(source.tool.inputSchema, parsedInput);
@@ -80,26 +101,6 @@ export function installJustBashRegistrations(
       ...registrations.map((registration) => registration.command),
     ];
   }
-}
-
-function dispatcherHelp(providerName: string, sources: JustBashCommandSource[]): string {
-  const maxNameLength = Math.max(
-    ...sources.map((source) => source.backendToolName.replaceAll("_", "-").length),
-    0,
-  );
-  return [
-    `${providerName} - the ${providerName} toolset`,
-    "",
-    "USAGE:",
-    `  ${providerName} <subcommand> [options]`,
-    "",
-    "SUBCOMMANDS:",
-    ...sources.map((source) => {
-      const description = (source.tool.description ?? "").replace(/\s+/g, " ").trim();
-      const subcommand = source.backendToolName.replaceAll("_", "-");
-      return `  ${subcommand.padEnd(maxNameLength + 2)}${description}`.trimEnd();
-    }),
-  ].join("\n");
 }
 
 function output(stdout: string): ExecResult {

--- a/typescript/src/native.ts
+++ b/typescript/src/native.ts
@@ -11,6 +11,8 @@ export interface NativeCore {
   formatToolSchemaResponseJson(toolJson: string): string;
   maybeToonifyOutputJson(output: string): string;
   parseToolArgvJson(toolJson: string, argvJson: string): string;
+  renderCliTopLevelHelpJson(command: string, cliName: string, toolsJson: string): string;
+  renderCliSubcommandHelpJson(cliName: string, toolJson: string): string;
   generateClientArtifactsJson(kind: string, configJson: string): string;
   generateClientArtifactFilesJson(kind: string, configJson: string): string;
   buildHostTransformPlanJson(configJson: string): string;

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -36,6 +36,27 @@ export function parseToolArgv(tool: ToolSpec, argv: string[]): Record<string, un
   ) as Record<string, unknown>;
 }
 
+/**
+ * Render the shared top-level CLI help text (`<command> --help`). Backed by the
+ * same Rust renderer used for the generated CLI script and the `*_help` tool
+ * description, so all transform modes stay in sync.
+ */
+export function renderCliTopLevelHelp(command: string, cliName: string, tools: ToolSpec[]): string {
+  return loadNativeCore().renderCliTopLevelHelpJson(
+    command,
+    cliName,
+    stringify(tools.map(toNativeTool)),
+  );
+}
+
+/**
+ * Render the shared rich per-subcommand CLI help text
+ * (`<command> <subcommand> --help`).
+ */
+export function renderCliSubcommandHelp(cliName: string, tool: ToolSpec): string {
+  return loadNativeCore().renderCliSubcommandHelpJson(cliName, stringify(toNativeTool(tool)));
+}
+
 export type ClientArtifactKind = "cli" | "python" | "typescript";
 
 export interface ClientGeneratorConfig {

--- a/typescript/tests/agent_facing_snapshots.test.ts
+++ b/typescript/tests/agent_facing_snapshots.test.ts
@@ -143,6 +143,63 @@ describe("agent-facing alpha snapshots", () => {
     }
   });
 
+  it("Just Bash help has parity with generated CLI help (top-level + subcommand)", async () => {
+    // Generate the CLI script so we can compare against the actual `--help`
+    // outputs the shell user would see.
+    const outputDir = mkdtempSync(join(tmpdir(), "mcp-alpha-parity-snapshot-"));
+    const cli = await transformToolsForCliMode(alphaTools, { serverName: "alpha", outputDir });
+    const bash = new Bash({ customCommands: [] });
+    transformToolsForJustBash(alphaTools, { serverName: "alpha", bash });
+    try {
+      materializeFiles(outputDir, cli.files, ["alpha"]);
+      const scriptPath = join(outputDir, "alpha");
+
+      // Top-level dispatcher help must match the generated CLI `--help` body.
+      const cliTopLevel = runScript(scriptPath, ["--help"]);
+      const bashTopLevel = (await bash.exec("alpha --help")).stdout.trimEnd();
+      expect(bashTopLevel).toBe(cliTopLevel);
+
+      // Per-subcommand help must be the rich help, identical to the CLI's.
+      const cliSubHelp = runScript(scriptPath, ["echo", "--help"]);
+      const bashSubHelp = (await bash.exec("alpha echo --help")).stdout.trimEnd();
+      expect(bashSubHelp).toBe(cliSubHelp);
+      // Sanity: rich subcommand help includes the USAGE + typed option, not just a one-liner.
+      expect(bashSubHelp).toContain("USAGE:");
+      expect(bashSubHelp).toContain("--message <string>");
+    } finally {
+      cli.close();
+    }
+  });
+
+  it("Just Bash validates enum arguments like the generated CLI", async () => {
+    const enumTools = {
+      search: {
+        name: "search",
+        description: "Search things.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            sort: {
+              type: "string",
+              description: "Sort order.",
+              enum: ["score", "timestamp"],
+            },
+          },
+        },
+        execute: async (): Promise<unknown> => "ok",
+      },
+    };
+    const bash = new Bash({ customCommands: [] });
+    transformToolsForJustBash(enumTools, { serverName: "things", bash });
+    const ok = await bash.exec("things search --sort timestamp");
+    expect(ok.exitCode).toBe(0);
+    const bad = await bash.exec("things search --sort nonsense");
+    expect(bad.exitCode).not.toBe(0);
+    expect(`${bad.stderr}${bad.stdout}`).toContain(
+      "invalid value for --sort: nonsense (expected one of: score, timestamp)",
+    );
+  });
+
   it("snapshots camelCase tool and property names as kebab-case CLI affordances", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "mcp-atlassian-cli-snapshot-"));
     const transform = await transformToolsForCliMode(


### PR DESCRIPTION
## Why

The generated CLI script (`client_gen/cli.rs`), the `*_help` tool description (`ffi/host_transform.rs`), and the Just Bash command shim (`typescript/src/just_bash_commands.ts`) each had **their own** help-rendering and/or argument-handling logic. They had drifted:

- The generated CLI `--help` and the `*_help` tool description used **different column widths and footers** (already divergent on `main`).
- Just Bash had **no per-subcommand `--help`** at all (`parse error: unknown flag: --help`) and listed **full raw descriptions** in its dispatcher help instead of concise first-sentence summaries.
- The native arg parser (used by Just Bash) **did not validate `enum` constraints**, while the generated CLI Python script did.

This unifies all of it into one source of truth and brings Just Bash to **full parity** with CLI mode, with no agent-YAML changes.

## What

- **New `cli::help` module** — single renderer for top-level help and rich per-subcommand help. The only allowed differences between surfaces are a `HelpFraming` prefix/footer; the **body is byte-identical**.
- `client_gen/cli.rs` and `ffi/host_transform.rs` now **delegate** to `cli::help` (removed duplicated `short_tool_description` / `first_sentence` / `first_non_empty_line` / `truncate_clean` and the divergent top-level renderers).
- **Native parser enum validation** added to `cli/parser.rs` so Just Bash validates enums exactly like the generated CLI (`invalid value for --x: y (expected one of: ...)`).
- **FFI**: `render_cli_top_level_help` / `render_cli_subcommand_help` exposed via `ffi/pure.rs` + napi addon; `just_bash_commands.ts` uses them and **intercepts per-subcommand `--help`** to emit the same rich help as CLI mode.
- Captures all recent fixes in the shared path: concise first-sentence summaries (200-char clean truncation), newline-preserving multi-line descriptions, dropped `OUTPUT` section, base64 schema embedding (unchanged), raw-result unwrapping (unchanged), `fetch` shadow fix (unchanged).

## Parity guaranteed by tests

- CLI top-level `--help` body == `*_help` tool description body (modulo framing).
- Just Bash top-level help == generated CLI `--help`.
- Just Bash per-subcommand `--help` == generated CLI subcommand `--help` (rich).
- Just Bash enum validation matches the generated CLI error.
- Goldens updated to dynamic-width subcommand columns (content unchanged).

## Validation

- `cargo test -p mcp-compressor-core` — all green (incl. new help/parser tests).
- `bun run check` (typescript) — 90 tests green (lint/format/typecheck/tests).
- All touched Rust files individually `rustfmt`-clean; unrelated fmt churn reverted.

## End-to-end ACP verification (local build)

Built this branch locally, overlaid into Alta's store, and ran ACP probes against the real `rovo-core` agent in **`--workspace-type in-memory` (Just Bash)**:

- `slack --help` → concise first-sentence summaries, dynamic-width columns ✅
- `slack <subcommand> --help` → full rich help (REQUIRED/OPTIONAL/GLOBAL, typed flags, `Accepted values`, `--no-*`) ✅
- invalid `--limit notaninteger` → `parse error: invalid integer value for limit: notaninteger` ✅

CLI-mode behavior is preserved; Just Bash catches up to full parity.