### PR TITLE
test: kill spawned test process trees on unwind

### DIFF
--- a/crates/mcp-compressor-core/tests/child_process_cleanup.rs
+++ b/crates/mcp-compressor-core/tests/child_process_cleanup.rs
@@ -1,0 +1,76 @@
+mod common;
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use common::ChildGuard;
+
+/// A test that spawns `mcp-compressor` must not strand it when an assertion
+/// fails. The stranded binary keeps `target/debug/mcp-compressor.exe` open on
+/// Windows, so one failing test turns every later `cargo test` into a build
+/// error, and the backend it spawned keeps running too.
+#[test]
+fn child_guard_kills_the_process_tree_when_a_test_unwinds() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let parent_beat = tempdir.path().join("beat");
+    let child_beat = parent_beat.with_extension("child");
+
+    let result = std::panic::catch_unwind({
+        let parent_beat = parent_beat.clone();
+        let child_beat = child_beat.clone();
+        move || {
+            let mut command = Command::new(common::python_command());
+            command
+                .arg(common::fixture_path("process_tree_server.py"))
+                .arg("parent")
+                .arg(&parent_beat)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            let _guard = ChildGuard::spawn(&mut command).unwrap();
+
+            wait_for_growth(&parent_beat);
+            wait_for_growth(&child_beat);
+
+            panic!("simulated assertion failure");
+        }
+    });
+
+    assert!(result.is_err(), "the closure must unwind");
+
+    // Give the tree a moment to die, then prove neither process is still
+    // writing: a survivor appends a heartbeat every 50ms.
+    std::thread::sleep(Duration::from_millis(500));
+    let parent_after = fs::metadata(&parent_beat).unwrap().len();
+    let child_after = fs::metadata(&child_beat).unwrap().len();
+    std::thread::sleep(Duration::from_millis(500));
+
+    assert_eq!(
+        fs::metadata(&parent_beat).unwrap().len(),
+        parent_after,
+        "the spawned process outlived the guard"
+    );
+    assert_eq!(
+        fs::metadata(&child_beat).unwrap().len(),
+        child_after,
+        "a descendant of the spawned process outlived the guard"
+    );
+}
+
+fn wait_for_growth(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut seen = 0;
+    while Instant::now() < deadline {
+        if let Ok(metadata) = fs::metadata(path) {
+            if metadata.len() > seen {
+                seen = metadata.len();
+                if seen > 0 {
+                    return;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    panic!("timed out waiting for {} to be written", path.display());
+}

--- a/crates/mcp-compressor-core/tests/cli_binary.rs
+++ b/crates/mcp-compressor-core/tests/cli_binary.rs
@@ -415,7 +415,8 @@ fn rust_cli_mode_honors_explicit_output_dir() {
 fn rust_cli_mode_manual_flow_generates_script_that_invokes_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     let output_dir = tempdir.path().join("generated");
-    let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("mcp-compressor"))
+    let mut command = StdCommand::new(assert_cmd::cargo::cargo_bin("mcp-compressor"));
+    command
         .env("MCP_COMPRESSOR_CLI_OUTPUT_DIR", &output_dir)
         .args([
             "--cli-mode",
@@ -426,11 +427,12 @@ fn rust_cli_mode_manual_flow_generates_script_that_invokes_backend() {
             common::fixture_path("alpha_server.py").to_str().unwrap(),
         ])
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
+        .stderr(Stdio::piped());
+    // Guarded so a failing assertion below cannot strand the compressor and its
+    // backend; a stranded compressor keeps the test binary's artifact locked.
+    let mut child = common::ChildGuard::spawn(&mut command).unwrap();
 
-    let stdout = child.stdout.take().unwrap();
+    let stdout = child.take_stdout();
     let mut reader = BufReader::new(stdout);
     let script_path = wait_for_generated_cli_path(&mut reader);
 
@@ -467,9 +469,6 @@ fn rust_cli_mode_manual_flow_generates_script_that_invokes_backend() {
         String::from_utf8_lossy(&output.stdout).trim(),
         "alpha:hello"
     );
-
-    let _ = child.kill();
-    let _ = child.wait();
 }
 
 fn wait_for_generated_cli_path(reader: &mut impl BufRead) -> String {
@@ -517,7 +516,8 @@ fn rust_cli_mode_exits_on_ctrl_c() {
         use std::process::Stdio;
         use std::time::{Duration, Instant};
 
-        let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("mcp-compressor"))
+        let mut command = StdCommand::new(assert_cmd::cargo::cargo_bin("mcp-compressor"));
+        command
             .arg("--cli-mode")
             .arg("--server-name")
             .arg("alpha")
@@ -527,11 +527,12 @@ fn rust_cli_mode_exits_on_ctrl_c() {
             .arg(common::python_command())
             .arg(common::fixture_path("alpha_server.py"))
             .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()
-            .expect("spawn mcp-compressor");
+            .stdout(Stdio::piped());
+        // Guarded so the assertions below cannot strand the compressor and its
+        // backend when the CLI fails to become ready.
+        let mut child = common::ChildGuard::spawn(&mut command).expect("spawn mcp-compressor");
 
-        let stdout = child.stdout.take().expect("stdout");
+        let stdout = child.take_stdout();
         let reader = BufReader::new(stdout);
         let started = Instant::now();
         let mut saw_ready = false;

--- a/crates/mcp-compressor-core/tests/common/mod.rs
+++ b/crates/mcp-compressor-core/tests/common/mod.rs
@@ -87,8 +87,8 @@ fn kill_process_tree(child: &mut Child) {
 
 #[cfg(unix)]
 fn kill_process_tree(child: &mut Child) {
-    // The child leads its own process group, so signalling the negated pid
-    // reaches the backends it spawned as well.
+    // The child leads its own process group, so signalling that group reaches
+    // the backends it spawned as well.
     unsafe {
         libc::killpg(child.id() as i32, libc::SIGKILL);
     }

--- a/crates/mcp-compressor-core/tests/common/mod.rs
+++ b/crates/mcp-compressor-core/tests/common/mod.rs
@@ -1,9 +1,99 @@
 use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
 
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::server::{
     BackendConfigSource, BackendServerConfig, CompressedServerConfig, ProxyTransformMode,
 };
+
+/// A spawned child process that is killed, with its descendants, when dropped.
+///
+/// Tests that spawn `mcp-compressor` also spawn its backend processes. Killing
+/// the child at the end of the test body is not enough: a failed assertion
+/// unwinds past that call, leaving the whole tree running. On Windows the
+/// stranded binary then holds `target\debug\mcp-compressor.exe` open, so every
+/// later `cargo test` fails with "failed to remove file ... (os error 5)" and a
+/// single test failure blocks the entire suite.
+///
+/// Cleaning up in `Drop` runs on both the success and the unwind path.
+#[allow(dead_code)]
+pub struct ChildGuard {
+    child: Option<Child>,
+}
+
+#[allow(dead_code)]
+impl ChildGuard {
+    /// Spawn `command` under a guard.
+    ///
+    /// On Unix the child gets its own process group so the group can be
+    /// signalled as a unit; Windows has no equivalent at spawn time, so the
+    /// tree is walked at kill time instead.
+    pub fn spawn(command: &mut Command) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        Ok(Self {
+            child: Some(command.spawn()?),
+        })
+    }
+
+    pub fn id(&self) -> u32 {
+        self.child
+            .as_ref()
+            .expect("child is only taken in Drop")
+            .id()
+    }
+
+    pub fn take_stdout(&mut self) -> std::process::ChildStdout {
+        self.child
+            .as_mut()
+            .expect("child is only taken in Drop")
+            .stdout
+            .take()
+            .expect("stdout was piped")
+    }
+
+    pub fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        self.child
+            .as_mut()
+            .expect("child is only taken in Drop")
+            .try_wait()
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        kill_process_tree(&mut child);
+        let _ = child.wait();
+    }
+}
+
+#[cfg(windows)]
+fn kill_process_tree(child: &mut Child) {
+    // taskkill /T terminates the process and every descendant. Without it the
+    // backend the compressor spawned survives its parent.
+    let _ = Command::new("taskkill")
+        .args(["/PID", &child.id().to_string(), "/T", "/F"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    let _ = child.kill();
+}
+
+#[cfg(unix)]
+fn kill_process_tree(child: &mut Child) {
+    // The child leads its own process group, so signalling the negated pid
+    // reaches the backends it spawned as well.
+    unsafe {
+        libc::killpg(child.id() as i32, libc::SIGKILL);
+    }
+    let _ = child.kill();
+}
 
 pub fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/mcp-compressor-core/tests/fixtures/process_tree_server.py
+++ b/crates/mcp-compressor-core/tests/fixtures/process_tree_server.py
@@ -1,0 +1,31 @@
+"""Long-lived process tree used to verify test child cleanup.
+
+Started as ``parent`` it spawns one grandchild and both processes append a
+heartbeat to their own file until they are killed. A caller can therefore tell
+whether the whole tree stopped by checking that both heartbeat files stop
+growing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def heartbeat(path: Path) -> None:
+    while True:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write("tick\n")
+        time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    role = sys.argv[1]
+    target = Path(sys.argv[2])
+    if role == "parent":
+        subprocess.Popen(  # noqa: S603
+            [sys.executable, __file__, "child", str(target.with_suffix(".child"))]
+        )
+    heartbeat(target)


### PR DESCRIPTION
## Problem

Two tests in `cli_binary.rs` spawn the `mcp-compressor` binary and kill it at the end of the test body. A failed assertion unwinds past that call, so the compressor — and the backend it spawned — keep running after the test binary exits.

On Windows the stranded compressor holds `target\debug\mcp-compressor.exe` open, so the next `cargo test` fails while linking:

```
error: failed to remove file `target\debug\mcp-compressor.exe`
Caused by: Access is denied. (os error 5)
```

One failing test therefore blocks every later run of the whole suite until the orphan is killed by hand. I hit this repeatedly while working through the Windows failures.

The leak is real on Unix too — the processes simply do not hold a file lock, so it is quieter there.

## Change

Test-only, four files, no production code.

`common::ChildGuard` owns the spawned child and kills it from `Drop`, so cleanup runs on the unwind path as well as the success path. Killing the child alone is not enough, because it does not reap the backend the compressor spawned, so the guard kills the whole tree: `taskkill /T /F` on Windows, and on Unix the child is spawned into its own process group which is then signalled as a unit.

The two call sites in `cli_binary.rs` now hold a guard instead of killing by hand.

## Verification

The regression test spawns a fixture that keeps a grandchild alive, panics inside `catch_unwind` while the guard is in scope, and asserts that both heartbeat files stop growing.

```
cargo test -p mcp-compressor-core --test child_process_cleanup
```

Red/green, on Windows:

- with the guard: `1 passed`
- with the body of `ChildGuard::drop` stubbed out: `FAILED`, `assertion left == right failed: the spawned process outlived the guard, left: 132, right: 78`
- guard restored: `1 passed`

No regression in the file it touches. `cargo test -p mcp-compressor-core --test cli_binary -- --test-threads=1`:

| | passed | failed |
|---|---|---|
| `main` (fad0206) | 15 | 3 |
| this branch | 15 | 3 |

The three failures are identical by name on both sides. They are separate Windows problems, each addressed in its own change.

A small aside that may amuse: while producing the red result above, the stubbed guard stranded a process tree and the next run picked up the still-growing heartbeat files. The failure mode is exactly the one this PR removes.

Please note what CI can and cannot show: every job in `main.yml` runs on `ubuntu-latest`, so a green run demonstrates the guard does not regress Linux. The `os error 5` symptom is Windows-specific and was measured locally.

## Scope

Kept separate per the contributing guide's preference for unrelated changes in separate PRs.