### PR TITLE
test: make the TypeScript and Rust client-gen tests run on Windows

### DIFF
--- a/crates/mcp-compressor-core/src/client_gen/python.rs
+++ b/crates/mcp-compressor-core/src/client_gen/python.rs
@@ -377,12 +377,13 @@ mod tests {
             "def real_tool(required_second, optional_first=None, optional_third=None) -> str:"
         ));
         assert!(content.contains("{\"optional_first\": optional_first, \"required_second\": required_second, \"optional_third\": optional_third}"));
-        std::process::Command::new("python3")
+        let python = std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string());
+        std::process::Command::new(&python)
             .arg("-m")
             .arg("py_compile")
             .arg(&paths[0])
             .status()
-            .expect("python3 should run")
+            .expect("python should run")
             .success()
             .then_some(())
             .expect("generated Python should compile");
@@ -418,12 +419,13 @@ mod tests {
         assert!(content.contains(
             r#"{"cloudId": cloud_id, "maxResults": max_results, "nextPageToken": next_page_token}"#
         ));
-        std::process::Command::new("python3")
+        let python = std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string());
+        std::process::Command::new(&python)
             .arg("-m")
             .arg("py_compile")
             .arg(&paths[0])
             .status()
-            .expect("python3 should run")
+            .expect("python should run")
             .success()
             .then_some(())
             .expect("generated Python should compile");

