### PR TITLE
fix: prefer a user-owned directory for generated CLI scripts on Windows

### DIFF
--- a/crates/mcp-compressor-core/src/app/paths.rs
+++ b/crates/mcp-compressor-core/src/app/paths.rs
@@ -10,27 +10,52 @@ pub fn cli_output_dir() -> std::io::Result<(PathBuf, bool)> {
     }
 
     let path_dirs = path_dirs();
-    for candidate in candidate_script_dirs() {
-        let resolved = candidate.canonicalize().unwrap_or(candidate.clone());
-        if resolved.is_dir() && path_dirs.iter().any(|path_dir| path_dir == &resolved) {
-            return Ok((resolved, true));
-        }
+    if let Some(output_dir) = select_script_dir(cfg!(windows), candidate_script_dirs(), &path_dirs)
+    {
+        return Ok(output_dir);
     }
 
     Ok((std::env::current_dir()?, false))
 }
 
-fn candidate_script_dirs() -> Vec<PathBuf> {
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    let mut candidates = Vec::new();
-    if cfg!(windows) {
-        if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {
-            candidates.push(
-                PathBuf::from(local_app_data)
-                    .join("Microsoft")
-                    .join("WindowsApps"),
-            );
+fn select_script_dir(
+    windows: bool,
+    candidates: Vec<PathBuf>,
+    path_dirs: &[PathBuf],
+) -> Option<(PathBuf, bool)> {
+    if windows {
+        let candidate = candidates.into_iter().next()?;
+        let resolved = candidate.canonicalize().unwrap_or(candidate);
+        let on_path = resolved.is_dir() && path_dirs.iter().any(|path_dir| path_dir == &resolved);
+        return Some((resolved, on_path));
+    }
+
+    for candidate in candidates {
+        let resolved = candidate.canonicalize().unwrap_or(candidate.clone());
+        if resolved.is_dir() && path_dirs.iter().any(|path_dir| path_dir == &resolved) {
+            return Some((resolved, true));
         }
+    }
+
+    None
+}
+
+fn candidate_script_dirs() -> Vec<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from);
+    candidate_script_dirs_for(cfg!(windows), home)
+}
+
+/// Rank the directories a generated CLI may be installed into.
+///
+/// User-owned directories come first on every platform. On Windows
+/// `%LOCALAPPDATA%\Microsoft\WindowsApps` is on `PATH` by default, but it is
+/// reserved for App Execution Aliases and is rewritten by the Store, so it is
+/// never an installation candidate.
+fn candidate_script_dirs_for(windows: bool, home: Option<PathBuf>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if windows {
         if let Some(home) = &home {
             candidates.push(home.join(".local").join("bin"));
         }
@@ -53,4 +78,58 @@ fn path_dirs() -> Vec<PathBuf> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_only_offers_the_user_owned_directory() {
+        let candidates = candidate_script_dirs_for(true, Some(PathBuf::from(r"C:\Users\dev")));
+
+        assert_eq!(
+            candidates,
+            vec![PathBuf::from(r"C:\Users\dev").join(".local").join("bin")]
+        );
+    }
+
+    #[test]
+    fn windows_has_no_implicit_install_directory_without_a_home_directory() {
+        let candidates = candidate_script_dirs_for(true, None);
+
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn windows_selects_the_user_owned_directory_even_when_only_windows_apps_is_on_path() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let user_bin = tempdir.path().join(".local").join("bin");
+        let windows_apps = tempdir.path().join("Microsoft").join("WindowsApps");
+        std::fs::create_dir_all(&windows_apps).unwrap();
+        let windows_apps = windows_apps.canonicalize().unwrap();
+
+        let selected = select_script_dir(
+            true,
+            vec![user_bin.clone(), windows_apps.clone()],
+            &[windows_apps],
+        );
+
+        assert_eq!(selected, Some((user_bin, false)));
+    }
+
+    #[test]
+    fn unix_ranks_user_directories_before_shared_prefixes() {
+        let candidates = candidate_script_dirs_for(false, Some(PathBuf::from("/home/dev")));
+
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/home/dev/.local/bin"),
+                PathBuf::from("/home/dev/bin"),
+                PathBuf::from("/usr/local/bin"),
+                PathBuf::from("/opt/homebrew/bin"),
+            ]
+        );
+    }
 }

