### PR TITLE
fix: run the CLI entrypoint on a stack it sizes itself

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,7 @@ jobs:
           timeout 180 cargo test -p mcp-compressor-core --test proxy_http -- --nocapture
           timeout 180 cargo test -p mcp-compressor-core --test generated_clients -- --nocapture
           timeout 180 cargo test -p mcp-compressor-core --test cli_binary -- --nocapture
+          timeout 180 cargo test -p mcp-compressor-core --test cli_stack -- --nocapture
           timeout 180 cargo test -p mcp-compressor-core --test transform_modes -- --nocapture
 
   rust-binary-e2e:

--- a/crates/mcp-compressor-core/src/app/entrypoint.rs
+++ b/crates/mcp-compressor-core/src/app/entrypoint.rs
@@ -37,8 +37,26 @@ where
     I: IntoIterator<Item = T>,
     T: Into<std::ffi::OsString> + Clone,
 {
+    let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
+    // Neither argument parsing nor the top-level future is small, and the stack
+    // they would otherwise run on is not ours to size: the process main thread
+    // gets 1 MiB on Windows, and embedders can call this from any thread. Do the
+    // whole run on a thread whose stack we control, and give the runtime's
+    // worker threads the same reserve so spawned work has equal headroom.
+    std::thread::Builder::new()
+        .stack_size(CLI_STACK_SIZE)
+        .spawn(move || run_on_current_thread(args))
+        .map_err(|error| CliError::Runtime(error.to_string()))?
+        .join()
+        .unwrap_or_else(|_| Err(CliError::Runtime("compressor run panicked".to_string())))
+}
+
+fn run_on_current_thread(args: Vec<std::ffi::OsString>) -> Result<(), CliError> {
     let cli = CliOptions::try_parse_from(args).map_err(|error| {
-        if matches!(error.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+        if matches!(
+            error.kind(),
+            ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+        ) {
             CliError::Display(error.to_string())
         } else {
             CliError::Usage(error.to_string())
@@ -46,10 +64,19 @@ where
     })?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
+        .thread_stack_size(CLI_STACK_SIZE)
         .build()
         .map_err(|error| CliError::Runtime(error.to_string()))?;
     runtime.block_on(async move { run_async(cli).await })
 }
+
+/// Stack size for the thread that parses arguments and drives the CLI runtime,
+/// and for the runtime's own worker threads.
+///
+/// Sized for headroom rather than measured need: the aggregated startup,
+/// discovery and transform state machine grows as command paths are added, and
+/// an overflow aborts the process with no usable diagnostic.
+const CLI_STACK_SIZE: usize = 16 * 1024 * 1024;
 
 async fn run_async(cli: CliOptions) -> Result<(), CliError> {
     cli.validate().map_err(CliError::Usage)?;

--- a/crates/mcp-compressor-core/src/app/entrypoint.rs
+++ b/crates/mcp-compressor-core/src/app/entrypoint.rs
@@ -43,12 +43,18 @@ where
     // gets 1 MiB on Windows, and embedders can call this from any thread. Do the
     // whole run on a thread whose stack we control, and give the runtime's
     // worker threads the same reserve so spawned work has equal headroom.
-    std::thread::Builder::new()
+    let thread = std::thread::Builder::new()
         .stack_size(CLI_STACK_SIZE)
         .spawn(move || run_on_current_thread(args))
-        .map_err(|error| CliError::Runtime(error.to_string()))?
-        .join()
-        .unwrap_or_else(|_| Err(CliError::Runtime("compressor run panicked".to_string())))
+        .map_err(|error| CliError::Runtime(error.to_string()))?;
+    join_entrypoint_thread(thread)
+}
+
+fn join_entrypoint_thread<T>(thread: std::thread::JoinHandle<T>) -> T {
+    match thread.join() {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
 }
 
 fn run_on_current_thread(args: Vec<std::ffi::OsString>) -> Result<(), CliError> {
@@ -229,4 +235,26 @@ pub enum CliError {
     Display(String),
     Usage(String),
     Runtime(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::join_entrypoint_thread;
+
+    #[test]
+    fn join_entrypoint_thread_preserves_panic_payload() {
+        let thread = std::thread::spawn(|| {
+            std::panic::panic_any(String::from("entrypoint panic payload"));
+        });
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            join_entrypoint_thread(thread)
+        }))
+        .expect_err("the entrypoint panic must resume on the caller");
+
+        assert_eq!(
+            panic.downcast_ref::<String>().map(String::as_str),
+            Some("entrypoint panic payload")
+        );
+    }
 }

--- a/crates/mcp-compressor-core/tests/cli_stack.rs
+++ b/crates/mcp-compressor-core/tests/cli_stack.rs
@@ -1,0 +1,66 @@
+mod common;
+
+use std::time::Duration;
+
+use mcp_compressor_core::app::entrypoint::run_from;
+
+/// A caller stack far below what argument parsing plus the CLI's top-level
+/// future needs. Measured on Windows debug builds: without the entrypoint's own
+/// sized thread, the run overflows even at 512 KiB, while with it 128 KiB is
+/// still enough, so this sits clear of both bounds.
+const SMALL_CALLER_STACK_SIZE: usize = 256 * 1024;
+
+/// `run_from` must run on a stack it sizes itself, not on the caller's.
+///
+/// The process main thread reserves 1 MiB on Windows and is not ours to resize,
+/// and embedders may call the entrypoint from any thread. Both `clap` parsing
+/// and the aggregated startup/discovery/transform future are large and grow as
+/// command paths are added, and exhausting the stack aborts the whole process
+/// with only "has overflowed its stack" and no backtrace.
+///
+/// Driving the entrypoint from a deliberately small thread pins that guarantee:
+/// without the re-spawn the test binary dies with STATUS_STACK_OVERFLOW rather
+/// than failing an assertion.
+#[test]
+fn cli_entrypoint_runs_on_its_own_stack_not_the_callers() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config_path = tempdir.path().join("mcp.json");
+    // Serialized rather than interpolated: the fixture path is absolute, and on
+    // Windows its separators would otherwise land in the JSON as escapes.
+    let config = serde_json::json!({
+        "mcpServers": {
+            "alpha": {
+                "command": common::python_command(),
+                "args": [common::fixture_path("alpha_server.py")],
+            }
+        }
+    });
+    std::fs::write(&config_path, config.to_string()).unwrap();
+
+    std::env::set_var("MCP_COMPRESSOR_EXIT_AFTER_READY", "1");
+
+    let worker = std::thread::Builder::new()
+        .stack_size(SMALL_CALLER_STACK_SIZE)
+        .spawn(move || {
+            run_from([
+                "mcp-compressor".to_string(),
+                "--just-bash".to_string(),
+                "--config".to_string(),
+                config_path.to_string_lossy().into_owned(),
+            ])
+        })
+        .expect("spawn small-stack caller");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    while !worker.is_finished() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the entrypoint did not return"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let result = worker.join().expect("the entrypoint thread panicked");
+    std::env::remove_var("MCP_COMPRESSOR_EXIT_AFTER_READY");
+    result.expect("the entrypoint must complete from a small caller stack");
+}

--- a/crates/mcp-compressor-core/tests/cli_stack.rs
+++ b/crates/mcp-compressor-core/tests/cli_stack.rs
@@ -1,8 +1,41 @@
 mod common;
 
-use std::time::Duration;
+use std::{ffi::OsString, sync::Mutex};
 
 use mcp_compressor_core::app::entrypoint::run_from;
+
+const EXIT_AFTER_READY_ENV: &str = "MCP_COMPRESSOR_EXIT_AFTER_READY";
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn capture(name: &'static str) -> Self {
+        Self {
+            name,
+            previous: std::env::var_os(name),
+        }
+    }
+
+    fn set(name: &'static str, value: &str) -> Self {
+        let guard = Self::capture(name);
+        std::env::set_var(name, value);
+        guard
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var(self.name, previous);
+        } else {
+            std::env::remove_var(self.name);
+        }
+    }
+}
 
 /// A caller stack far below what argument parsing plus the CLI's top-level
 /// future needs. Measured on Windows debug builds: without the entrypoint's own