--- a/typescript/tests/agent_facing_snapshots.test.ts
+++ b/typescript/tests/agent_facing_snapshots.test.ts
@@ -66,14 +66,29 @@ const alphaTools: Record<string, ExecutableTool<unknown>> = {
 };
 
 function normalizePaths(value: string, replacements: Record<string, string>): string {
-  return Object.entries(replacements).reduce(
+  const replaced = Object.entries(replacements).reduce(
     (text, [actual, placeholder]) => text.split(actual).join(placeholder),
     value,
   );
+  // Generated source paths use the OS separator (`\` on Windows); the goldens are
+  // POSIX. Normalize the separator so these prose snapshots compare on any platform.
+  return process.platform === "win32" ? replaced.split("\\").join("/") : replaced;
+}
+
+// Windows runs the `.cmd`; other platforms run the extensionless shell script.
+function generatedScriptPath(outputDir: string, baseName: string): string {
+  return join(outputDir, process.platform === "win32" ? `${baseName}.cmd` : baseName);
 }
 
 function runScript(scriptPath: string, args: readonly string[]): string {
-  return execFileSync(scriptPath, [...args], { encoding: "utf8" }).trimEnd();
+  // A `.cmd` can only be launched through a shell on Windows; elsewhere the script
+  // runs directly. Normalize CRLF so the snapshots compare on any platform.
+  return execFileSync(scriptPath, [...args], {
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  })
+    .trimEnd()
+    .replace(/\r\n/g, "\n");
 }
 
 function materializeFiles(
@@ -92,10 +107,11 @@ function materializeFiles(
 }
 
 function golden(relativePath: string): string {
-  return readFileSync(
-    join(process.cwd(), "..", "testdata", "golden", relativePath),
-    "utf8",
-  ).trimEnd();
+  // A Windows checkout may store these goldens with CRLF; normalize to LF so they
+  // compare against the LF-normalized script output on any platform.
+  return readFileSync(join(process.cwd(), "..", "testdata", "golden", relativePath), "utf8")
+    .trimEnd()
+    .replace(/\r\n/g, "\n");
 }
 
 function toStableJson(value: unknown): string {
@@ -111,7 +127,7 @@ describe("agent-facing alpha snapshots", () => {
     });
     try {
       materializeFiles(outputDir, transform.files, ["alpha"]);
-      const scriptPath = join(outputDir, "alpha");
+      const scriptPath = generatedScriptPath(outputDir, "alpha");
       expect(runScript(scriptPath, ["--help"])).toBe(golden("agent-facing/cli/alpha-help.txt"));
       expect(runScript(scriptPath, ["echo", "--help"])).toBe(
         golden("agent-facing/cli/alpha-echo-help.txt"),
@@ -152,7 +168,7 @@ describe("agent-facing alpha snapshots", () => {
     transformToolsForJustBash(alphaTools, { serverName: "alpha", bash });
     try {
       materializeFiles(outputDir, cli.files, ["alpha"]);
-      const scriptPath = join(outputDir, "alpha");
+      const scriptPath = generatedScriptPath(outputDir, "alpha");
 
       // Top-level dispatcher help must match the generated CLI `--help` body.
       const cliTopLevel = runScript(scriptPath, ["--help"]);
@@ -224,7 +240,7 @@ describe("agent-facing alpha snapshots", () => {
     );
     try {
       materializeFiles(outputDir, transform.files, ["atlassian"]);
-      const scriptPath = join(outputDir, "atlassian");
+      const scriptPath = generatedScriptPath(outputDir, "atlassian");
       expect(runScript(scriptPath, ["--help"])).toBe(
         golden("agent-facing/atlassian-like/atlassian-help.txt"),
       );

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -3,7 +3,7 @@ import { request } from "node:http";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { tmpdir } from "node:os";
 import { Bash } from "just-bash";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -761,9 +761,16 @@ describe("local TypeScript tool compression", () => {
       { serverName: "alpha" },
     );
     try {
-      expect(transform.paths).toEqual(["./dist/alpha"]);
+      // Windows emits the shell script plus the `.cmd`, and PATH uses `;`/`%PATH%`;
+      // every other platform emits one script and uses `:`/`$PATH`.
+      if (process.platform === "win32") {
+        expect(transform.paths).toEqual(["./dist\\alpha", "./dist\\alpha.cmd"]);
+        expect(transform.environment.PATH).toBe("./dist;%PATH%");
+      } else {
+        expect(transform.paths).toEqual(["./dist/alpha"]);
+        expect(transform.environment.PATH).toBe("./dist:$PATH");
+      }
       expect(transform.files.alpha).toContain("alpha - the alpha toolset");
-      expect(transform.environment.PATH).toBe("./dist:$PATH");
       expect(transform.tools.alpha_help?.description).toContain("`alpha` CLI");
       expect(transform.tools.alpha_help?.description).not.toContain("PATH hint");
       expect(existsSync(join(home, ".local", "bin", "alpha"))).toBe(false);
@@ -821,7 +828,8 @@ describe("Rust native core wrapper", () => {
       sessionPid: 42,
       outputDir,
     });
-    expect(cliPaths).toHaveLength(1);
+    // Windows emits the shell script plus the `.cmd`; other platforms emit one.
+    expect(cliPaths).toHaveLength(process.platform === "win32" ? 2 : 1);
     expect(readFileSync(cliPaths[0]!, "utf8")).toContain("native-alpha - the native-alpha toolset");
 
     const pyPaths = generateClientArtifacts("python", {
@@ -990,14 +998,18 @@ describe("Rust native core wrapper", () => {
       const tsPaths = typescriptClient.files;
       expect(pythonClient.environment).toEqual({ PYTHONPATH: join(outputDir, "py") });
       expect(typescriptClient.environment).toEqual({});
-      const cliPath = cliPaths.find((path) => path.endsWith("alpha"));
+      // Windows runs the `.cmd`; other platforms run the extensionless shell script.
+      const cliArtifactName = process.platform === "win32" ? "alpha.cmd" : "alpha";
+      const cliPath = cliPaths.find((path) => path.endsWith(cliArtifactName));
       const pythonPath = pythonPaths.find((path) => path.endsWith("alpha.py"));
       const tsPath = tsPaths.find((path) => path.endsWith("alpha.ts"));
       expect(cliPath).toBeDefined();
       expect(pythonPath).toBeDefined();
       expect(tsPath).toBeDefined();
       const cliResult = await new Promise<string>((resolve, reject) => {
-        const child = spawn(cliPath!, ["echo", "--message", "generated-cli"]);
+        const child = spawn(cliPath!, ["echo", "--message", "generated-cli"], {
+          shell: process.platform === "win32",
+        });
         let stdout = "";
         let stderr = "";
         child.stdout.on("data", (chunk) => {
@@ -1017,7 +1029,7 @@ describe("Rust native core wrapper", () => {
       const pyResult = await new Promise<string>((resolve, reject) => {
         const child = spawn(python, [
           "-c",
-          `import sys; sys.path.insert(0, ${JSON.stringify(pythonPath!.replace(/\/alpha\.py$/, ""))}); import alpha; print(alpha.echo('generated'))`,
+          `import sys; sys.path.insert(0, ${JSON.stringify(dirname(pythonPath!))}); import alpha; print(alpha.echo('generated'))`,
         ]);
         let stdout = "";
         let stderr = "";

--- a/typescript/tests/transforms_e2e.test.ts
+++ b/typescript/tests/transforms_e2e.test.ts
@@ -65,10 +65,17 @@ describe("host-owned transform e2e", () => {
       expect(helpDescription).not.toContain("CLI Mode");
       expect(helpDescription).not.toContain("PATH hint");
 
-      expect(transform.paths).toEqual([join(outputDir, "alpha")]);
+      // Windows emits the shell script plus the `.cmd`, and PATH uses `;`/`%PATH%`;
+      // every other platform emits one script and uses `:`/`$PATH`.
+      if (process.platform === "win32") {
+        expect(transform.paths).toEqual([join(outputDir, "alpha"), join(outputDir, "alpha.cmd")]);
+        expect(transform.environment.PATH).toBe(`${outputDir};%PATH%`);
+      } else {
+        expect(transform.paths).toEqual([join(outputDir, "alpha")]);
+        expect(transform.environment.PATH).toBe(`${outputDir}:$PATH`);
+      }
       expect(transform.files).toHaveProperty("alpha");
       expect(transform.files.alpha).toContain("alpha - the alpha toolset");
-      expect(transform.environment.PATH).toBe(`${outputDir}:$PATH`);
       expect(existsSync(join(outputDir, "alpha"))).toBe(false);
     } finally {
       transform.close();
@@ -138,7 +145,9 @@ describe("host-owned transform e2e", () => {
     try {
       const pythonHelp = python.tools.alpha_help?.description ?? "";
       expect(pythonHelp).toContain("provided via a Python module");
-      expect(pythonHelp).toContain(`Python source code is available in ${pythonDir}/alpha.py`);
+      expect(pythonHelp).toContain(
+        `Python source code is available in ${join(pythonDir, "alpha.py")}`,
+      );
       expect(pythonHelp).toContain("Available functions:");
       expect(pythonHelp).toContain(
         "summarize_payload(items, metadata=None, include_details=None)  Summarize a structured payload.",
@@ -149,7 +158,7 @@ describe("host-owned transform e2e", () => {
 
       const tsHelp = typescript.tools.alpha_help?.description ?? "";
       expect(tsHelp).toContain("provided via a TypeScript module");
-      expect(tsHelp).toContain(`TypeScript source code is available in ${tsDir}/alpha.ts`);
+      expect(tsHelp).toContain(`TypeScript source code is available in ${join(tsDir, "alpha.ts")}`);
       expect(tsHelp).toContain(
         "summarizePayload(items, metadata?, include_details?)  Summarize a structured payload.",
       );


### PR DESCRIPTION
## What was broken

The TypeScript vitest suite and two Rust `client_gen::python` tests assumed a Unix
host (`python3`, `/` separators, `:`/`$PATH`, a single generated artifact, LF line
endings) and failed on Windows. #231 fixed the generated client and the Rust and
Python suites; these tests were the remaining Unix-only spot.

## What this changes

Test-only, and no change on Unix.

- `client_gen::python`: compile the generated module with the `PYTHON` interpreter,
  not a literal `python3`. Unset `PYTHON` still means `python3`.
- On Windows, expect both generated files (the shell script and the `.cmd`), select
  the `.cmd`, and use `;`/`%PATH%`; other platforms keep the single script and
  `:`/`$PATH`.
- Build paths with `join`/`dirname` so they use the OS separator instead of a
  literal `/`.
- Run the generated `.cmd` through a shell (Node can't run it directly).
- Normalize CRLF before comparing snapshots.

## Checked

- Windows, `.cmd` via cmd.exe (local): vitest 91/91 and cargo `--lib` 230/0 (incl.
  the two `client_gen::python` tests); the generated client dispatches `--help` and
  rejects an unknown subcommand.
- Windows, `sh` script via a POSIX shell (local): the same client's `sh` launcher
  dispatches identically (`python3` pointed at a real interpreter for the run, since
  this box ships only the Store stub).
- Unix, `sh` script (CI): ubuntu CI on this PR exercises the native Linux path.

Generated with Claude
