### PR TITLE
ci: speed up release builds with Rust caching and addon reuse

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -57,6 +57,14 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # Cache the cargo registry + target dir so each matrix wheel build does not
+      # recompile the Rust core from scratch. Keyed per-target to avoid cross-OS
+      # cache clobbering.
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-python-wheel-${{ matrix.target }}
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -230,7 +238,7 @@ jobs:
           TAG="${{ steps.prepare.outputs.tag }}"
           RELEASE_SHA="${{ steps.prepare.outputs.release_sha }}"
           echo "Waiting for publish-typescript-package workflow on release branch for $TAG at $RELEASE_SHA"
-          for attempt in $(seq 1 120); do
+          for attempt in $(seq 1 240); do
             RUN_JSON="$(gh run list \
               --workflow publish-typescript-package.yml \
               --branch release \
@@ -238,8 +246,8 @@ jobs:
               --json databaseId,status,conclusion,headSha \
               --jq '.[0] // empty')"
             if [ -z "$RUN_JSON" ]; then
-              echo "No TypeScript publish run found yet (attempt $attempt/120)"
-              sleep 20
+              echo "No TypeScript publish run found yet (attempt $attempt/240)"
+              sleep 10
               continue
             fi
             RUN_ID="$(jq -r '.databaseId' <<<"$RUN_JSON")"
@@ -248,7 +256,7 @@ jobs:
             CONCLUSION="$(jq -r '.conclusion // ""' <<<"$RUN_JSON")"
             if [ "$HEAD_SHA" != "$RELEASE_SHA" ]; then
               echo "Latest TypeScript publish run $RUN_ID is for $HEAD_SHA, waiting for $RELEASE_SHA"
-              sleep 20
+              sleep 10
               continue
             fi
             echo "Run $RUN_ID status=$STATUS conclusion=$CONCLUSION"
@@ -260,7 +268,7 @@ jobs:
               echo "TypeScript publish workflow failed with conclusion=$CONCLUSION" >&2
               exit 1
             fi
-            sleep 20
+            sleep 10
           done
           echo "Timed out waiting for TypeScript publish workflow after 40 minutes" >&2
           exit 1
@@ -276,6 +284,11 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-rust-crate
 
       - name: Derive crate version from tag
         id: version
@@ -315,15 +328,15 @@ jobs:
         shell: bash
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          for attempt in {1..20}; do
+          for attempt in {1..60}; do
             if cargo info "mcp-compressor-core@$VERSION" >/tmp/mcp-compressor-core-info 2>&1; then
               cat /tmp/mcp-compressor-core-info
               echo "mcp-compressor-core $VERSION is visible in crates.io index"
               exit 0
             fi
             cat /tmp/mcp-compressor-core-info || true
-            echo "Waiting for mcp-compressor-core $VERSION in crates.io index (attempt $attempt/20)..."
-            sleep 30
+            echo "Waiting for mcp-compressor-core $VERSION in crates.io index (attempt $attempt/60)..."
+            sleep 10
           done
           echo "Timed out waiting for mcp-compressor-core $VERSION in crates.io index" >&2
           exit 1

--- a/.github/workflows/publish-typescript-package.yml
+++ b/.github/workflows/publish-typescript-package.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-ts-native-${{ matrix.artifact-suffix }}
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -112,6 +117,11 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-ts-publish
+
       - name: Set up Python environment for fixture servers
         uses: ./.github/actions/setup-python-env
 
@@ -130,20 +140,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build native addon and CLI binary for checks
-        run: |
-          bun run build:native
-          cargo build -p mcp-compressor --bin mcp-compressor
-
-      - name: Run package checks
-        env:
-          MCP_COMPRESSOR_CORE_BINARY: ${{ github.workspace }}/target/debug/mcp-compressor
-          PYTHON: ${{ github.workspace }}/.venv/bin/python
-        run: bun run check:ci
-
-      - name: Build TypeScript package
-        run: bun run build
-
+      # Reuse the native addon already produced by build-typescript-native-addons
+      # instead of recompiling it here. This is the same set of addons bundled
+      # into the published package, and the runner-matching addon (linux-x64) is
+      # what `check:ci` loads. Only the CLI core binary still needs building.
       - name: Download cross-platform native addons
         uses: actions/download-artifact@v4
         with:
@@ -154,6 +154,18 @@ jobs:
       - name: List bundled native addons
         working-directory: .
         run: ls -lh typescript/native
+
+      - name: Build CLI binary for checks
+        run: cargo build -p mcp-compressor --bin mcp-compressor
+
+      - name: Run package checks
+        env:
+          MCP_COMPRESSOR_CORE_BINARY: ${{ github.workspace }}/target/debug/mcp-compressor
+          PYTHON: ${{ github.workspace }}/.venv/bin/python
+        run: bun run check:ci
+
+      - name: Build TypeScript package
+        run: bun run build
 
       - name: Pack package
         shell: bash

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: artifacts-${{ matrix.artifact-suffix }}
+
       - name: Build Rust CLI binary
         run: cargo build -p mcp-compressor-core --release
 
@@ -82,6 +87,11 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: artifacts-${{ matrix.artifact-suffix }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -155,6 +165,11 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: artifacts-${{ matrix.artifact-suffix }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Why

The `release-main` workflow fans out into Python / TypeScript / Rust / docs tracks, but **none of the Rust-compiling jobs cache anything** — so a single release does ~12 cold `--release` compiles of the same Rust core (5 Python wheels, 5 TS native addons, a redundant rebuild in the TS publish job, and the Rust crate job). Release Rust builds dominate the wall-clock time.

This PR reduces that **without changing the release structure** — the main workflow still dispatches the TS-specific publish workflow and polls it (per the required pattern).

## Changes (safe, high-impact set)

### 1. Rust build caching everywhere ⭐
Added `Swatinem/rust-cache@v2` after every `dtolnay/rust-toolchain@stable` in:
- `on-release-main.yml`: python wheel matrix (keyed per-target), rust crate publish
- `publish-typescript-package.yml`: native addon matrix (keyed per-suffix), publish job
- `release-artifacts.yml`: all three matrix jobs

Caches the cargo registry + `target/`, keyed per OS/target to avoid cross-platform clobbering. On warm runs this is the dominant saving.

### 2. Stop the redundant rebuild in the TS publish job
The publish job used to `bun run build:native` (cold Rust→addon compile) just to run `check:ci`, and then **download** all cross-platform addons anyway. It now **downloads** the addons produced by `build-typescript-native-addons` (which already ran, and whose output is what ships) *before* running checks, and only builds the CLI core binary locally. Removes a whole cold native build from the critical path.

### 3. Tighter poll granularity (less tail latency)
- TS publish wait: `sleep 20`→`sleep 10` (attempts 120→240; same 40-min ceiling).
- crates.io index wait: `sleep 30`→`sleep 10` (attempts 20→60; same 10-min ceiling).

## Notes / limitations
- Linux wheels build inside the manylinux Docker image via `maturin-action`, so host-level `rust-cache` does **not** accelerate those two jobs. The mac/windows `uvx maturin` builds and every other Rust job do benefit. (A future follow-up could cache inside the manylinux container, but that's more invasive and left out of this safe set.)
- No change to what is published or to the dispatch+poll structure.

## Validation
- All three workflow files parse as valid YAML.
- `needs: build-typescript-native-addons` is preserved so the downloaded artifacts always exist before the publish job's checks.