### PR TITLE
fix: support remote MCP JSON configuration

### DIFF
--- a/crates/mcp-compressor-core/src/app/options.rs
+++ b/crates/mcp-compressor-core/src/app/options.rs
@@ -96,7 +96,7 @@ pub struct CliOptions {
 impl CliOptions {
     pub fn validate(&self) -> Result<(), String> {
         if self.config_path.is_some() && self.server_name.is_some() {
-            return Err("--server-name cannot be used with --config; MCP config server names come from mcpServers keys".to_string());
+            return Err("--server-name cannot be used with --config; MCP config server names come from the selected server-map keys".to_string());
         }
 
         let mode_aliases = [

--- a/crates/mcp-compressor-core/src/config/topology.rs
+++ b/crates/mcp-compressor-core/src/config/topology.rs
@@ -190,6 +190,15 @@ impl MCPConfig {
         self.servers.get(name)
     }
 
+    pub(crate) fn server_metadata(
+        &self,
+        name: &str,
+    ) -> Option<(&HashMap<String, String>, Option<&str>)> {
+        self.options
+            .get(name)
+            .map(|options| (&options.headers, options.oauth_app_name.as_deref()))
+    }
+
     /// Return the CLI prefix (sanitized server name) for a given server.
     ///
     /// Used to namespace subcommands in multi-server CLI mode.
@@ -306,6 +315,50 @@ mod tests {
 
         assert_eq!(backend.headers["X-Trace-Id"], "abc123");
         assert!(backend.should_use_oauth());
+    }
+
+    #[test]
+    fn url_backend_can_force_oauth_from_json_args() {
+        let json = r#"{
+            "mcpServers": {
+                "remote": {
+                    "url": "https://example.test/mcp",
+                    "args": ["--auth", "oauth"],
+                    "headers": { "Authorization": "Bearer static-token" }
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(backend.auth_mode, crate::server::BackendAuthMode::OAuth);
+        assert!(backend.should_use_oauth());
+    }
+
+    #[test]
+    fn url_backend_can_force_explicit_headers_from_json_args() {
+        let json = r#"{
+            "mcpServers": {
+                "remote": {
+                    "url": "https://example.test/mcp",
+                    "args": ["--auth=explicit-headers"]
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(
+            backend.auth_mode,
+            crate::server::BackendAuthMode::ExplicitHeaders
+        );
+        assert!(!backend.should_use_oauth());
     }
 
     /// `BackendServerConfig::new` parses `-H` and `--env` out of `args`, so the
@@ -555,13 +608,28 @@ mod tests {
     }
 
     #[test]
-    fn config_requires_exactly_one_server_envelope() {
-        for json in [r#"{}"#, r#"{"mcpServers":{},"servers":{}}"#] {
-            let error = MCPConfig::from_json(json).unwrap_err();
-            assert!(error
-                .to_string()
-                .contains("exactly one of mcpServers or servers"));
-        }
+    fn empty_servers_envelope_is_accepted() {
+        let config = MCPConfig::from_json(r#"{"servers":{}}"#).unwrap();
+
+        assert!(config.server_names().is_empty());
+    }
+
+    #[test]
+    fn missing_server_envelope_is_error() {
+        let error = MCPConfig::from_json(r#"{}"#).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("exactly one of mcpServers or servers"));
+    }
+
+    #[test]
+    fn multiple_server_envelopes_are_error() {
+        let error = MCPConfig::from_json(r#"{"mcpServers":{},"servers":{}}"#).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("exactly one of mcpServers or servers"));
     }
 
     // ------------------------------------------------------------------

--- a/crates/mcp-compressor-core/src/config/topology.rs
+++ b/crates/mcp-compressor-core/src/config/topology.rs
@@ -1,7 +1,7 @@
 //! MCP config JSON parsing and server-topology helpers.
 //!
-//! Supports the standard `mcpServers` JSON format used by Claude Desktop,
-//! VS Code, and other MCP host applications:
+//! Supports both the `mcpServers` and `servers` JSON envelopes used by MCP host
+//! applications; MCP host configuration envelopes are not protocol-standard:
 //!
 //! ```json
 //! {
@@ -18,6 +18,8 @@
 use std::collections::HashMap;
 
 use crate::cli::mapping::sanitize_cli_name;
+use crate::server::backend::interpolate_env;
+use crate::server::BackendServerConfig;
 use crate::Error;
 
 /// Configuration for a single MCP backend server.
@@ -33,26 +35,147 @@ pub struct ServerConfig {
     pub env: HashMap<String, String>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct ServerOptions {
+    headers: HashMap<String, String>,
+    oauth_app_name: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ParsedServerConfig {
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: HashMap<String, String>,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    #[serde(default)]
+    oauth_app_name: Option<String>,
+}
+
+impl ParsedServerConfig {
+    fn into_parts(self, name: &str) -> Result<(ServerConfig, ServerOptions), Error> {
+        let command = match (self.command, self.url) {
+            (Some(command), None) => command,
+            (None, Some(url)) => normalize_http_url(name, &url)?,
+            _ => {
+                return Err(Error::Config(format!(
+                    "server {name} must define exactly one of command or url"
+                )))
+            }
+        };
+        Ok((
+            ServerConfig {
+                command,
+                args: self.args,
+                env: self.env,
+            },
+            ServerOptions {
+                headers: self.headers,
+                oauth_app_name: self.oauth_app_name,
+            },
+        ))
+    }
+}
+
+fn normalize_http_url(name: &str, value: &str) -> Result<String, Error> {
+    let url = reqwest::Url::parse(value).map_err(|error| {
+        Error::Config(format!(
+            "server {name} url must be a valid HTTP(S) URL: {error}"
+        ))
+    })?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(Error::Config(format!(
+            "server {name} url must be a valid HTTP(S) URL"
+        )));
+    }
+    Ok(url.to_string())
+}
+
+impl ServerConfig {
+    fn into_backend(self, name: String, options: ServerOptions) -> BackendServerConfig {
+        let mut backend = BackendServerConfig::new(name, self.command, self.args);
+        // `BackendServerConfig::new` also parses `-H`/`--env` flags out of
+        // `args`, so the explicit config maps have to be merged on top of the
+        // parsed ones instead of replacing them.
+        let mut env = backend.env.clone();
+        env.extend(
+            self.env
+                .into_iter()
+                .map(|(key, value)| (key, interpolate_env(&value))),
+        );
+        let mut headers = backend.headers.clone();
+        for (name, value) in options.headers {
+            headers.retain(|existing, _| !existing.eq_ignore_ascii_case(&name));
+            headers.insert(name, interpolate_env(&value));
+        }
+        backend = backend.with_env(env).with_headers(headers);
+        // The auth mode stays `Auto` so that, exactly as on the CLI, only an
+        // `Authorization` header disables OAuth. Non-auth headers such as
+        // `X-Trace-Id` must not silently opt the backend out of login.
+        if let Some(app_name) = options.oauth_app_name {
+            backend = backend.with_oauth_app_name(app_name);
+        }
+        backend
+    }
+}
+
 /// Parsed representation of an MCP host config file.
 #[derive(Debug, Clone)]
 pub struct MCPConfig {
     servers: HashMap<String, ServerConfig>,
+    options: HashMap<String, ServerOptions>,
 }
 
 impl MCPConfig {
     /// Parse an MCP config JSON string.
     ///
-    /// Returns an error when the JSON is malformed or when the `mcpServers`
-    /// key is absent.
+    /// Returns an error when the JSON is malformed or does not contain exactly
+    /// one supported server envelope.
     pub fn from_json(json: &str) -> Result<Self, Error> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct RawConfig {
-            mcp_servers: HashMap<String, ServerConfig>,
+            #[serde(default)]
+            mcp_servers: Option<HashMap<String, ParsedServerConfig>>,
+            #[serde(default)]
+            servers: Option<HashMap<String, ParsedServerConfig>>,
         }
 
         let raw: RawConfig = serde_json::from_str(json)?;
-        Ok(Self { servers: raw.mcp_servers })
+        let parsed_servers = match (raw.mcp_servers, raw.servers) {
+            (Some(servers), None) | (None, Some(servers)) => servers,
+            _ => {
+                return Err(Error::Config(
+                    "config must define exactly one of mcpServers or servers".to_string(),
+                ))
+            }
+        };
+        let mut servers = HashMap::new();
+        let mut options = HashMap::new();
+        for (name, parsed) in parsed_servers {
+            let (server, server_options) = parsed.into_parts(&name)?;
+            servers.insert(name.clone(), server);
+            options.insert(name, server_options);
+        }
+        Ok(Self { servers, options })
+    }
+
+    pub(crate) fn into_backend_configs(self) -> Result<Vec<BackendServerConfig>, Error> {
+        let mut servers = self.servers.into_iter().collect::<Vec<_>>();
+        servers.sort_by(|(left, _), (right, _)| left.cmp(right));
+        Ok(servers
+            .into_iter()
+            .map(|(name, server)| {
+                let options = self.options.get(&name).cloned().unwrap_or_default();
+                server.into_backend(name, options)
+            })
+            .collect())
     }
 
     /// Return server names in ascending lexicographic order.
@@ -103,6 +226,222 @@ mod tests {
         let server = config.server("s").unwrap();
         assert_eq!(server.command, "uvx");
         assert_eq!(server.args, vec!["mcp-fetch"]);
+    }
+
+    #[test]
+    fn command_backend_preserves_args_and_env() {
+        let json = r#"{
+            "mcpServers": {
+                "local": {
+                    "command": "python",
+                    "args": ["server.py"],
+                    "env": { "API_KEY": "test-value" }
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(backend.command, "python");
+        assert_eq!(backend.args, ["server.py"]);
+        assert_eq!(backend.env["API_KEY"], "test-value");
+    }
+
+    #[test]
+    fn url_backend_preserves_headers_and_disables_oauth() {
+        let json = r#"{
+            "mcpServers": {
+                "remote": {
+                    "url": "https://example.test/mcp",
+                    "headers": { "Authorization": "Bearer test-token" },
+                    "oauthAppName": "Test Agent"
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(backend.command, "https://example.test/mcp");
+        assert_eq!(backend.headers["Authorization"], "Bearer test-token");
+        assert_eq!(backend.oauth_app_name.as_deref(), Some("Test Agent"));
+        assert!(!backend.should_use_oauth());
+    }
+
+    #[test]
+    fn url_backend_without_headers_uses_oauth() {
+        let json = r#"{"mcpServers":{"remote":{"url":"https://example.test/mcp"}}}"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert!(backend.should_use_oauth());
+    }
+
+    /// Only an `Authorization` header opts a remote backend out of OAuth. A
+    /// tracing or tenant header must not silently disable login, which is how
+    /// the same backend behaves when configured on the CLI.
+    #[test]
+    fn url_backend_with_non_auth_headers_still_uses_oauth() {
+        let json = r#"{
+            "mcpServers": {
+                "remote": {
+                    "url": "https://example.test/mcp",
+                    "headers": { "X-Trace-Id": "abc123" }
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(backend.headers["X-Trace-Id"], "abc123");
+        assert!(backend.should_use_oauth());
+    }
+
+    /// `BackendServerConfig::new` parses `-H` and `--env` out of `args`, so the
+    /// explicit config maps must merge with them rather than wipe them.
+    #[test]
+    fn config_maps_merge_with_values_parsed_from_args() {
+        let json = r#"{
+            "mcpServers": {
+                "remote": {
+                    "url": "https://example.test/mcp",
+                    "args": ["-H", "X-From-Args=args-value"],
+                    "headers": { "X-From-Config": "config-value" }
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(backend.headers["X-From-Args"], "args-value");
+        assert_eq!(backend.headers["X-From-Config"], "config-value");
+    }
+
+    #[test]
+    fn explicit_headers_override_parsed_headers_case_insensitively() {
+        let json = r#"{
+            "mcpServers": {
+                "remote": {
+                    "url": "https://example.test/mcp",
+                    "args": ["-H", "authorization=stale"],
+                    "headers": { "Authorization": "current" }
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(backend.headers.len(), 1);
+        assert_eq!(backend.headers["Authorization"], "current");
+    }
+
+    /// Env values are interpolated exactly like header values and like the
+    /// TypeScript config loader, so `${VAR}` placeholders resolve.
+    #[test]
+    fn config_env_values_interpolate_environment_variables() {
+        std::env::set_var("MCP_COMPRESSOR_TOPOLOGY_TEST", "resolved");
+        let json = r#"{
+            "mcpServers": {
+                "local": {
+                    "command": "python",
+                    "env": { "TOKEN": "${MCP_COMPRESSOR_TOPOLOGY_TEST}" }
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(backend.env["TOKEN"], "resolved");
+    }
+
+    #[test]
+    fn config_header_values_interpolate_environment_variables_once() {
+        std::env::set_var(
+            "MCP_COMPRESSOR_HEADER_OUTER_TEST",
+            "${MCP_COMPRESSOR_HEADER_INNER_TEST}",
+        );
+        std::env::set_var("MCP_COMPRESSOR_HEADER_INNER_TEST", "expanded twice");
+        let json = r#"{
+            "mcpServers": {
+                "remote": {
+                    "url": "https://example.test/mcp",
+                    "headers": { "X-Token": "${MCP_COMPRESSOR_HEADER_OUTER_TEST}" }
+                }
+            }
+        }"#;
+        let backend = MCPConfig::from_json(json)
+            .unwrap()
+            .into_backend_configs()
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(
+            backend.headers["X-Token"],
+            "${MCP_COMPRESSOR_HEADER_INNER_TEST}"
+        );
+    }
+
+    #[test]
+    fn server_requires_exactly_one_transport() {
+        for json in [
+            r#"{"mcpServers":{"invalid":{}}}"#,
+            r#"{"mcpServers":{"invalid":{"command":"python","url":"https://example.test/mcp"}}}"#,
+        ] {
+            let error = MCPConfig::from_json(json).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("must define exactly one of command or url"));
+        }
+    }
+
+    #[test]
+    fn url_backend_rejects_invalid_or_non_http_urls() {
+        for url in ["", "not-a-url", "ftp://example.test/mcp"] {
+            let json = serde_json::json!({
+                "mcpServers": { "remote": { "url": url } }
+            });
+            let error = MCPConfig::from_json(&json.to_string()).unwrap_err();
+            assert!(
+                error.to_string().contains("valid HTTP(S) URL"),
+                "url {url:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn url_backend_normalizes_case_insensitive_http_scheme() {
+        let backend =
+            MCPConfig::from_json(r#"{"mcpServers":{"remote":{"url":"HTTP://example.test/mcp"}}}"#)
+                .unwrap()
+                .into_backend_configs()
+                .unwrap()
+                .remove(0);
+
+        assert_eq!(
+            backend.transport,
+            crate::server::BackendTransport::StreamableHttp
+        );
+        assert_eq!(backend.command, "http://example.test/mcp");
     }
 
     /// A server with no `args` key defaults to an empty arg list.
@@ -172,7 +511,10 @@ mod tests {
             }
         }"#;
         let config = MCPConfig::from_json(json).unwrap();
-        assert_eq!(config.server_names(), vec!["alpha-server", "mango-server", "zebra-server"]);
+        assert_eq!(
+            config.server_names(),
+            vec!["alpha-server", "mango-server", "zebra-server"]
+        );
     }
 
     // ------------------------------------------------------------------
@@ -203,10 +545,23 @@ mod tests {
         assert!(MCPConfig::from_json("").is_err());
     }
 
-    /// A JSON object missing the `mcpServers` key returns an error.
     #[test]
-    fn missing_mcp_servers_key_is_error() {
-        assert!(MCPConfig::from_json(r#"{"servers": {}}"#).is_err());
+    fn servers_envelope_is_accepted() {
+        let config =
+            MCPConfig::from_json(r#"{"servers":{"remote":{"url":"https://example.test/mcp"}}}"#)
+                .unwrap();
+
+        assert_eq!(config.server_names(), ["remote"]);
+    }
+
+    #[test]
+    fn config_requires_exactly_one_server_envelope() {
+        for json in [r#"{}"#, r#"{"mcpServers":{},"servers":{}}"#] {
+            let error = MCPConfig::from_json(json).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("exactly one of mcpServers or servers"));
+        }
     }
 
     // ------------------------------------------------------------------

--- a/crates/mcp-compressor-core/src/ffi/dto.rs
+++ b/crates/mcp-compressor-core/src/ffi/dto.rs
@@ -23,6 +23,10 @@ pub struct FfiMcpServer {
     pub args: Vec<String>,
     pub env: Vec<(String, String)>,
     pub cli_prefix: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub headers: Vec<(String, String)>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth_app_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/mcp-compressor-core/src/ffi/pure.rs
+++ b/crates/mcp-compressor-core/src/ffi/pure.rs
@@ -51,6 +51,14 @@ pub fn parse_mcp_config(config_json: &str) -> Result<Vec<FfiMcpServer>, Error> {
             let server = config
                 .server(&name)
                 .ok_or_else(|| Error::Config(format!("server not found: {name}")))?;
+            let (headers, oauth_app_name) = config
+                .server_metadata(&name)
+                .ok_or_else(|| Error::Config(format!("server metadata not found: {name}")))?;
+            let mut headers = headers
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect::<Vec<_>>();
+            headers.sort_by(|(left, _), (right, _)| left.cmp(right));
             Ok(FfiMcpServer {
                 cli_prefix: config.cli_prefix(&name),
                 name,
@@ -61,6 +69,8 @@ pub fn parse_mcp_config(config_json: &str) -> Result<Vec<FfiMcpServer>, Error> {
                     .iter()
                     .map(|(key, value)| (key.clone(), value.clone()))
                     .collect(),
+                headers,
+                oauth_app_name: oauth_app_name.map(str::to_string),
             })
         })
         .collect()

--- a/crates/mcp-compressor-core/src/ffi/pure.rs
+++ b/crates/mcp-compressor-core/src/ffi/pure.rs
@@ -44,12 +44,14 @@ pub fn render_cli_subcommand_help(cli_name: String, tool: FfiTool) -> String {
 
 pub fn parse_mcp_config(config_json: &str) -> Result<Vec<FfiMcpServer>, Error> {
     let config = MCPConfig::from_json(config_json)?;
-    Ok(config
+    config
         .server_names()
         .into_iter()
-        .filter_map(|name| {
-            let server = config.server(&name)?;
-            Some(FfiMcpServer {
+        .map(|name| {
+            let server = config
+                .server(&name)
+                .ok_or_else(|| Error::Config(format!("server not found: {name}")))?;
+            Ok(FfiMcpServer {
                 cli_prefix: config.cli_prefix(&name),
                 name,
                 command: server.command.clone(),
@@ -61,5 +63,5 @@ pub fn parse_mcp_config(config_json: &str) -> Result<Vec<FfiMcpServer>, Error> {
                     .collect(),
             })
         })
-        .collect())
+        .collect()
 }

--- a/crates/mcp-compressor-core/src/ffi/types.rs
+++ b/crates/mcp-compressor-core/src/ffi/types.rs
@@ -415,13 +415,14 @@ mod tests {
 
     #[test]
     fn ffi_parses_mcp_config() {
+        std::env::set_var("MCP_COMPRESSOR_FFI_RAW_ENV_TEST", "resolved");
         let parsed = parse_mcp_config(
             r#"{
                 "mcpServers": {
                     "my server": {
                         "command": "python3",
                         "args": ["server.py"],
-                        "env": { "A": "B" }
+                        "env": { "A": "${MCP_COMPRESSOR_FFI_RAW_ENV_TEST}" }
                     }
                 }
             }"#,
@@ -430,6 +431,34 @@ mod tests {
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].name, "my server");
         assert_eq!(parsed[0].cli_prefix, "my-server");
-        assert_eq!(parsed[0].env, vec![("A".to_string(), "B".to_string())]);
+        assert_eq!(
+            parsed[0].env,
+            vec![(
+                "A".to_string(),
+                "${MCP_COMPRESSOR_FFI_RAW_ENV_TEST}".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn ffi_preserves_remote_mcp_config_metadata() {
+        let parsed = parse_mcp_config(
+            r#"{
+                "mcpServers": {
+                    "remote": {
+                        "url": "https://example.test/mcp",
+                        "headers": { "X-Tenant": "tenant-123" },
+                        "oauthAppName": "Test Agent"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            parsed[0].headers,
+            vec![("X-Tenant".to_string(), "tenant-123".to_string())]
+        );
+        assert_eq!(parsed[0].oauth_app_name.as_deref(), Some("Test Agent"));
     }
 }

--- a/crates/mcp-compressor-core/src/server/backend.rs
+++ b/crates/mcp-compressor-core/src/server/backend.rs
@@ -339,7 +339,7 @@ fn parse_key_value_arg(value: &str) -> Option<(String, String)> {
     Some((key.to_string(), value.to_string()))
 }
 
-fn interpolate_env(value: &str) -> String {
+pub(crate) fn interpolate_env(value: &str) -> String {
     let mut output = String::new();
     let chars = value.chars().collect::<Vec<_>>();
     let mut index = 0;
@@ -391,6 +391,15 @@ mod tests {
         assert!(backend.args.is_empty());
         assert_eq!(backend.headers["Authorization"], "Bearer token");
         assert_eq!(backend.headers["X-Test"], "yes");
+    }
+
+    #[test]
+    fn direct_headers_preserve_environment_placeholders() {
+        let backend =
+            BackendServerConfig::new("remote", "https://example.test/mcp", [] as [&str; 0])
+                .with_headers([("X-Test-Path", "${PATH}")]);
+
+        assert_eq!(backend.headers["X-Test-Path"], "${PATH}");
     }
 
     #[test]

--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -150,17 +150,7 @@ impl CompressedServer {
         config: CompressedServerConfig,
         mcp_config_json: &str,
     ) -> Result<Self, Error> {
-        let mcp_config = MCPConfig::from_json(mcp_config_json)?;
-        let mut backends = Vec::new();
-        for name in mcp_config.server_names() {
-            let server = mcp_config
-                .server(&name)
-                .ok_or_else(|| Error::Config(format!("server not found: {name}")))?;
-            backends.push(
-                BackendServerConfig::new(name, server.command.clone(), server.args.clone())
-                    .with_env(server.env.clone()),
-            );
-        }
+        let backends = MCPConfig::from_json(mcp_config_json)?.into_backend_configs()?;
 
         if backends.len() == 1 {
             let backend = backends.into_iter().next().expect("one backend exists");

--- a/crates/mcp-compressor-core/src/server/connect.rs
+++ b/crates/mcp-compressor-core/src/server/connect.rs
@@ -125,6 +125,7 @@ async fn connect_streamable_http_backend(
 async fn connect_oauth_streamable_http_backend(
     backend: &BackendServerConfig,
 ) -> Result<RunningService<RoleClient, ()>, Error> {
+    let http_client = oauth_http_client(backend)?;
     let mut manager = AuthorizationManager::new(backend.command.as_str())
         .await
         .map_err(|error| Error::Config(format!("failed to initialize OAuth manager: {error}")))?;
@@ -153,7 +154,12 @@ async fn connect_oauth_streamable_http_backend(
             .start_authorization(
                 &[],
                 &redirect_uri,
-                Some(backend.oauth_app_name.as_deref().unwrap_or("mcp-compressor")),
+                Some(
+                    backend
+                        .oauth_app_name
+                        .as_deref()
+                        .unwrap_or("mcp-compressor"),
+                ),
             )
             .await
             .map_err(|error| {
@@ -192,7 +198,7 @@ async fn connect_oauth_streamable_http_backend(
         })?;
     }
 
-    let client = AuthClient::new(reqwest::Client::default(), manager);
+    let client = AuthClient::new(http_client, manager);
     let transport = StreamableHttpClientTransport::with_client(
         client,
         StreamableHttpClientTransportConfig::with_uri(backend.command.clone()),
@@ -202,6 +208,14 @@ async fn connect_oauth_streamable_http_backend(
         .map_err(|error| remote_backend_error(&backend.command, error.to_string()))
 }
 
+fn oauth_http_client(backend: &BackendServerConfig) -> Result<reqwest::Client, Error> {
+    let headers = backend_http_headers(backend)?.into_iter().collect();
+    reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .map_err(|error| Error::Config(format!("failed to build OAuth HTTP client: {error}")))
+}
+
 fn remote_backend_error(uri: &str, error: String) -> Error {
     let auth_hint = if error.contains("401")
         || error.contains("403")
@@ -209,11 +223,11 @@ fn remote_backend_error(uri: &str, error: String) -> Error {
         || error.to_ascii_lowercase().contains("unauthorized")
     {
         "\n\nThis remote MCP server appears to require authentication. \
-Pass explicit backend headers after the URL, for example: \
-`-- <url> -H \"Authorization=Bearer <token>\"`. Native OAuth support is not implemented yet."
+For direct URL mode, pass explicit backend headers with the full command, for example: \
+`mcp-compressor -- <url> -H \"Authorization=Bearer <token>\"`. Use native OAuth by omitting the `Authorization` header; other configured headers are sent alongside OAuth. For MCP JSON config, set valid headers in the server headers object."
     } else {
-        "\n\nIf this remote MCP server requires authentication, pass explicit backend headers after the URL, \
-for example: `-- <url> -H \"Authorization=Bearer <token>\"`. Native OAuth support is not implemented yet."
+        "\n\nIf this remote MCP server requires authentication, use native OAuth or configure explicit headers. For direct URL mode, pass explicit backend headers with the full command, \
+for example: `mcp-compressor -- <url> -H \"Authorization=Bearer <token>\"`. Use native OAuth by omitting the `Authorization` header; other configured headers are sent alongside OAuth. For MCP JSON config, set valid headers in the server headers object."
     };
     Error::Config(format!(
         "failed to initialize remote streamable HTTP backend {uri}: {error}{auth_hint}"
@@ -226,4 +240,59 @@ fn convert_tool(tool: rmcp::model::Tool) -> Tool {
         tool.description.map(|description| description.to_string()),
         Value::Object((*tool.input_schema).clone()),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn oauth_http_client_sends_configured_headers() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let read = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .unwrap();
+            String::from_utf8_lossy(&request[..read]).into_owned()
+        });
+        let backend =
+            BackendServerConfig::new("remote", format!("http://{address}/mcp"), [] as [&str; 0])
+                .with_headers([("X-Tenant", "tenant-123")]);
+
+        oauth_http_client(&backend)
+            .unwrap()
+            .get(format!("http://{address}/mcp"))
+            .send()
+            .await
+            .unwrap();
+
+        assert!(server
+            .join()
+            .unwrap()
+            .to_ascii_lowercase()
+            .contains("x-tenant: tenant-123"));
+    }
+
+    #[tokio::test]
+    async fn oauth_backend_validates_headers_before_authorization() {
+        let backend = BackendServerConfig::new(
+            "remote",
+            "http://127.0.0.1:0/mcp",
+            [] as [&str; 0],
+        )
+        .with_headers([("invalid header", "value")]);
+
+        let error = connect_oauth_streamable_http_backend(&backend)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("invalid HTTP header name"));
+    }
 }

--- a/crates/mcp-compressor-core/tests/common/mod.rs
+++ b/crates/mcp-compressor-core/tests/common/mod.rs
@@ -5,6 +5,7 @@ use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::server::{
     BackendConfigSource, BackendServerConfig, CompressedServerConfig, ProxyTransformMode,
 };
+use serde_json::json;
 
 /// A spawned child process that is killed, with its descendants, when dropped.
 ///
@@ -145,13 +146,11 @@ pub fn mcp_config_json(backends: &[(&str, &str)]) -> String {
         .iter()
         .map(|(name, fixture)| {
             let path = fixture_path(fixture).to_string_lossy().into_owned();
-            format!(
-                r#""{name}":{{"command":"{}","args":["{}"]}}"#,
-                python_command(),
-                path
+            (
+                name.to_string(),
+                json!({ "command": python_command(), "args": [path] }),
             )
         })
-        .collect::<Vec<_>>()
-        .join(",");
-    format!(r#"{{"mcpServers":{{{servers}}}}}"#)
+        .collect::<serde_json::Map<_, _>>();
+    json!({ "mcpServers": servers }).to_string()
 }

--- a/crates/mcp-compressor-core/tests/config_sources.rs
+++ b/crates/mcp-compressor-core/tests/config_sources.rs
@@ -1,8 +1,12 @@
 mod common;
 
+use std::time::Duration;
+
 use mcp_compressor_core::compression::CompressionLevel;
 use mcp_compressor_core::server::{BackendConfigSource, CompressedServer, ProxyTransformMode};
 use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 
 #[tokio::test]
 async fn single_server_direct_command_config_connects_and_invokes() {
@@ -123,4 +127,72 @@ async fn multi_server_json_mcp_config_connects_and_routes() {
         .unwrap();
     assert_eq!(alpha, "10");
     assert_eq!(beta, "20");
+}
+
+#[tokio::test]
+async fn remote_json_mcp_config_uses_url_and_headers() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let request_task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream.read(&mut buffer).await.unwrap();
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..read]);
+        }
+        stream
+            .write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+        String::from_utf8(request).unwrap()
+    });
+    let config_json = json!({
+        "mcpServers": {
+            "remote": {
+                "url": format!("http://{address}/mcp"),
+                "headers": { "Authorization": "Bearer test-token" }
+            }
+        }
+    })
+    .to_string();
+
+    let result = CompressedServer::connect_mcp_config_json(
+        common::config(
+            CompressionLevel::Max,
+            None,
+            ProxyTransformMode::CompressedTools,
+            BackendConfigSource::SingleServerJsonConfig,
+        ),
+        &config_json,
+    )
+    .await;
+    let error = match result {
+        Ok(_) => panic!("401 fixture should reject the remote backend"),
+        Err(error) => error,
+    };
+    assert!(
+        !error.to_string().contains("missing field `command`"),
+        "remote URL configuration must not require a command: {error}"
+    );
+    let request = tokio::time::timeout(Duration::from_secs(5), request_task)
+        .await
+        .expect("remote backend should connect to the loopback fixture")
+        .unwrap();
+
+    assert!(
+        request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-token"),
+        "remote backend must forward configured headers"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("failed to initialize remote streamable HTTP backend"),
+        "remote URL configuration must use streamable HTTP: {error}"
+    );
 }

--- a/crates/mcp-compressor-core/tests/config_sources.rs
+++ b/crates/mcp-compressor-core/tests/config_sources.rs
@@ -131,6 +131,7 @@ async fn multi_server_json_mcp_config_connects_and_routes() {
 
 #[tokio::test]
 async fn remote_json_mcp_config_uses_url_and_headers() {
+    let authorization = "Bearer test-token";
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let request_task = tokio::spawn(async move {
@@ -154,7 +155,7 @@ async fn remote_json_mcp_config_uses_url_and_headers() {
         "mcpServers": {
             "remote": {
                 "url": format!("http://{address}/mcp"),
-                "headers": { "Authorization": "Bearer test-token" }
+                "headers": { "Authorization": authorization }
             }
         }
     })
@@ -184,9 +185,10 @@ async fn remote_json_mcp_config_uses_url_and_headers() {
         .unwrap();
 
     assert!(
-        request
-            .to_ascii_lowercase()
-            .contains("authorization: bearer test-token"),
+        request.to_ascii_lowercase().contains(&format!(
+            "authorization: {}",
+            authorization.to_ascii_lowercase()
+        )),
         "remote backend must forward configured headers"
     );
     assert!(

--- a/crates/mcp-compressor/tests/public_api.rs
+++ b/crates/mcp-compressor/tests/public_api.rs
@@ -1,13 +1,28 @@
 use mcp_compressor::compression::CompressionLevel;
 use mcp_compressor::sdk::{CompressorClient, CompressorMode, GeneratedClientKind, ServerConfig};
+use std::collections::HashMap;
 
 #[test]
 fn public_crate_exports_expected_sdk_surface() {
     let _client = CompressorClient::builder()
-        .server("alpha", ServerConfig::command("python").arg("alpha_server.py"))
+        .server(
+            "alpha",
+            ServerConfig::command("python").arg("alpha_server.py"),
+        )
         .compression_level(CompressionLevel::Max)
         .mode(CompressorMode::CompressedTools)
         .build();
 
     let _kind = GeneratedClientKind::Python;
+}
+
+#[test]
+fn topology_server_config_preserves_public_fields() {
+    let config = mcp_compressor::config::topology::ServerConfig {
+        command: "python".to_string(),
+        args: vec!["server.py".to_string()],
+        env: HashMap::new(),
+    };
+
+    assert_eq!(config.command, "python");
 }

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -52,6 +52,7 @@ The format is `name=command [args...]`. This adds one backend per flag value.
 ## MCP config JSON
 
 MCP config JSON is the easiest way to describe multiple backends.
+The server map may use either the `mcpServers` or `servers` envelope, but not both in the same file.
 
 ```json
 {
@@ -74,7 +75,7 @@ mcp-compressor -c medium --config mcp.json
 ```
 
 !!! note
-    `--server-name` cannot be combined with `--config`. When using a config file, server names come from the `mcpServers` keys.
+    `--server-name` cannot be combined with `--config`. When using a config file, server names come from the selected server-map keys.
 
 For providers that require OAuth, the URL-only form triggers native OAuth. For non-interactive CI or static-token providers, add explicit headers:
 

--- a/python/mcp-compressor/tests/test_core.py
+++ b/python/mcp-compressor/tests/test_core.py
@@ -463,3 +463,21 @@ def test_native_extension_parses_mcp_config() -> None:
             "cli_prefix": "my-server",
         }
     ]
+
+
+def test_native_extension_preserves_remote_mcp_config_metadata() -> None:
+    parsed = parse_mcp_config(
+        '{"mcpServers":{"remote":{"url":"https://example.test/mcp",'
+        '"headers":{"X-Tenant":"tenant-123"},"oauthAppName":"Test Agent"}}}'
+    )
+    assert parsed == [
+        {
+            "name": "remote",
+            "command": "https://example.test/mcp",
+            "args": [],
+            "env": [],
+            "cli_prefix": "remote",
+            "headers": [["X-Tenant", "tenant-123"]],
+            "oauth_app_name": "Test Agent",
+        }
+    ]

--- a/typescript/src/rust_core.ts
+++ b/typescript/src/rust_core.ts
@@ -256,6 +256,8 @@ export interface ParsedMcpServer {
   args: string[];
   env: Array<[string, string]>;
   cli_prefix: string;
+  headers?: Array<[string, string]>;
+  oauth_app_name?: string;
 }
 
 export function parseMcpConfig(configJson: string): ParsedMcpServer[] {

--- a/typescript/tests/rust_core.test.ts
+++ b/typescript/tests/rust_core.test.ts
@@ -1447,4 +1447,22 @@ describe("Rust native core wrapper", () => {
       },
     ]);
   });
+
+  it("preserves remote MCP config metadata through the native addon", () => {
+    expect(
+      parseMcpConfig(
+        '{"mcpServers":{"remote":{"url":"https://example.test/mcp","headers":{"X-Tenant":"tenant-123"},"oauthAppName":"Test Agent"}}}',
+      ),
+    ).toEqual([
+      {
+        name: "remote",
+        command: "https://example.test/mcp",
+        args: [],
+        env: [],
+        cli_prefix: "remote",
+        headers: [["X-Tenant", "tenant-123"]],
+        oauth_app_name: "Test Agent",
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- accept remote URL backends from either the `mcpServers` or `servers` JSON envelope while rejecting ambiguous configurations
- validate HTTP(S) URLs, preserve the public topology configuration shape, and merge headers case-insensitively
- retain configured non-authorization headers during OAuth and validate headers before authorization starts
- document the supported server-map envelopes and add integration/public API regression coverage

## Test plan

- `cargo test -p mcp-compressor-core config::topology::tests --lib -- --nocapture`
- `cargo test -p mcp-compressor-core server::backend::tests --lib -- --nocapture`
- `cargo test -p mcp-compressor-core server::connect::tests --lib -- --nocapture`
- `cargo test -p mcp-compressor-core --test config_sources`
- `cargo test -p mcp-compressor-core --lib`
- `cargo test -p mcp-compressor --test public_api`
- `uv run python scripts/check_public_api_names.py`
- `uv run mkdocs build -s`
- `uv run pre-commit run --all-files`