### PR TITLE
fix: preserve MCP tool result semantics

### DIFF
--- a/crates/mcp-compressor-core/src/server/compressed.rs
+++ b/crates/mcp-compressor-core/src/server/compressed.rs
@@ -5,8 +5,8 @@
 //! language bindings, and the standalone Rust CLI.
 
 use rmcp::model::{
-    CallToolRequestParams, Content, GetPromptRequestParams, GetPromptResult, RawContent,
-    ReadResourceRequestParams, ResourceContents,
+    CallToolRequestParams, CallToolResult, Content, GetPromptRequestParams, GetPromptResult, Meta,
+    RawContent, ReadResourceRequestParams, ResourceContents,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -304,8 +304,24 @@ impl CompressedServer {
         tool_input: Value,
     ) -> Result<String, Error> {
         let backend = self.backend_for_wrapper(_wrapper_tool_name)?;
-        self.invoke_backend(backend, backend_tool_name, tool_input)
-            .await
+        let result = self
+            .invoke_backend_result(backend, backend_tool_name, tool_input, None)
+            .await?;
+        Ok(self.tool_result_to_string(result))
+    }
+
+    pub(crate) async fn invoke_tool_result(
+        &self,
+        wrapper_tool_name: &str,
+        backend_tool_name: &str,
+        tool_input: Value,
+        request_meta: Option<Meta>,
+    ) -> Result<CallToolResult, Error> {
+        let backend = self.backend_for_wrapper(wrapper_tool_name)?;
+        let result = self
+            .invoke_backend_result(backend, backend_tool_name, tool_input, request_meta)
+            .await?;
+        Ok(toonify_result(self.config.toonify, result))
     }
 
     /// List frontend resources, including pass-through backend resources and
@@ -420,16 +436,19 @@ impl CompressedServer {
             .first()
             .filter(|_| self.backends.len() == 1)
             .ok_or_else(|| Error::ToolNotFound(backend_tool_name.to_string()))?;
-        self.invoke_backend(backend, backend_tool_name, tool_input)
-            .await
+        let result = self
+            .invoke_backend_result(backend, backend_tool_name, tool_input, None)
+            .await?;
+        Ok(self.tool_result_to_string(result))
     }
 
-    async fn invoke_backend(
+    async fn invoke_backend_result(
         &self,
         backend: &ConnectedBackend,
         backend_tool_name: &str,
         tool_input: Value,
-    ) -> Result<String, Error> {
+        request_meta: Option<Meta>,
+    ) -> Result<CallToolResult, Error> {
         let tool = backend
             .tools
             .iter()
@@ -441,27 +460,24 @@ impl CompressedServer {
             _ => None,
         };
         let mut params = CallToolRequestParams::new(backend_tool_name.to_string());
+        params.meta = request_meta.map(strip_caller_progress_token);
         if let Some(arguments) = arguments {
             params = params.with_arguments(arguments);
         }
-        let result = backend
+        backend
             .client
             .call_tool(params)
             .await
-            .map_err(|error| Error::Config(error.to_string()))?;
+            .map_err(|error| Error::Config(error.to_string()))
+    }
+
+    fn tool_result_to_string(&self, result: CallToolResult) -> String {
         let output = call_tool_result_to_string(result);
-        Ok(self.maybe_toonify_output(&output))
+        self.maybe_toonify_output(&output)
     }
 
     fn maybe_toonify_output(&self, output: &str) -> String {
-        if !self.config.toonify {
-            return output.to_string();
-        }
-        let Ok(value) = serde_json::from_str::<Value>(output) else {
-            return output.to_string();
-        };
-        toon_format::encode(&value, &toon_format::EncodeOptions::default())
-            .unwrap_or_else(|_| output.to_string())
+        toonify_output(self.config.toonify, output)
     }
 
     fn cli_help_tools(&self) -> Vec<Tool> {
@@ -522,6 +538,16 @@ impl CompressedServer {
             })
             .ok_or_else(|| Error::ToolNotFound(wrapper_tool_name.to_string()))
     }
+}
+
+/// Drop the caller's progress token before forwarding request metadata.
+///
+/// The proxy does not relay `notifications/progress` from the backend, so
+/// passing the caller's token through would promise progress that never
+/// arrives. Every other `_meta` entry is forwarded untouched.
+fn strip_caller_progress_token(mut meta: Meta) -> Meta {
+    meta.remove("progressToken");
+    meta
 }
 
 fn validate_required_tool_input(tool: &Tool, tool_input: &Value) -> Result<(), Error> {
@@ -731,5 +757,90 @@ fn value_to_string(value: &Value) -> String {
             value_to_string(&map["result"])
         }
         _ => value.to_string(),
+    }
+}
+
+fn toonify_output(toonify: bool, output: &str) -> String {
+    if !toonify {
+        return output.to_string();
+    }
+    let Ok(value) = serde_json::from_str::<Value>(output) else {
+        return output.to_string();
+    };
+    toon_format::encode(&value, &toon_format::EncodeOptions::default())
+        .unwrap_or_else(|_| output.to_string())
+}
+
+/// Apply `--toonify` to a pass-through tool result.
+///
+/// The MCP frontend returns the backend `CallToolResult` verbatim to preserve
+/// structured and typed content, so the TOON re-encoding has to happen here
+/// instead of in the string-returning path. Only JSON text blocks change;
+/// typed content, structured content and error results are left untouched.
+fn toonify_result(toonify: bool, mut result: CallToolResult) -> CallToolResult {
+    if !toonify || result.is_error == Some(true) {
+        return result;
+    }
+    for item in result.content.iter_mut() {
+        if let RawContent::Text(text) = &mut item.raw {
+            text.text = toonify_output(true, &text.text);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod toonify_tests {
+    use super::*;
+
+    fn json_result() -> CallToolResult {
+        serde_json::from_value(serde_json::json!({
+            "content": [{"type": "text", "text": "[{\"id\":1,\"name\":\"alpha\"}]"}]
+        }))
+        .unwrap()
+    }
+
+    /// The MCP frontend returns backend results verbatim, so `--toonify`
+    /// must still be applied there or the flag silently does nothing.
+    #[test]
+    fn toonify_reencodes_json_text_blocks_of_passthrough_results() {
+        let result = toonify_result(true, json_result());
+
+        let text = match &result.content[0].raw {
+            RawContent::Text(text) => text.text.clone(),
+            other => panic!("expected text content, got {other:?}"),
+        };
+        assert_ne!(text, "[{\"id\":1,\"name\":\"alpha\"}]");
+        assert_eq!(
+            text,
+            toonify_output(true, "[{\"id\":1,\"name\":\"alpha\"}]")
+        );
+    }
+
+    /// Without the flag the result must stay byte-identical.
+    #[test]
+    fn toonify_disabled_preserves_passthrough_results() {
+        let result = toonify_result(false, json_result());
+
+        let text = match &result.content[0].raw {
+            RawContent::Text(text) => text.text.clone(),
+            other => panic!("expected text content, got {other:?}"),
+        };
+        assert_eq!(text, "[{\"id\":1,\"name\":\"alpha\"}]");
+    }
+
+    /// Backend failures must not be re-encoded; agents rely on the raw text.
+    #[test]
+    fn toonify_preserves_backend_error_results() {
+        let mut result = json_result();
+        result.is_error = Some(true);
+
+        let result = toonify_result(true, result);
+
+        let text = match &result.content[0].raw {
+            RawContent::Text(text) => text.text.clone(),
+            other => panic!("expected text content, got {other:?}"),
+        };
+        assert_eq!(text, "[{\"id\":1,\"name\":\"alpha\"}]");
     }
 }

--- a/crates/mcp-compressor-core/src/server/registration.rs
+++ b/crates/mcp-compressor-core/src/server/registration.rs
@@ -6,9 +6,8 @@ use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
     Annotated, CallToolRequestParams, CallToolResult, Content, ErrorCode, GetPromptRequestParams,
     GetPromptResult, InitializeResult, ListPromptsResult, ListResourcesResult, ListToolsResult,
-    PaginatedRequestParams, Prompt,
-    RawResource, ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents,
-    ServerCapabilities, Tool,
+    PaginatedRequestParams, Prompt, RawResource, ReadResourceRequestParams, ReadResourceResult,
+    Resource, ResourceContents, ServerCapabilities, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData as McpError, RoleServer};
@@ -66,23 +65,27 @@ impl ServerHandler for FrontendServer {
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let wrapper_name = request.name.to_string();
         let arguments = request.arguments.unwrap_or_default();
-        let output = if wrapper_name.ends_with("get_tool_schema") {
-            let tool_name = required_string(&arguments, "tool_name")?;
-            self.compressed
-                .get_tool_schema(&wrapper_name, &tool_name)
-                .await
-        } else if wrapper_name.ends_with("invoke_tool") {
+        if wrapper_name.ends_with("invoke_tool") {
             let tool_name = required_string(&arguments, "tool_name")?;
             let tool_input = arguments
                 .get("tool_input")
                 .cloned()
                 .unwrap_or_else(|| Value::Object(Map::new()));
+            return self
+                .compressed
+                .invoke_tool_result(&wrapper_name, &tool_name, tool_input, Some(context.meta))
+                .await
+                .map_err(mcp_error);
+        }
+
+        let output = if wrapper_name.ends_with("get_tool_schema") {
+            let tool_name = required_string(&arguments, "tool_name")?;
             self.compressed
-                .invoke_tool(&wrapper_name, &tool_name, tool_input)
+                .get_tool_schema(&wrapper_name, &tool_name)
                 .await
         } else if wrapper_name.ends_with("list_tools") {
             self.compressed.list_backend_tools(&wrapper_name).await
@@ -120,9 +123,10 @@ impl ServerHandler for FrontendServer {
             .read_resource(&request.uri)
             .await
             .map_err(mcp_error)?;
-        Ok(ReadResourceResult::new(vec![
-            ResourceContents::text(text, request.uri),
-        ]))
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(
+            text,
+            request.uri,
+        )]))
     }
 
     async fn list_prompts(
@@ -170,16 +174,19 @@ fn convert_tool(tool: crate::compression::engine::Tool) -> Tool {
 }
 
 fn convert_resource(uri: String) -> Resource {
-    Annotated::new(RawResource {
-        name: uri.clone(),
-        uri,
-        title: None,
-        description: None,
-        mime_type: None,
-        icons: None,
-        size: None,
-        meta: None,
-    }, None)
+    Annotated::new(
+        RawResource {
+            name: uri.clone(),
+            uri,
+            title: None,
+            description: None,
+            mime_type: None,
+            icons: None,
+            size: None,
+            meta: None,
+        },
+        None,
+    )
 }
 
 fn required_string(arguments: &Map<String, Value>, name: &str) -> Result<String, McpError> {

--- a/crates/mcp-compressor-core/tests/common/mod.rs
+++ b/crates/mcp-compressor-core/tests/common/mod.rs
@@ -154,3 +154,10 @@ pub fn mcp_config_json(backends: &[(&str, &str)]) -> String {
         .collect::<serde_json::Map<_, _>>();
     json!({ "mcpServers": servers }).to_string()
 }
+
+pub fn toonify_config(server_name: impl Into<Option<&'static str>>) -> CompressedServerConfig {
+    CompressedServerConfig {
+        toonify: true,
+        ..max_config(server_name)
+    }
+}

--- a/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
+++ b/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
@@ -313,7 +313,7 @@ async fn mcp_frontend_toonifies_json_text_results() {
     .await
     .unwrap();
     let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         FrontendServer::new(server)
             .serve(server_transport)
             .await
@@ -322,7 +322,7 @@ async fn mcp_frontend_toonifies_json_text_results() {
             .await
             .unwrap();
     });
-    let client = ().serve(client_transport).await.unwrap();
+    let mut client = ().serve(client_transport).await.unwrap();
 
     let result = client
         .call_tool(
@@ -344,4 +344,7 @@ async fn mcp_frontend_toonifies_json_text_results() {
     );
     assert!(text.contains("1,alpha"), "expected TOON rows, got {text}");
     assert_eq!(result["content"][0]["annotations"]["priority"], json!(0.75));
+
+    client.close().await.unwrap();
+    server_task.await.unwrap();
 }

--- a/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
+++ b/crates/mcp-compressor-core/tests/compressed_server_stdio.rs
@@ -1,7 +1,155 @@
 mod common;
 
-use mcp_compressor_core::{server::CompressedServer, Error};
+use mcp_compressor_core::{
+    server::{registration::FrontendServer, CompressedServer},
+    Error,
+};
+use rmcp::{
+    model::{CallToolRequestParams, Meta},
+    ServiceExt,
+};
 use serde_json::json;
+
+#[tokio::test]
+async fn mcp_frontend_preserves_complete_backend_tool_results() {
+    let server = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_task = tokio::spawn(async move {
+        FrontendServer::new(server)
+            .serve(server_transport)
+            .await
+            .unwrap()
+            .waiting()
+            .await
+            .unwrap();
+    });
+    let mut client = ().serve(client_transport).await.unwrap();
+
+    let mut request = CallToolRequestParams::new("alpha_invoke_tool").with_arguments(
+        json!({"tool_name": "rich_result", "tool_input": {}})
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    request.meta = Some(Meta(
+        json!({"trace": "forwarded"}).as_object().unwrap().clone(),
+    ));
+    let result = client.call_tool(request).await.unwrap();
+    let mut result = serde_json::to_value(result).unwrap();
+    let progress_token = result
+        .pointer_mut("/_meta/request/progressToken")
+        .expect("request metadata should reach the backend tool");
+    assert!(progress_token.is_number());
+    *progress_token = json!("forwarded");
+
+    assert_eq!(
+        result,
+        json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "rich text",
+                    "annotations": {"audience": ["assistant"], "priority": 0.75},
+                    "_meta": {"content": "text"}
+                },
+                {
+                    "type": "image",
+                    "data": "aW1hZ2U=",
+                    "mimeType": "image/png",
+                    "annotations": {"audience": ["user"], "priority": 0.5},
+                    "_meta": {"content": "image"}
+                },
+                {
+                    "type": "audio",
+                    "data": "YXVkaW8=",
+                    "mimeType": "audio/wav",
+                    "annotations": {"priority": 0.25}
+                }
+            ],
+            "structuredContent": {"ok": true, "values": [1, 2]},
+            "isError": false,
+            "_meta": {
+                "result": "rich",
+                "request": {
+                    "trace": "forwarded",
+                    "progressToken": "forwarded"
+                }
+            }
+        })
+    );
+
+    let error = client
+        .call_tool(
+            CallToolRequestParams::new("alpha_invoke_tool").with_arguments(
+                json!({"tool_name": "tool_error", "tool_input": {}})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(error.is_error, Some(true));
+
+    client.close().await.unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn mcp_frontend_does_not_forward_the_caller_progress_token() {
+    let server = CompressedServer::connect_stdio(
+        common::max_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_task = tokio::spawn(async move {
+        FrontendServer::new(server)
+            .serve(server_transport)
+            .await
+            .unwrap()
+            .waiting()
+            .await
+            .unwrap();
+    });
+    let mut client = ().serve(client_transport).await.unwrap();
+
+    let mut request = CallToolRequestParams::new("alpha_invoke_tool").with_arguments(
+        json!({"tool_name": "rich_result", "tool_input": {}})
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    request.meta = Some(Meta(
+        json!({"trace": "kept", "progressToken": "caller-token"})
+            .as_object()
+            .unwrap()
+            .clone(),
+    ));
+    let result = client.call_tool(request).await.unwrap();
+    let result = serde_json::to_value(result).unwrap();
+    let backend_meta = result
+        .pointer("/_meta/request")
+        .expect("request metadata should reach the backend tool");
+
+    // Unrelated caller metadata is forwarded, but the caller's progress token is
+    // not: no progress notifications are relayed back, so honouring the token
+    // would promise progress that never arrives.
+    assert_eq!(backend_meta.get("trace"), Some(&json!("kept")));
+    assert_ne!(
+        backend_meta.get("progressToken"),
+        Some(&json!("caller-token"))
+    );
+
+    client.close().await.unwrap();
+    server_task.await.unwrap();
+}
 
 #[tokio::test]
 async fn single_stdio_backend_exposes_only_compressed_wrapper_tools() {
@@ -152,4 +300,48 @@ async fn single_stdio_backend_schema_listing_invocation_resources_and_prompts_wo
 
     let prompts = server.list_prompts().await.unwrap();
     assert!(prompts.iter().any(|name| name == "alpha_prompt"));
+}
+
+/// `--toonify` must still shrink JSON payloads once the MCP frontend returns
+/// backend results verbatim, and must not damage annotations or typed content.
+#[tokio::test]
+async fn mcp_frontend_toonifies_json_text_results() {
+    let server = CompressedServer::connect_stdio(
+        common::toonify_config(Some("alpha")),
+        common::backend("alpha", "alpha_server.py"),
+    )
+    .await
+    .unwrap();
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    tokio::spawn(async move {
+        FrontendServer::new(server)
+            .serve(server_transport)
+            .await
+            .unwrap()
+            .waiting()
+            .await
+            .unwrap();
+    });
+    let client = ().serve(client_transport).await.unwrap();
+
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("alpha_invoke_tool").with_arguments(
+                json!({"tool_name": "json_rows", "tool_input": {}})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .unwrap();
+    let result = serde_json::to_value(result).unwrap();
+
+    let text = result["content"][0]["text"].as_str().unwrap();
+    assert!(
+        text.starts_with("[2]{id,name}:"),
+        "expected TOON table, got {text}"
+    );
+    assert!(text.contains("1,alpha"), "expected TOON rows, got {text}");
+    assert_eq!(result["content"][0]["annotations"]["priority"], json!(0.75));
 }

--- a/crates/mcp-compressor-core/tests/fixtures/alpha_server.py
+++ b/crates/mcp-compressor-core/tests/fixtures/alpha_server.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import contextlib
 from typing import Any
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.tools.tool import ToolResult
+from mcp.types import Annotations, AudioContent, ImageContent, TextContent
 
 mcp = FastMCP("Rust Core Alpha Fixture")
 
@@ -35,6 +38,60 @@ def summarize_payload(items: list[str], metadata: dict[str, Any]) -> dict[str, A
         "metadata": metadata,
         "metadata_keys": sorted(metadata.keys()),
     }
+
+
+@mcp.tool
+def json_rows() -> ToolResult:
+    """Return a JSON table in an annotated text block for toonify contract tests."""
+    return ToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text='[{"id": 1, "name": "alpha"}, {"id": 2, "name": "beta"}]',
+                annotations=Annotations(audience=["assistant"], priority=0.75),
+            )
+        ]
+    )
+
+
+@mcp.tool
+def rich_result(ctx: Context) -> ToolResult:
+    """Return every supported tool-result field for contract tests."""
+    request_meta: dict[str, Any] = {}
+    if ctx.request_context is not None and ctx.request_context.meta is not None:
+        request_meta = ctx.request_context.meta.model_dump(by_alias=True, exclude_none=True)
+
+    return ToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text="rich text",
+                annotations=Annotations(audience=["assistant"], priority=0.75),
+                _meta={"content": "text"},
+            ),
+            ImageContent(
+                type="image",
+                data="aW1hZ2U=",
+                mimeType="image/png",
+                annotations=Annotations(audience=["user"], priority=0.5),
+                _meta={"content": "image"},
+            ),
+            AudioContent(
+                type="audio",
+                data="YXVkaW8=",
+                mimeType="audio/wav",
+                annotations=Annotations(priority=0.25),
+            ),
+        ],
+        structured_content={"ok": True, "values": [1, 2]},
+        meta={"result": "rich", "request": request_meta},
+    )
+
+
+@mcp.tool
+def tool_error() -> None:
+    """Return an MCP tool error result."""
+    raise ToolError("fixture tool error")
 
 
 @mcp.resource("fixture://alpha-resource")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "fastmcp==3.2.4",
+    "mcp>=1.24.0,<2.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1003,6 +1003,7 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "mcp" },
 ]
 
 [package.dev-dependencies]
