### PR TITLE
feat: add in-process session API (bridge-less invoke/list/schema)

### DIFF
--- a/crates/mcp-compressor-core/src/ffi/dto.rs
+++ b/crates/mcp-compressor-core/src/ffi/dto.rs
@@ -84,6 +84,10 @@ pub enum FfiSdkServerConfig {
 
 pub type FfiSdkServersConfig = BTreeMap<String, FfiSdkServerConfig>;
 
+fn default_bridge() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FfiCompressedSessionConfig {
     pub compression_level: String,
@@ -95,6 +99,14 @@ pub struct FfiCompressedSessionConfig {
     #[serde(default)]
     pub toonify: bool,
     pub transform_mode: Option<String>,
+    /// Whether to start the local authenticated HTTP bridge.
+    ///
+    /// Defaults to `true` for backward compatibility with out-of-process
+    /// clients (generated CLI/Python/TS clients, Just Bash). In-process SDK
+    /// consumers can set this to `false` to dispatch tools directly without a
+    /// local HTTP listener, token, or background task.
+    #[serde(default = "default_bridge")]
+    pub bridge: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/mcp-compressor-core/src/ffi/session.rs
+++ b/crates/mcp-compressor-core/src/ffi/session.rs
@@ -1,4 +1,8 @@
-use crate::proxy::{RunningToolProxy, ToolProxyServer};
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::proxy::{dispatch_exec, RunningToolProxy, ToolProxyServer};
 use crate::server::{CompressedServer, CompressedServerConfig, ProxyTransformMode};
 use crate::Error;
 
@@ -60,7 +64,10 @@ fn normalize_sdk_server(
 
 pub struct FfiCompressedSession {
     info: FfiCompressedSessionInfo,
-    _proxy: RunningToolProxy,
+    server: Arc<CompressedServer>,
+    // Kept alive to keep the HTTP bridge running for out-of-process clients.
+    // `None` for in-process (bridge-less) sessions.
+    _proxy: Option<RunningToolProxy>,
 }
 
 impl FfiCompressedSession {
@@ -74,6 +81,34 @@ impl FfiCompressedSession {
 
     pub fn info(&self) -> FfiCompressedSessionInfo {
         self.info.clone()
+    }
+
+    /// Frontend (compressed) tools exposed to callers, as DTOs.
+    ///
+    /// In-process equivalent of reading `info().frontend_tools`.
+    pub fn list_frontend_tools(&self) -> Vec<FfiTool> {
+        self.info.frontend_tools.clone()
+    }
+
+    /// Get the full backend schema for a tool via the compressed wrapper API,
+    /// dispatched in-process (no HTTP bridge required).
+    pub async fn get_tool_schema(
+        &self,
+        wrapper_tool_name: &str,
+        backend_tool_name: &str,
+    ) -> Result<String, Error> {
+        self.server
+            .get_tool_schema(wrapper_tool_name, backend_tool_name)
+            .await
+    }
+
+    /// Invoke a frontend wrapper tool (or single-backend pass-through tool)
+    /// in-process, reusing the session's live connection and OAuth.
+    ///
+    /// This shares [`dispatch_exec`] with the HTTP `/exec` bridge endpoint, so
+    /// in-process and bridge invocations return identical payloads.
+    pub async fn invoke(&self, tool: &str, input: Value) -> Result<String, Error> {
+        dispatch_exec(&self.server, tool.to_string(), input).await
     }
 
     pub fn close(self) {}
@@ -90,6 +125,7 @@ fn parse_ffi_transform_mode(value: Option<&str>) -> Result<ProxyTransformMode, E
 
 async fn compressed_session_from_server(
     server: CompressedServer,
+    bridge: bool,
 ) -> Result<FfiCompressedSession, Error> {
     let frontend_tools = server
         .list_frontend_tools()
@@ -111,16 +147,27 @@ async fn compressed_session_from_server(
         .into_iter()
         .map(Into::into)
         .collect();
-    let proxy = ToolProxyServer::start(server).await?;
+    let (proxy, shared_server, bridge_url, token) = if bridge {
+        let proxy = ToolProxyServer::start(server).await?;
+        let bridge_url = proxy.bridge_url().to_string();
+        let token = proxy.token_value().to_string();
+        let shared_server = Arc::clone(proxy.server());
+        (Some(proxy), shared_server, bridge_url, token)
+    } else {
+        let shared_server = ToolProxyServer::in_process(server);
+        (None, shared_server, String::new(), String::new())
+    };
+
     Ok(FfiCompressedSession {
         info: FfiCompressedSessionInfo {
-            bridge_url: proxy.bridge_url().to_string(),
-            token: proxy.token_value().to_string(),
+            bridge_url,
+            token,
             frontend_tools,
             backend_tools,
             backend_tools_by_server,
             just_bash_providers,
         },
+        server: shared_server,
         _proxy: proxy,
     })
 }
@@ -140,6 +187,7 @@ pub async fn start_compressed_session_with_backend_configs(
     config: FfiCompressedSessionConfig,
     backends: Vec<crate::server::BackendServerConfig>,
 ) -> Result<FfiCompressedSession, Error> {
+    let bridge = config.bridge;
     let server = CompressedServer::connect_multi_stdio(
         CompressedServerConfig {
             level: config.compression_level.parse()?,
@@ -153,13 +201,14 @@ pub async fn start_compressed_session_with_backend_configs(
         backends,
     )
     .await?;
-    compressed_session_from_server(server).await
+    compressed_session_from_server(server, bridge).await
 }
 
 pub async fn start_compressed_session_from_mcp_config(
     config: FfiCompressedSessionConfig,
     mcp_config_json: &str,
 ) -> Result<FfiCompressedSession, Error> {
+    let bridge = config.bridge;
     let server = CompressedServer::connect_mcp_config_json(
         CompressedServerConfig {
             level: config.compression_level.parse()?,
@@ -173,5 +222,5 @@ pub async fn start_compressed_session_from_mcp_config(
         mcp_config_json,
     )
     .await?;
-    compressed_session_from_server(server).await
+    compressed_session_from_server(server, bridge).await
 }

--- a/crates/mcp-compressor-core/src/ffi/types.rs
+++ b/crates/mcp-compressor-core/src/ffi/types.rs
@@ -164,6 +164,7 @@ mod tests {
                 exclude_tools: Vec::new(),
                 toonify: false,
                 transform_mode: None,
+                bridge: true,
             },
             vec![FfiBackendConfig {
                 name: "alpha".to_string(),
@@ -197,6 +198,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ffi_session_dispatches_in_process_without_bridge() {
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("alpha_server.py");
+        let session = start_compressed_session(
+            FfiCompressedSessionConfig {
+                compression_level: "max".to_string(),
+                server_name: Some("alpha".to_string()),
+                include_tools: Vec::new(),
+                exclude_tools: Vec::new(),
+                toonify: false,
+                transform_mode: None,
+                bridge: false,
+            },
+            vec![FfiBackendConfig {
+                name: "alpha".to_string(),
+                command_or_url: std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
+                args: vec![fixture.to_string_lossy().into_owned()],
+                oauth_app_name: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        // No HTTP bridge is started in in-process mode.
+        let info = session.info();
+        assert!(info.bridge_url.is_empty());
+        assert!(info.token.is_empty());
+
+        // Frontend tools are still listable in-process.
+        let frontend_tools = session.list_frontend_tools();
+        let invoke_tool_name = frontend_tools
+            .iter()
+            .find(|tool| tool.name.ends_with("invoke_tool"))
+            .map(|tool| tool.name.clone())
+            .expect("invoke wrapper tool");
+        let schema_tool_name = frontend_tools
+            .iter()
+            .find(|tool| tool.name.ends_with("get_tool_schema"))
+            .map(|tool| tool.name.clone())
+            .expect("schema wrapper tool");
+
+        // In-process schema lookup works.
+        let schema = session
+            .get_tool_schema(&schema_tool_name, "echo")
+            .await
+            .unwrap();
+        assert!(schema.contains("echo"));
+
+        // In-process invoke returns the same payload the bridge would.
+        let result = session
+            .invoke(
+                &invoke_tool_name,
+                serde_json::json!({"tool_name": "echo", "tool_input": {"message": "ffi"}}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result, "alpha:ffi");
+    }
+
+    #[tokio::test]
     async fn ffi_starts_compressed_session_from_mcp_config_and_routes_multiple_servers() {
         let fixture_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests")
@@ -223,6 +286,7 @@ mod tests {
                 exclude_tools: Vec::new(),
                 toonify: false,
                 transform_mode: None,
+                bridge: true,
             },
             &config_json,
         )
@@ -273,6 +337,7 @@ mod tests {
                 exclude_tools: Vec::new(),
                 toonify: false,
                 transform_mode: Some("cli".to_string()),
+                bridge: true,
             },
             vec![FfiBackendConfig {
                 name: "alpha".to_string(),
@@ -302,6 +367,7 @@ mod tests {
                 exclude_tools: Vec::new(),
                 toonify: false,
                 transform_mode: Some("just-bash".to_string()),
+                bridge: true,
             },
             vec![
                 FfiBackendConfig {

--- a/crates/mcp-compressor-core/src/proxy/mod.rs
+++ b/crates/mcp-compressor-core/src/proxy/mod.rs
@@ -3,4 +3,4 @@ pub mod registry;
 pub mod router;
 pub mod server;
 
-pub use server::{RunningToolProxy, ToolProxyServer};
+pub use server::{dispatch_exec, RunningToolProxy, ToolProxyServer};

--- a/crates/mcp-compressor-core/src/proxy/server.rs
+++ b/crates/mcp-compressor-core/src/proxy/server.rs
@@ -27,6 +27,7 @@ pub struct RunningToolProxy {
     bridge_url: String,
     token: SessionToken,
     task: tokio::task::JoinHandle<()>,
+    server: Arc<CompressedServer>,
 }
 
 #[derive(Clone)]
@@ -52,8 +53,9 @@ struct WrapperInvokeInput {
 impl ToolProxyServer {
     pub async fn start(server: CompressedServer) -> Result<RunningToolProxy, Error> {
         let token = SessionToken::generate();
+        let server = Arc::new(server);
         let state = ProxyState {
-            server: Arc::new(server),
+            server: Arc::clone(&server),
             token: token.clone(),
         };
 
@@ -74,7 +76,18 @@ impl ToolProxyServer {
             bridge_url: format!("http://{addr}"),
             token,
             task,
+            server,
         })
+    }
+
+    /// Wrap a connected compressed server for in-process (bridge-less) use.
+    ///
+    /// No HTTP listener, token, or background task is created. Callers dispatch
+    /// tools directly via [`dispatch_exec`] using the returned shared handle.
+    /// This is the preferred path for in-process SDK consumers that do not need
+    /// to expose the session to out-of-process clients.
+    pub fn in_process(server: CompressedServer) -> Arc<CompressedServer> {
+        Arc::new(server)
     }
 }
 
@@ -91,7 +104,7 @@ async fn exec(
         return close_response(StatusCode::UNAUTHORIZED, "unauthorized");
     }
 
-    match dispatch_exec(&state.server, request).await {
+    match dispatch_exec(&state.server, request.tool, request.input).await {
         Ok(result) => close_response(StatusCode::OK, result),
         Err(error) => close_response(StatusCode::BAD_REQUEST, error.to_string()),
     }
@@ -105,16 +118,23 @@ fn close_response(status: StatusCode, body: impl Into<String>) -> Response {
     response
 }
 
-async fn dispatch_exec(server: &CompressedServer, request: ExecRequest) -> Result<String, Error> {
-    if request.tool.ends_with("_invoke_tool") || request.tool == "invoke_tool" {
-        let wrapper_input: WrapperInvokeInput = serde_json::from_value(request.input)?;
+/// Execute a frontend wrapper tool (or single-backend pass-through tool) against
+/// a compressed server.
+///
+/// This is the shared dispatch used by both the HTTP `/exec` bridge endpoint and
+/// the in-process SDK session path, so both transports produce identical results.
+pub async fn dispatch_exec(
+    server: &CompressedServer,
+    tool: String,
+    input: Value,
+) -> Result<String, Error> {
+    if tool.ends_with("_invoke_tool") || tool == "invoke_tool" {
+        let wrapper_input: WrapperInvokeInput = serde_json::from_value(input)?;
         server
-            .invoke_tool(&request.tool, &wrapper_input.tool_name, wrapper_input.tool_input)
+            .invoke_tool(&tool, &wrapper_input.tool_name, wrapper_input.tool_input)
             .await
     } else {
-        server
-            .invoke_single_backend_tool(&request.tool, request.input)
-            .await
+        server.invoke_single_backend_tool(&tool, input).await
     }
 }
 
@@ -132,6 +152,12 @@ impl Drop for RunningToolProxy {
 }
 
 impl RunningToolProxy {
+    /// Shared handle to the underlying compressed server, used for in-process
+    /// (bridge-less) dispatch by SDK sessions.
+    pub fn server(&self) -> &Arc<CompressedServer> {
+        &self.server
+    }
+
     pub fn bridge_url(&self) -> &str {
         &self.bridge_url
     }

--- a/crates/mcp-compressor-python/src/lib.rs
+++ b/crates/mcp-compressor-python/src/lib.rs
@@ -135,6 +135,35 @@ impl PyCompressedSession {
         serde_json::to_string(&self.inner.info()).map_err(py_value_error)
     }
 
+    /// In-process compressed frontend tool list (no HTTP bridge required).
+    fn list_frontend_tools_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner.list_frontend_tools()).map_err(py_value_error)
+    }
+
+    /// In-process schema lookup for a backend tool via a compressed wrapper.
+    fn get_tool_schema_json(
+        &self,
+        py: Python<'_>,
+        wrapper_tool_name: &str,
+        backend_tool_name: &str,
+    ) -> PyResult<String> {
+        py.detach(|| {
+            self.runtime
+                .block_on(self.inner.get_tool_schema(wrapper_tool_name, backend_tool_name))
+        })
+        .map_err(py_value_error)
+    }
+
+    /// In-process tool invocation, reusing the session's connection and OAuth.
+    ///
+    /// `input_json` is the JSON-encoded tool input (for wrapper invoke tools,
+    /// an object with `tool_name` and `tool_input`).
+    fn invoke_tool_json(&self, py: Python<'_>, tool: &str, input_json: &str) -> PyResult<String> {
+        let input: Value = parse_json(input_json)?;
+        py.detach(|| self.runtime.block_on(self.inner.invoke(tool, input)))
+            .map_err(py_value_error)
+    }
+
     fn close(&mut self) {
         // The Rust session/proxy shuts down when the Python object is dropped.
     }

--- a/python/mcp-compressor/mcp_compressor/core.py
+++ b/python/mcp-compressor/mcp_compressor/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import json
 from dataclasses import dataclass
@@ -41,6 +42,14 @@ class CompressedSessionConfig:
     exclude_tools: list[str] | None = None
     toonify: bool = False
     transform_mode: str | None = None
+    bridge: bool = True
+    """Start the local authenticated HTTP bridge.
+
+    Defaults to ``True`` for out-of-process clients (generated CLI/Python/TS
+    clients, Just Bash). Set to ``False`` for in-process use, where tools are
+    dispatched directly via :meth:`CompressedSession.invoke` without a local
+    HTTP listener, token, or background task.
+    """
 
     def to_json_dict(self) -> dict[str, Any]:
         return {
@@ -50,11 +59,19 @@ class CompressedSessionConfig:
             "exclude_tools": self.exclude_tools or [],
             "toonify": self.toonify,
             "transform_mode": self.transform_mode,
+            "bridge": self.bridge,
         }
 
 
 class CompressedSession:
-    """Python wrapper around a Rust-backed compressed session handle."""
+    """Python wrapper around a Rust-backed compressed session handle.
+
+    In addition to bridge-based access via :class:`CompressorProxy`, a session
+    can be driven entirely in-process: :meth:`list_tools`, :meth:`get_schema`,
+    and :meth:`invoke` reuse the session's live upstream connection and OAuth
+    without an HTTP bridge. Async variants are provided for use from event
+    loops (they run the blocking native call in a worker thread).
+    """
 
     def __init__(self, native_session: Any) -> None:
         self._native_session = native_session
@@ -65,6 +82,46 @@ class CompressedSession:
             msg = "Rust core session info_json returned non-object JSON"
             raise TypeError(msg)
         return value
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        """Return the compressed frontend tools (in-process; no bridge needed)."""
+        value = json.loads(self._native_session.list_frontend_tools_json())
+        if not isinstance(value, list):
+            msg = "Rust core session list_frontend_tools_json returned non-list JSON"
+            raise TypeError(msg)
+        return value
+
+    def get_schema(self, wrapper_tool: str, backend_tool: str) -> str:
+        """Return the full backend schema response for a tool, in-process.
+
+        ``wrapper_tool`` is the compressed ``*get_tool_schema``/``*invoke_tool``
+        wrapper name (used to resolve the backend); ``backend_tool`` is the
+        underlying backend tool name.
+        """
+        return str(self._native_session.get_tool_schema_json(wrapper_tool, backend_tool))
+
+    def invoke(self, tool: str, tool_input: dict[str, Any] | None = None) -> str:
+        """Invoke a tool in-process, reusing the session's connection and OAuth.
+
+        ``tool`` is a frontend wrapper tool name (e.g. ``*invoke_tool``) or, in
+        single-backend setups, a pass-through backend tool name. For wrapper
+        invoke tools, ``tool_input`` should contain ``tool_name`` and
+        ``tool_input``. Returns the same payload the HTTP bridge ``/exec``
+        endpoint would return.
+        """
+        return str(self._native_session.invoke_tool_json(tool, _json_dumps(tool_input or {})))
+
+    async def alist_tools(self) -> list[dict[str, Any]]:
+        """Async variant of :meth:`list_tools`."""
+        return await asyncio.to_thread(self.list_tools)
+
+    async def aget_schema(self, wrapper_tool: str, backend_tool: str) -> str:
+        """Async variant of :meth:`get_schema`."""
+        return await asyncio.to_thread(self.get_schema, wrapper_tool, backend_tool)
+
+    async def ainvoke(self, tool: str, tool_input: dict[str, Any] | None = None) -> str:
+        """Async variant of :meth:`invoke`."""
+        return await asyncio.to_thread(self.invoke, tool, tool_input)
 
     def close(self) -> None:
         self._native_session.close()
@@ -121,7 +178,12 @@ def start_compressed_session(
     config: CompressedSessionConfig,
     backends: list[BackendConfig],
 ) -> CompressedSession:
-    """Start a Rust-backed compressed session and local proxy."""
+    """Start a Rust-backed compressed session.
+
+    By default this also starts a local HTTP bridge for out-of-process clients.
+    Set ``config.bridge=False`` for in-process use (dispatch via the session's
+    :meth:`CompressedSession.invoke` / :meth:`CompressedSession.list_tools`).
+    """
     native_session = _native.start_compressed_session_json(
         _json_dumps(config.to_json_dict()),
         _json_dumps([backend.to_json_dict() for backend in backends]),

--- a/python/mcp-compressor/tests/test_public_sdk_workflow.py
+++ b/python/mcp-compressor/tests/test_public_sdk_workflow.py
@@ -107,6 +107,40 @@ def test_public_python_sdk_quickstart_flow() -> None:
         )
 
 
+def test_public_python_sdk_in_process_session_without_bridge() -> None:
+    from mcp_compressor.core import (
+        BackendConfig,
+        CompressedSessionConfig,
+        start_compressed_session,
+    )
+
+    session = start_compressed_session(
+        CompressedSessionConfig(compression_level="max", server_name="alpha", bridge=False),
+        [BackendConfig(name="alpha", command_or_url=PYTHON, args=[str(FIXTURE)])],
+    )
+    try:
+        info = session.info()
+        # In-process mode starts no HTTP bridge.
+        assert info["bridge_url"] == ""
+        assert info["token"] == ""
+
+        tool_names = {tool["name"] for tool in session.list_tools()}
+        invoke_tool = next(name for name in tool_names if name.endswith("invoke_tool"))
+        schema_tool = next(name for name in tool_names if name.endswith("get_tool_schema"))
+
+        schema = session.get_schema(schema_tool, "echo")
+        assert "echo" in schema
+
+        # In-process invoke returns the same payload the bridge /exec would.
+        result = session.invoke(
+            invoke_tool,
+            {"tool_name": "echo", "tool_input": {"message": "in-process"}},
+        )
+        assert result == "alpha:in-process"
+    finally:
+        session.close()
+
+
 def test_public_python_sdk_preserves_oauth_app_name_in_config() -> None:
     from mcp_compressor.core import normalize_sdk_servers
 


### PR DESCRIPTION
## What

Adds an **in-process tool API** on `CompressedSession` so SDK consumers can reuse a session's live upstream connection and OAuth **without** running a local HTTP bridge per server.

- **core (`proxy/server.rs`)**: `dispatch_exec` is now a shared, public function used by both the HTTP `/exec` bridge endpoint and the in-process path, so both transports return identical payloads. `RunningToolProxy` retains/exposes its `Arc<CompressedServer>` (`server()`), and a new `ToolProxyServer::in_process()` wraps a connected server with no listener/token/background task.
- **ffi (`ffi/session.rs`, `ffi/dto.rs`)**: `FfiCompressedSession` gains `list_frontend_tools()`, `get_tool_schema()`, and `invoke()`. `FfiCompressedSessionConfig` gains a `bridge` flag (serde default `true`) to optionally skip the HTTP bridge (empty `bridge_url`/`token` when disabled).
- **python bindings (`lib.rs`)**: new native methods `list_frontend_tools_json`, `get_tool_schema_json`, `invoke_tool_json` (GIL released around the blocking native call).
- **python SDK (`core.py`)**: `CompressedSession.list_tools()/get_schema()/invoke()` plus async variants `alist_tools()/aget_schema()/ainvoke()` (via `asyncio.to_thread`, so they don't block an event loop). New `CompressedSessionConfig.bridge` flag.

## Why

In-process consumers (e.g. agents embedding the SDK) want the session's good OAuth + connection management, but spinning up a local HTTP bridge + token + subprocess per MCP server is undesirable. This exposes the same operations the bridge already performs, directly on the session handle.

## Compatibility

Fully backward compatible — the bridge stays **on by default**, so `CompressorClient`/`CompressorProxy` and generated CLI/Python/TS/Just-Bash clients are unaffected.

## Tests

- Rust: `ffi_session_dispatches_in_process_without_bridge` (verifies bridge-less list/schema/invoke returns the same payload as the bridge).
- Python: `test_public_python_sdk_in_process_session_without_bridge`.
- Full suites green locally: 239 Rust core lib tests, 31 Python tests; `ty` type check and public-API name guard pass.