### PR TITLE
fix: report a stopped proxy on Windows in generated Python clients

### DIFF
--- a/crates/mcp-compressor-core/src/client_gen/python.rs
+++ b/crates/mcp-compressor-core/src/client_gen/python.rs
@@ -61,10 +61,11 @@ def _exec(tool: str, tool_input: dict) -> str:
     except urllib.error.HTTPError as exc:
         message = exc.read().decode(errors="replace") or exc.reason
         raise RuntimeError(f"mcp-compressor proxy returned HTTP {{exc.code}}: {{message}}") from None
-    except urllib.error.URLError as exc:
+    except OSError as exc:
+        details = getattr(exc, "reason", exc)
         raise RuntimeError(
             "mcp-compressor proxy is not running; restart the mcp-compressor process and try again. "
-            f"details: {{exc.reason}}"
+            f"details: {{details}}"
         ) from None
 "#,
         bridge = config.bridge_url,


### PR DESCRIPTION
## Summary

- catch bare Windows `ConnectionRefusedError` failures in generated Python clients
- preserve the existing actionable stopped-proxy error instead of exposing a urllib traceback
- retain `HTTPError` handling before the broader `OSError` branch

## Tests

- `cargo test -p mcp-compressor-core --test generated_clients generated_python_module_reports_stopped_proxy_without_urllib_traceback -- --nocapture`
- `cargo test -p mcp-compressor-core client_gen::python::tests --lib`
- `cargo test -p mcp-compressor-core --lib`