@@ -1023,7 +1024,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fastmcp", specifier = "==3.2.4" }]
+requires-dist = [
+    { name = "fastmcp", specifier = "==3.2.4" },
+    { name = "mcp", specifier = ">=1.24.0,<2.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Problem

The MCP frontend converted every backend `CallToolResult` into plain text and then wrapped that text in a new successful result. This changed MCP semantics in observable ways:

- backend tool failures with `isError: true` appeared successful to clients
- `structuredContent` was discarded
- image and audio content were flattened instead of remaining typed content
- content annotations and result metadata were lost

Agents and MCP clients could therefore make decisions from an incorrect success state or receive an incomplete result even though the backend returned the full protocol object.

## Solution

- forward the complete backend `CallToolResult` through the MCP frontend
- keep generated CLI and Python/TypeScript code-client text conversion explicit so their existing output contract remains unchanged
- preserve `--toonify` for successful JSON text blocks without rewriting typed content or backend error text
- retain PR #254 exact wrapper routing and unknown-wrapper rejection
- forward request metadata while removing only the caller progress token, because this proxy does not relay backend progress notifications

- close the toonify test's MCP client and await its server task for deterministic shutdown

## Verification

- `cargo check -p mcp-compressor-core`
- `cargo test -p mcp-compressor-core --lib toonify_tests`
- `cargo test -p mcp-compressor-core --test compressed_server_stdio -- --nocapture` — rerun after rebasing onto main and applying the cleanup: 8 passed
- `cargo test -p mcp-compressor-core --test multi_server -- --nocapture`
- `cargo test -p mcp-compressor-core --test generated_clients generated_cli_ -- --nocapture`
- `cargo test -p mcp-compressor-core --test generated_clients generated_python_ -- --nocapture`
- `cargo test -p mcp-compressor-core --tests --no-run`
- exact `make check` subcommands: lock consistency, all pre-commit hooks, `ty`, public API names, and `deptry`

The three Bun-backed TypeScript runtime tests were not run locally because Bun is not installed; their client and test code are unchanged by this branch and CI provides the Bun lane.