--- a/crates/mcp-compressor-core/src/app/paths.rs
+++ b/crates/mcp-compressor-core/src/app/paths.rs
@@ -26,7 +26,11 @@ fn select_script_dir(
     if windows {
         let candidate = candidates.into_iter().next()?;
         let resolved = candidate.canonicalize().unwrap_or(candidate);
-        let on_path = resolved.is_dir() && path_dirs.iter().any(|path_dir| path_dir == &resolved);
+        let on_path = path_dirs.iter().any(|path_dir| {
+            path_dir
+                .as_os_str()
+                .eq_ignore_ascii_case(resolved.as_os_str())
+        });
         return Some((resolved, on_path));
     }
 
@@ -41,10 +45,9 @@ fn select_script_dir(
 }
 
 fn candidate_script_dirs() -> Vec<PathBuf> {
-    let home = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(PathBuf::from);
-    candidate_script_dirs_for(cfg!(windows), home)
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let user_profile = std::env::var_os("USERPROFILE").map(PathBuf::from);
+    candidate_script_dirs_for(cfg!(windows), home, user_profile)
 }
 
 /// Rank the directories a generated CLI may be installed into.
@@ -53,7 +56,12 @@ fn candidate_script_dirs() -> Vec<PathBuf> {
 /// `%LOCALAPPDATA%\Microsoft\WindowsApps` is on `PATH` by default, but it is
 /// reserved for App Execution Aliases and is rewritten by the Store, so it is
 /// never an installation candidate.
-fn candidate_script_dirs_for(windows: bool, home: Option<PathBuf>) -> Vec<PathBuf> {
+fn candidate_script_dirs_for(
+    windows: bool,
+    home: Option<PathBuf>,
+    user_profile: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let home = if windows { home.or(user_profile) } else { home };
     let mut candidates = Vec::new();
     if windows {
         if let Some(home) = &home {
@@ -86,7 +94,22 @@ mod tests {
 
     #[test]
     fn windows_only_offers_the_user_owned_directory() {
-        let candidates = candidate_script_dirs_for(true, Some(PathBuf::from(r"C:\Users\dev")));
+        let candidates = candidate_script_dirs_for(
+            true,
+            Some(PathBuf::from(r"C:\Users\dev")),
+            Some(PathBuf::from(r"C:\Users\fallback")),
+        );
+
+        assert_eq!(
+            candidates,
+            vec![PathBuf::from(r"C:\Users\dev").join(".local").join("bin")]
+        );
+    }
+
+    #[test]
+    fn windows_uses_userprofile_when_home_is_missing() {
+        let candidates =
+            candidate_script_dirs_for(true, None, Some(PathBuf::from(r"C:\Users\dev")));
 
         assert_eq!(
             candidates,
@@ -96,9 +119,23 @@ mod tests {
 
     #[test]
     fn windows_has_no_implicit_install_directory_without_a_home_directory() {
-        let candidates = candidate_script_dirs_for(true, None);
+        let candidates = candidate_script_dirs_for(true, None, None);
 
         assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn unix_does_not_use_userprofile_when_home_is_missing() {
+        let candidates =
+            candidate_script_dirs_for(false, None, Some(PathBuf::from("/windows/profile")));
+
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/usr/local/bin"),
+                PathBuf::from("/opt/homebrew/bin"),
+            ]
+        );
     }
 
     #[test]
@@ -119,8 +156,29 @@ mod tests {
     }
 
     #[test]
+    fn windows_reports_nonexistent_user_owned_directory_as_on_path_when_listed() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let user_bin = tempdir.path().join(".local").join("bin");
+        assert!(!user_bin.exists());
+
+        let selected = select_script_dir(true, vec![user_bin.clone()], &[user_bin.clone()]);
+
+        assert_eq!(selected, Some((user_bin, true)));
+    }
+
+    #[test]
+    fn windows_matches_nonexistent_path_entries_case_insensitively() {
+        let user_bin = PathBuf::from(r"C:\Users\dev\.local\bin");
+        let listed_path = PathBuf::from(r"c:\users\DEV\.LOCAL\BIN");
+
+        let selected = select_script_dir(true, vec![user_bin.clone()], &[listed_path]);
+
+        assert_eq!(selected, Some((user_bin, true)));
+    }
+
+    #[test]
     fn unix_ranks_user_directories_before_shared_prefixes() {
-        let candidates = candidate_script_dirs_for(false, Some(PathBuf::from("/home/dev")));
+        let candidates = candidate_script_dirs_for(false, Some(PathBuf::from("/home/dev")), None);
 
         assert_eq!(
             candidates,


### PR DESCRIPTION
## Problem

CLI Mode could select `%LOCALAPPDATA%\Microsoft\WindowsApps` as the installation directory for generated scripts. WindowsApps is controlled by Microsoft Store App Execution Aliases and may be rewritten by the Store, so it is not a reliable application-owned installation target.

The earlier selection also treated directory existence as evidence of `PATH` membership. A user-owned directory already listed on `PATH` but not created yet was therefore reported as missing from `PATH`, producing incorrect invocation guidance.

## Solution

- select the user-owned `~/.local/bin` directory from `HOME` or Windows-only `USERPROFILE`, even before it exists
- never use WindowsApps as an implicit installation target
- fall back to the current directory when Windows has no home directory
- determine `PATH` membership independently of filesystem existence and compare Windows paths case-insensitively
- preserve the existing Unix directory-selection behavior

## Verification

- `cargo check -p mcp-compressor-core`
- `cargo test -p mcp-compressor-core --lib app::paths::tests`
- eight path-selection tests cover Windows home fallback, missing directories, case-insensitive PATH matching, WindowsApps exclusion, and unchanged Unix behavior