### PR TITLE
test: run the normal-mode fixtures with the suite's own interpreter

### DIFF
--- a/tests/test_rust_core_normal_mode.py
+++ b/tests/test_rust_core_normal_mode.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 
 from fastmcp import Client
 from fastmcp.client.transports import StdioTransport, StreamableHttpTransport
+
+# Run the fixture servers with the interpreter that runs this suite. A bare
+# "python3" is not the test environment's interpreter on Windows, where it
+# resolves to a Store execution alias pointing at some other installation that
+# has no fastmcp, so every backend connection closes during initialize.
+PYTHON = os.environ.get("PYTHON", sys.executable)
 
 
 def rust_core_command(*args: str) -> list[str]:
@@ -23,6 +31,13 @@ def rust_core_command(*args: str) -> list[str]:
     ]
 
 
+def multi_server_spec(name: str, script: Path) -> str:
+    # --multi-server splits on whitespace and has no quoting, so an interpreter
+    # path containing spaces cannot be expressed here.
+    assert " " not in PYTHON, f"--multi-server cannot quote the interpreter path: {PYTHON}"
+    return f"{name}={PYTHON} {script}"
+
+
 async def test_rust_core_normal_stdio_mode_with_fixture_server() -> None:
     root = Path(__file__).parents[1]
     alpha = root / "crates" / "mcp-compressor-core" / "tests" / "fixtures" / "alpha_server.py"
@@ -32,7 +47,7 @@ async def test_rust_core_normal_stdio_mode_with_fixture_server() -> None:
         "--server-name",
         "alpha",
         "--",
-        "python3",
+        PYTHON,
         str(alpha),
     )
 
@@ -93,9 +108,9 @@ async def test_rust_core_normal_stdio_mode_with_multi_server_direct_config() -> 
         "--server-name",
         "suite",
         "--multi-server",
-        f"alpha=python3 {alpha}",
+        multi_server_spec("alpha", alpha),
         "--multi-server",
-        f"beta=python3 {beta}",
+        multi_server_spec("beta", beta),
     )
 
     async with Client(StdioTransport(command=command[0], args=command[1:])) as client:
@@ -145,7 +160,7 @@ async def test_rust_core_normal_streamable_http_mode_with_fixture_server() -> No
         "--port",
         "0",
         "--",
-        "python3",
+        PYTHON,
         str(alpha),
     )
     process = subprocess.Popen(  # noqa: S603
@@ -196,7 +211,7 @@ async def test_rust_core_normal_stdio_mode_with_remote_streamable_http_backend()
         "--port",
         "0",
         "--",
-        "python3",
+        PYTHON,
         str(alpha),
     )
     process = subprocess.Popen(  # noqa: S603
@@ -256,8 +271,8 @@ async def test_rust_core_normal_stdio_mode_with_json_config(tmp_path: Path) -> N
     config.write_text(
         json.dumps({
             "mcpServers": {
-                "alpha": {"command": "python3", "args": [str(alpha)]},
-                "beta": {"command": "python3", "args": [str(beta)]},
+                "alpha": {"command": PYTHON, "args": [str(alpha)]},
+                "beta": {"command": PYTHON, "args": [str(beta)]},
             }
         }),
         encoding="utf-8",


### PR DESCRIPTION
## Problem

`tests/test_rust_core_normal_mode.py` launches the fixture MCP servers as `python3`:

```python
"--",
"python3",
str(alpha),
```

`python3` is not the interpreter running the suite. On Windows the bare name resolves to the Microsoft Store execution alias, which points at a different installation that has no `fastmcp`, so the fixture server dies immediately during startup:

```
ModuleNotFoundError: No module named 'fastmcp'
error: config error: connection closed: initialize response
```

All five tests in the file fail, regardless of the code under test. The same problem exists for a virtualenv or a `uv`-managed environment on any platform whenever `python3` on `PATH` is not the environment the suite runs in.

## Change

Resolve the interpreter the same way the sibling CLI workflow tests already do — the running interpreter, overridable with `PYTHON`:

```python
PYTHON = os.environ.get("PYTHON", sys.executable)
```

and use it for the four launch styles the file exercises: `--` backend command, `--multi-server`, the HTTP-serving process, and the MCP JSON config.

`--multi-server` takes `name=command args` and splits on whitespace with no quoting, so an interpreter path containing a space cannot be expressed there. Rather than let that surface as an unrelated connection failure, the helper asserts the constraint with a message that names the actual cause:

```python
assert " " not in PYTHON, f"--multi-server cannot quote the interpreter path: {PYTHON}"
```

That is a deliberately narrow choice: this PR does not change `--multi-server` parsing. If quoting support is wanted, it belongs in its own change to the CLI, and this assertion is the thing that would be removed by it.

Test-only. No production code.

## Verification

```
uv run pytest -q tests/test_rust_core_normal_mode.py
```

On Windows, against `main` at 74674d5:

```
5 failed in 10.49s
```

with `ModuleNotFoundError: No module named 'fastmcp'` in each. With this change:

```
5 passed in 92.49s
```

On platforms where `python3` already resolves to the suite's interpreter, `sys.executable` is that same interpreter, so behaviour is unchanged.

## Scope

One of several small changes needed to make the suite runnable on Windows, kept separate per the contributing guide's preference for unrelated changes in separate PRs.