### PR TITLE
test: run the generated-client tests on Windows

### DIFF
--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -49,22 +49,23 @@ async fn running_proxy_config(output_dir: &std::path::Path) -> (GeneratorConfig,
 }
 
 fn generated_script_output(script: &std::path::Path, args: &[&str]) -> std::process::Output {
+    let program = std::path::PathBuf::from(generated_script_command(script).get_program());
     let mut last_error = None;
     for attempt in 0..5 {
-        match generated_script_command(script).args(args).output() {
+        match Command::new(&program).args(args).output() {
             Ok(output) => return output,
             Err(error) if error.raw_os_error() == Some(26) && attempt < 4 => {
                 last_error = Some(error);
                 thread::sleep(Duration::from_millis(25 * (attempt + 1) as u64));
             }
-            Err(error) => panic!("failed to execute {}: {error}", script.display()),
+            Err(error) => panic!("failed to execute {}: {error}", program.display()),
         }
     }
     let error =
         last_error.unwrap_or_else(|| io::Error::other("unknown generated script execution error"));
     panic!(
         "failed to execute {} after retrying ETXTBSY: {error}",
-        script.display()
+        program.display()
     );
 }
 

--- a/crates/mcp-compressor-core/tests/generated_clients.rs
+++ b/crates/mcp-compressor-core/tests/generated_clients.rs
@@ -51,7 +51,7 @@ async fn running_proxy_config(output_dir: &std::path::Path) -> (GeneratorConfig,
 fn generated_script_output(script: &std::path::Path, args: &[&str]) -> std::process::Output {
     let mut last_error = None;
     for attempt in 0..5 {
-        match Command::new(script).args(args).output() {
+        match generated_script_command(script).args(args).output() {
             Ok(output) => return output,
             Err(error) if error.raw_os_error() == Some(26) && attempt < 4 => {
                 last_error = Some(error);
@@ -66,6 +66,12 @@ fn generated_script_output(script: &std::path::Path, args: &[&str]) -> std::proc
         "failed to execute {} after retrying ETXTBSY: {error}",
         script.display()
     );
+}
+
+fn generated_script_command(script: &std::path::Path) -> Command {
+    #[cfg(windows)]
+    let script = script.with_extension("cmd");
+    Command::new(script)
 }
 
 #[test]
@@ -200,7 +206,7 @@ async fn generated_cli_script_handles_structured_json_arguments() {
     CliGenerator.generate(&config).unwrap();
     let script = tempdir.path().join("alpha");
 
-    let output = std::process::Command::new(&script)
+    let output = generated_script_command(&script)
         .args([
             "summarize-payload",
             "--items",
@@ -231,7 +237,7 @@ async fn generated_cli_script_matches_legacy_argument_parser_features() {
     CliGenerator.generate(&config).unwrap();
     let script = tempdir.path().join("alpha");
 
-    let repeated = std::process::Command::new(&script)
+    let repeated = generated_script_command(&script)
         .args([
             "summarize-payload",
             "--items",
@@ -253,7 +259,7 @@ async fn generated_cli_script_matches_legacy_argument_parser_features() {
     assert!(stdout.contains("one"));
     assert!(stdout.contains("two"));
 
-    let json_escape = std::process::Command::new(&script)
+    let json_escape = generated_script_command(&script)
         .args([
             "summarize-payload",
             "--json",
@@ -391,8 +397,8 @@ async fn generated_typescript_module_invokes_real_proxy_and_backend() {
     let output = Command::new("bun")
         .arg("--eval")
         .arg(format!(
-            "import {{ echo }} from '{}'; console.log(await echo('hello'));",
-            module_path.display()
+            "import {{ echo }} from {module:?}; console.log(await echo('hello'));",
+            module = module_path.display().to_string()
         ))
         .output()
         .unwrap();
@@ -730,6 +736,7 @@ fn run_generated_script(script: &std::path::Path, args: &[&str]) -> String {
     );
     String::from_utf8(output.stdout)
         .unwrap()
+        .replace("\r\n", "\n")
         .trim_end()
         .to_string()
 }


### PR DESCRIPTION
## Problem

The generated-client tests invoke the artifacts they generate in ways that only work on Unix, so on Windows they fail for reasons unrelated to what they assert. Against `main`, `cargo test -p mcp-compressor-core --test generated_clients` on Windows gives:

```
test result: FAILED. 3 passed; 14 failed
```

Three separate causes:

1. **The generated CLI cannot be executed.** Code Mode writes an extensionless shell script plus a `.cmd` wrapper beside it. Windows cannot execute the extensionless file, so every test that runs the CLI fails at spawn.
2. **Generated output is compared line by line**, and the shell redirects that produce it emit CRLF on Windows. The golden-help comparisons then fail on invisible characters.
3. **The TypeScript module path is interpolated bare into a `bun --eval` import.** A Windows path is full of backslashes, which the JavaScript string literal consumes as escapes, so the import target is corrupted before bun ever sees it.

## Change

Test-harness only — one file, no production code, no change to what is generated:

- `generated_script_command()` picks the `.cmd` wrapper on Windows and the extensionless script elsewhere.
- `run_generated_script()` normalises line endings before comparing.
- The module path is interpolated with `{module:?}`, which escapes it correctly for a JavaScript string literal.

## Verification

`cargo test -p mcp-compressor-core --test generated_clients -- --test-threads=1`, on Windows:

| | passed | failed |
|---|---|---|
| `main` (fad0206) | 3 | 14 |
| this branch | 12 | 5 |

Nine tests fixed, and all five remaining failures are present in the `main` baseline too, so this introduces none. For completeness, those five are:

- `generated_typescript_module_invokes_real_proxy_and_backend`, `..._reports_stopped_proxy_without_fetch_noise`, `..._returns_raw_host_bridge_result` — these fail with `program not found` because bun is not installed in my environment. They are not addressed here.
- `generated_cli_prints_raw_host_bridge_result` and `generated_python_module_reports_stopped_proxy_without_urllib_traceback` — two further Windows problems with causes unrelated to how the tests launch the artifact. Each belongs in its own change.

Please note what CI can and cannot show here: every job in `main.yml` runs on `ubuntu-latest`, so a green run demonstrates that this does not regress Linux, and nothing more. The Windows result above was measured locally, and I am happy to provide fuller logs.

## Scope

One of several small changes needed to make the suite runnable on Windows, kept separate per the contributing guide's preference for unrelated changes in separate PRs.