### PR TITLE
Fix compressed tool input validation

### DIFF
--- a/crates/mcp-compressor-core/src/app/banner.rs
+++ b/crates/mcp-compressor-core/src/app/banner.rs
@@ -2,6 +2,7 @@
 
 use crate::compression::engine::Tool;
 use crate::compression::{CompressionEngine, CompressionLevel};
+use crate::server::compressed::INVOKE_TOOL_INPUT_SCHEMA_DESCRIPTION;
 
 const TITLE: &str = "\
 \x1b[32m█▀▄▀█ █▀▀ █▀█   █▀▀ █▀█ █▀▄▀█ █▀█ █▀█ █▀▀ █▀▀ █▀▀ █▀█ █▀█\x1b[0m
@@ -70,7 +71,7 @@ fn compressed_frontend_size(tools: &[Tool], level: &CompressionLevel) -> usize {
             "tool_name": {"type": "string", "description": "Name of the backend tool"},
             "tool_input": {
                 "type": "object",
-                "description": "JSON input for the backend tool",
+                "description": INVOKE_TOOL_INPUT_SCHEMA_DESCRIPTION,
                 "properties": {},
                 "additionalProperties": true
             }

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -11,6 +11,11 @@ use rmcp::model::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub(crate) const INVOKE_TOOL_INPUT_SCHEMA_DESCRIPTION: &str = concat!(
+    "JSON object matching the selected backend tool's input schema. ",
+    "Use get_tool_schema for the selected tool_name before invoking if required fields are unknown."
+);
+
 use crate::compression::engine::{CompressionEngine, Tool};
 use crate::compression::CompressionLevel;
 use crate::config::topology::MCPConfig;
@@ -435,13 +440,12 @@ impl CompressedServer {
         backend_tool_name: &str,
         tool_input: Value,
     ) -> Result<String, Error> {
-        if !backend
+        let tool = backend
             .tools
             .iter()
-            .any(|tool| tool.name == backend_tool_name)
-        {
-            return Err(Error::ToolNotFound(backend_tool_name.to_string()));
-        }
+            .find(|tool| tool.name == backend_tool_name)
+            .ok_or_else(|| Error::ToolNotFound(backend_tool_name.to_string()))?;
+        validate_required_tool_input(tool, &tool_input)?;
         let arguments = match tool_input {
             Value::Object(map) => Some(map),
             _ => None,
@@ -525,6 +529,54 @@ impl CompressedServer {
             .find(|backend| wrapper_tool_name.starts_with(&self.wrapper_prefix(backend)))
             .ok_or_else(|| Error::ToolNotFound(wrapper_tool_name.to_string()))
     }
+}
+
+fn validate_required_tool_input(tool: &Tool, tool_input: &Value) -> Result<(), Error> {
+    let required = required_field_names(&tool.input_schema);
+    if required.is_empty() {
+        return Ok(());
+    }
+
+    let input = match tool_input.as_object() {
+        Some(input) => input,
+        None => return Err(missing_required_tool_input_error(tool, &required)),
+    };
+    let missing = required
+        .iter()
+        .filter(|field| !input.contains_key(field.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(missing_required_tool_input_error(tool, &missing))
+    }
+}
+
+fn required_field_names(input_schema: &Value) -> Vec<String> {
+    input_schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|required| {
+            required
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn missing_required_tool_input_error(tool: &Tool, missing: &[String]) -> Error {
+    let schema = serde_json::to_string_pretty(&tool.input_schema)
+        .unwrap_or_else(|_| tool.input_schema.to_string());
+    Error::Validation(format!(
+        "Tool `{}` is missing required tool_input fields: {}. tool_input must be a JSON object matching the selected backend tool's input schema. Call get_tool_schema with tool_name=`{}` and retry with tool_input matching this schema:\n{}",
+        tool.name,
+        missing.join(", "),
+        tool.name,
+        schema
+    ))
 }
 
 fn format_backend_help(backend: &ConnectedBackend) -> String {
@@ -624,7 +676,7 @@ fn invoke_wrapper_tool(name: String, description: &str) -> Tool {
                 "tool_name": { "type": "string", "description": "Name of the backend tool" },
                 "tool_input": {
                     "type": "object",
-                    "description": "JSON input for the backend tool",
+                    "description": INVOKE_TOOL_INPUT_SCHEMA_DESCRIPTION,
                     "properties": {},
                     "additionalProperties": true
                 }

--- a/crates/mcp-compressor-core/src/server/registration.rs
+++ b/crates/mcp-compressor-core/src/server/registration.rs
@@ -191,5 +191,9 @@ fn required_string(arguments: &Map<String, Value>, name: &str) -> Result<String,
 }
 
 fn mcp_error(error: crate::Error) -> McpError {
-    McpError::new(ErrorCode::INTERNAL_ERROR, error.to_string(), None)
+    let code = match &error {
+        crate::Error::Validation(_) => ErrorCode::INVALID_PARAMS,
+        _ => ErrorCode::INTERNAL_ERROR,
+    };
+    McpError::new(code, error.to_string(), None)
 }

--- a/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
+++ b/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use mcp_compressor_core::server::CompressedServer;
+use mcp_compressor_core::{server::CompressedServer, Error};
 use serde_json::json;
 
 #[tokio::test]
@@ -31,7 +31,7 @@ async fn single_stdio_backend_exposes_only_compressed_wrapper_tools() {
 }
 
 #[tokio::test]
-async fn single_stdio_backend_invoke_wrapper_tool_input_schema_is_explicit_open_object() {
+async fn single_stdio_backend_invoke_wrapper_tool_input_schema_explains_selected_tool_schema() {
     let server = CompressedServer::connect_stdio(
         common::max_config(Some("alpha")),
         common::backend("alpha", "alpha_server.py"),
@@ -52,11 +52,34 @@ async fn single_stdio_backend_invoke_wrapper_tool_input_schema_is_explicit_open_
             .unwrap(),
         &json!({
             "type": "object",
-            "description": "JSON input for the backend tool",
+            "description": "JSON object matching the selected backend tool's input schema. Use get_tool_schema for the selected tool_name before invoking if required fields are unknown.",
             "properties": {},
             "additionalProperties": true
         })
     );
+}
+
+#[tokio::test]
+async fn single_stdio_backend_rejects_empty_tool_input_for_required_backend_tool() {
+    let server = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let error = server
+        .invoke_tool("alpha_invoke_tool", "echo", json!({}))
+        .await
+        .unwrap_err();
+    let Error::Validation(message) = &error else {
+        panic!("expected validation error, got {error:?}");
+    };
+
+    assert!(message.contains("echo"), "got: {message}");
+    assert!(message.contains("message"), "got: {message}");
+    assert!(message.contains("tool_input"), "got: {message}");
+    assert!(message.contains("get_tool_schema"), "got: {message}");
 }
 
 #[tokio::test]

--- a/typescript/src/local_tools.ts
+++ b/typescript/src/local_tools.ts
@@ -35,6 +35,35 @@ function asJsonSchema(
   );
 }
 
+const TOOL_INPUT_SCHEMA_DESCRIPTION =
+  "JSON object matching the selected tool's input schema. Use get_tool_schema for the selected tool_name before invoking if required fields are unknown.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requiredFieldNames(schema: Record<string, unknown>): string[] {
+  const required = schema.required;
+  if (!Array.isArray(required)) return [];
+  return required.filter((field): field is string => typeof field === "string");
+}
+
+function validateRequiredToolInput(spec: ToolSpec, toolInput: unknown): void {
+  const required = requiredFieldNames(spec.inputSchema);
+  if (required.length === 0) return;
+
+  const input = isRecord(toolInput) ? toolInput : {};
+  const missing = required.filter((field) => !Object.hasOwn(input, field));
+  if (missing.length === 0) return;
+
+  throw new Error(
+    `Tool \`${spec.name}\` is missing required tool_input fields: ${missing.join(", ")}. ` +
+      "tool_input must be a JSON object matching the selected tool's input schema. " +
+      `Call get_tool_schema with tool_name=\`${spec.name}\` and retry with tool_input matching this schema:\n` +
+      JSON.stringify(spec.inputSchema, null, 2),
+  );
+}
+
 function normalizeResult(value: unknown, toonify: boolean): string {
   const json = stringifyToolResult(value);
   if (!toonify) return json;
@@ -94,7 +123,7 @@ export function compressTools(
         tool_name: { type: "string", description: "Name of the tool" },
         tool_input: {
           type: "object",
-          description: "JSON input for the tool",
+          description: TOOL_INPUT_SCHEMA_DESCRIPTION,
           properties: {},
           additionalProperties: true,
         },
@@ -103,9 +132,12 @@ export function compressTools(
     },
     execute: async (input = {}) => {
       const toolName = String(input.tool_name ?? "");
+      const spec = specByName.get(toolName);
       const tool = toolByName.get(toolName);
-      if (!tool) throw new Error(`Tool not found: ${toolName}`);
-      const output = await tool.execute((input.tool_input ?? {}) as never);
+      if (!spec || !tool) throw new Error(`Tool not found: ${toolName}`);
+      const toolInput = input.tool_input ?? {};
+      validateRequiredToolInput(spec, toolInput);
+      const output = await tool.execute(toolInput as never);
       return normalizeResult(output, options.toonify ?? false);
     },
   };

--- a/typescript/tests/local_tools_schema.test.ts
+++ b/typescript/tests/local_tools_schema.test.ts
@@ -22,16 +22,33 @@ const tools = {
 };
 
 describe("local compressed tool schemas", () => {
-  it("exposes invoke wrapper tool_input as an explicit open object schema", () => {
+  it("explains that invoke wrapper tool_input matches the selected tool schema", () => {
     expect(compressTools(tools).invoke_tool?.inputSchema).toMatchObject({
       type: "object",
       properties: {
         tool_input: {
           type: "object",
           properties: {},
+          description:
+            "JSON object matching the selected tool's input schema. Use get_tool_schema for the selected tool_name before invoking if required fields are unknown.",
           additionalProperties: true,
         },
       },
     });
+  });
+
+  it("rejects empty tool_input for tools with required fields before executing", async () => {
+    const execute = vi.fn(async (): Promise<string> => "ok");
+    const invokeTool = compressTools({
+      echo: {
+        ...tools.echo,
+        execute,
+      },
+    }).invoke_tool;
+
+    await expect(invokeTool?.execute({ tool_name: "echo", tool_input: {} })).rejects.toThrow(
+      /echo.*message.*tool_input.*get_tool_schema/s,
+    );
+    expect(execute).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- clarify that compressed invoke wrapper `tool_input` must match the selected backend/local tool schema
- validate required top-level `tool_input` fields before dispatching compressed Rust backend tool calls
- surface validation failures as MCP invalid params instead of backend validation text-as-output
- apply the same required-field prevalidation to TypeScript local compressed tools

## Testing
- `cargo check -p mcp-compressor-core`
- `PYTHON="/Users/fciner/code/atlassian/mcp-compressor/.venv/bin/python" cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture`
- `cd typescript && bun run check`
- `git diff HEAD~1..HEAD --check`

## Context
Fixes the compressed-mode regression where agents could send an empty generic `tool_input: {}` for backend tools that require parameters, causing required arguments to be omitted until backend validation.