### PR TITLE
test: assert the generated code path with the native separator

### DIFF
--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 use std::process::{Command as StdCommand, Stdio};
 use std::time::{Duration, Instant};
 
@@ -199,7 +200,9 @@ fn rust_cli_code_mode_defaults_to_dist_directory() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Python code client ready"))
-        .stdout(predicate::str::contains("dist/alpha.py"));
+        .stdout(predicate::str::contains(
+            PathBuf::from("dist").join("alpha.py").display().to_string(),
+        ));
 
     assert!(dist.join("alpha.py").exists());
 }


### PR DESCRIPTION
## Problem

`rust_cli_code_mode_defaults_to_dist_directory` asserts that the Code Mode output mentions the generated file:

```rust
.stdout(predicate::str::contains("dist/alpha.py"));
```

The command prints a platform path, so the assertion can only hold where the path separator is a forward slash. On Windows the command prints `dist\alpha.py` and the test fails, even though the behaviour under test is correct and the file is created exactly where it should be. The following line already checks that with `dist.join("alpha.py").exists()`.

## Change

Build the expected fragment from path components so it renders with the native separator on every platform:

```rust
.stdout(predicate::str::contains(
    PathBuf::from("dist").join("alpha.py").display().to_string(),
));
```

Test-only. No production code, no change to what the assertion means: on Linux and macOS it still compares against `dist/alpha.py`.

## Verification

```
cargo test -p mcp-compressor-core --test cli_binary rust_cli_code_mode_defaults_to_dist_directory
```

Verified on Windows: the test fails before this change and passes after it. On platforms where the separator is `/` the expected string is unchanged, so behaviour there is identical.

## Scope

This is one of several small fixes needed to make the suite runnable on Windows. Kept separate per the contributing guide's "keep unrelated changes in separate PRs".