### PR TITLE
fix: route wrapper tools by exact backend identity

### DIFF
--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -511,12 +511,15 @@ impl CompressedServer {
     }
 
     fn backend_for_wrapper(&self, wrapper_tool_name: &str) -> Result<&ConnectedBackend, Error> {
-        if self.backends.len() == 1 && self.backends[0].public_name.is_empty() {
-            return Ok(&self.backends[0]);
-        }
         self.backends
             .iter()
-            .find(|backend| wrapper_tool_name.starts_with(&self.wrapper_prefix(backend)))
+            .find(|backend| {
+                wrapper_tool_name
+                    .strip_prefix(&self.wrapper_prefix(backend))
+                    .is_some_and(|suffix| {
+                        matches!(suffix, "get_tool_schema" | "invoke_tool" | "list_tools")
+                    })
+            })
             .ok_or_else(|| Error::ToolNotFound(wrapper_tool_name.to_string()))
     }
 }

--- a/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
+++ b/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
@@ -31,6 +31,26 @@ async fn single_stdio_backend_exposes_only_compressed_wrapper_tools() {
 }
 
 #[tokio::test]
+async fn unnamed_single_backend_rejects_unknown_wrapper_names() {
+    let server = CompressedServer::connect_stdio(
+        common::max_config(None),
+        common::backend("", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+
+    let error = server
+        .invoke_tool("unknown_invoke_tool", "add", json!({ "a": 2, "b": 5 }))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::ToolNotFound(name) if name == "unknown_invoke_tool"
+    ));
+}
+
+#[tokio::test]
 async fn single_stdio_backend_invoke_wrapper_tool_input_schema_explains_selected_tool_schema() {
     let server = CompressedServer::connect_stdio(
         common::max_config(Some("alpha")),

--- a/crates/mcp-compressor-core/tests/multi_server.rs
+++ b/crates/mcp-compressor-core/tests/multi_server.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use mcp_compressor_core::server::CompressedServer;
+use mcp_compressor_core::{server::CompressedServer, Error};
 use serde_json::json;
 
 #[tokio::test]
@@ -74,4 +74,46 @@ async fn multi_stdio_backends_are_prefixed_and_routed_independently() {
     assert!(resources
         .iter()
         .any(|uri| uri == "compressor://suite_beta/uncompressed-tools"));
+}
+
+#[tokio::test]
+async fn overlapping_backend_names_route_by_exact_wrapper_name() {
+    for reverse_order in [false, true] {
+        let mut backends = vec![
+            common::backend("foo", "alpha_server.py"),
+            common::backend("foo_bar", "beta_server.py"),
+        ];
+        if reverse_order {
+            backends.reverse();
+        }
+        let server = CompressedServer::connect_multi_stdio(
+            common::max_config(Some("suite")),
+            backends,
+        )
+        .await
+        .unwrap();
+
+        let result = server
+            .invoke_tool(
+                "suite_foo_bar_invoke_tool",
+                "multiply",
+                json!({ "a": 4, "b": 5 }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result, "20");
+
+        let error = server
+            .invoke_tool(
+                "suite_foo_extra_invoke_tool",
+                "add",
+                json!({ "a": 3, "b": 7 }),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            Error::ToolNotFound(name) if name == "suite_foo_extra_invoke_tool"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- match generated wrapper names exactly instead of using backend-name prefixes
- route overlapping backend names deterministically regardless of configuration order
- reject unknown wrappers, including for unnamed single-backend configurations

## Tests

- `cargo test -p mcp-compressor-core --test multi_server overlapping_backend_names_route_by_exact_wrapper_name -- --exact --nocapture`
- `cargo test -p mcp-compressor-core --test compressed_server_stdio unnamed_single_backend_rejects_unknown_wrapper_names -- --exact --nocapture`
- `cargo test -p mcp-compressor-core --test multi_server -- --nocapture`
- `cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture`
- `cargo test -p mcp-compressor-core --lib`
- `cargo check -p mcp-compressor-core`
- `cargo test -p mcp-compressor-core --tests --no-run`