@@ -23,6 +56,9 @@ const SMALL_CALLER_STACK_SIZE: usize = 256 * 1024;
 /// than failing an assertion.
 #[test]
 fn cli_entrypoint_runs_on_its_own_stack_not_the_callers() {
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let tempdir = tempfile::tempdir().unwrap();
     let config_path = tempdir.path().join("mcp.json");
     // Serialized rather than interpolated: the fixture path is absolute, and on
@@ -37,7 +73,7 @@ fn cli_entrypoint_runs_on_its_own_stack_not_the_callers() {
     });
     std::fs::write(&config_path, config.to_string()).unwrap();
 
-    std::env::set_var("MCP_COMPRESSOR_EXIT_AFTER_READY", "1");
+    let _exit_after_ready = EnvVarGuard::set(EXIT_AFTER_READY_ENV, "1");
 
     let worker = std::thread::Builder::new()
         .stack_size(SMALL_CALLER_STACK_SIZE)
@@ -51,16 +87,40 @@ fn cli_entrypoint_runs_on_its_own_stack_not_the_callers() {
         })
         .expect("spawn small-stack caller");
 
-    let deadline = std::time::Instant::now() + Duration::from_secs(120);
-    while !worker.is_finished() {
-        assert!(
-            std::time::Instant::now() < deadline,
-            "the entrypoint did not return"
-        );
-        std::thread::sleep(Duration::from_millis(50));
+    let result = worker.join().expect("the entrypoint thread panicked");
+    result.expect("the entrypoint must complete from a small caller stack");
+}
+
+#[test]
+fn env_var_guard_restores_previous_value_after_unwind() {
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _original = EnvVarGuard::set(EXIT_AFTER_READY_ENV, "original");
+
+    let panic = std::panic::catch_unwind(|| {
+        let _changed = EnvVarGuard::set(EXIT_AFTER_READY_ENV, "changed");
+        panic!("simulate test failure");
+    });
+
+    assert!(panic.is_err());
+    assert_eq!(
+        std::env::var_os(EXIT_AFTER_READY_ENV),
+        Some("original".into())
+    );
+}
+
+#[test]
+fn env_var_guard_removes_value_that_was_initially_absent() {
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _original = EnvVarGuard::capture(EXIT_AFTER_READY_ENV);
+    std::env::remove_var(EXIT_AFTER_READY_ENV);
+
+    {
+        let _changed = EnvVarGuard::set(EXIT_AFTER_READY_ENV, "changed");
     }
 
-    let result = worker.join().expect("the entrypoint thread panicked");
-    std::env::remove_var("MCP_COMPRESSOR_EXIT_AFTER_READY");
-    result.expect("the entrypoint must complete from a small caller stack");
+    assert_eq!(std::env::var_os(EXIT_AFTER_READY_ENV), None);
 }


### PR DESCRIPTION
## Problem

The CLI parsed arguments and drove its top-level async runtime on whatever stack the caller provided. On Windows, the process main thread reserves only 1 MiB, and embedded callers may provide even less.

As the CLI command surface grew, argument parsing and the aggregated startup future could exhaust that stack. A stack overflow aborts the entire process with `STATUS_STACK_OVERFLOW` and provides no usable backtrace or recoverable error, making the failure both disruptive and difficult to diagnose.

## Solution

- move argument parsing and the complete top-level runtime onto a dedicated thread with a 16 MiB stack
- give Tokio worker threads the same stack reserve
- preserve the previous panic contract by resuming the original panic payload across the new thread boundary
- restore the process-global test environment through serialized, panic-safe RAII cleanup and always join the worker before releasing that state
- execute the small-caller-stack regression in CI

## Verification

- `cargo check -p mcp-compressor-core`
- `cargo test -p mcp-compressor-core --lib join_entrypoint_thread_preserves_panic_payload`
- `cargo test -p mcp-compressor-core --test cli_stack`